### PR TITLE
"paranoid" scan mode, to handle invalid S3 key names

### DIFF
--- a/app/controllers/ScanTargetController.scala
+++ b/app/controllers/ScanTargetController.scala
@@ -73,6 +73,7 @@ class ScanTargetController @Inject() (@Named("bucketScannerActor") bucketScanner
         })
         Ok(ObjectListResponse[List[ScanTarget]]("ok","scan_target",success,success.length).asJson)
       } else {
+        errors.foreach(err=>logger.error(err.toString))
         InternalServerError(GenericErrorResponse("error", errors.map(_.toString).mkString(",")).asJson)
       }
     })

--- a/app/helpers/ContentHashingFlow.scala
+++ b/app/helpers/ContentHashingFlow.scala
@@ -36,7 +36,6 @@ class ContentHashingFlow(algo:String) extends GraphStage[FlowShape[ByteString, B
         } else {
           completeStage()
         }
-
       }
     })
 

--- a/app/helpers/ContentHashingFlow.scala
+++ b/app/helpers/ContentHashingFlow.scala
@@ -1,0 +1,39 @@
+package helpers
+
+import java.security.MessageDigest
+
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import akka.util.ByteString
+
+class ContentHashingFlow(algo:String) extends GraphStage[FlowShape[ByteString,ByteString]]{
+  final val in:Inlet[ByteString] = Inlet.create("ContentHashingFlow.in")
+  final val out:Outlet[ByteString] = Outlet.create("ContentHashingFlow.out")
+
+  override def shape: FlowShape[ByteString, ByteString] = FlowShape.of(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    val digester = MessageDigest.getInstance(algo)
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+        digester.update(elem.toArray)
+        pull(in)
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = {
+        pull(in)
+      }
+    })
+
+    override def postStop(): Unit = {
+      super.postStop()
+      val result = digester.digest()
+      push(out, ByteString(result))
+    }
+  }
+
+}

--- a/app/helpers/ParanoidS3Source.scala
+++ b/app/helpers/ParanoidS3Source.scala
@@ -102,9 +102,14 @@ class ParanoidS3Source(bucketName:String, region:Region, credsProvider: AWSCrede
         val baseParams = "list-type=2&encoding-type=url"
         //val baseParams = "delimiter=/&encoding-type=url&prefix"
         val qParams = continuationToken match {
-          case Some(token)=>baseParams + s"&continuationToken=${URLEncoder.encode(token)}"
-          case None=>baseParams
+          case Some(token)=>
+            logger.debug(s"continuation token is $token")
+            baseParams + s"&continuation-token=${URLEncoder.encode(token)}"
+          case None=>
+            logger.debug("no continuation token")
+            baseParams
         }
+
         val request = HttpRequest(HttpMethods.GET,
           Uri(s"https://$bucketName.s3.${region.getName}.amazonaws.com?$qParams"),
           headerSequence)

--- a/app/helpers/ParanoidS3Source.scala
+++ b/app/helpers/ParanoidS3Source.scala
@@ -1,5 +1,6 @@
 package helpers
 
+import java.net.URLEncoder
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
@@ -101,7 +102,7 @@ class ParanoidS3Source(bucketName:String, region:Region, credsProvider: AWSCrede
         val baseParams = "list-type=2&encoding-type=url"
         //val baseParams = "delimiter=/&encoding-type=url&prefix"
         val qParams = continuationToken match {
-          case Some(token)=>baseParams + s"&$token"
+          case Some(token)=>baseParams + s"&continuationToken=${URLEncoder.encode(token)}"
           case None=>baseParams
         }
         val request = HttpRequest(HttpMethods.GET,

--- a/app/helpers/ParanoidS3Source.scala
+++ b/app/helpers/ParanoidS3Source.scala
@@ -1,0 +1,135 @@
+package helpers
+
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.{Http, model}
+import akka.http.scaladsl.model._
+import akka.stream._
+import akka.stream.alpakka.s3.scaladsl.ListBucketResultContents
+import akka.stream.stage.{AbstractOutHandler, GraphStage, GraphStageLogic}
+import akka.http.scaladsl.model.HttpHeader.ParsingResult._
+import akka.stream.scaladsl.Sink
+import akka.util.ByteString
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.Region
+
+import scala.collection.immutable.Seq
+import play.api.Logger
+import akka.http.scaladsl.model.HttpProtocol
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+/**
+  * Source which performs Listbucket requests and outputs the XML as a String to be sanitised
+  * @param bucketName bucket to scan
+  * @param region AWS region that the bucket lives in
+  * @param actorSystem implicitly provided ActorSystem for akka http
+  */
+class ParanoidS3Source(bucketName:String, region:Region, credsProvider: AWSCredentialsProvider)(implicit actorSystem:ActorSystem)
+  extends GraphStage[SourceShape[ByteString]] with S3Signer {
+  private val out:Outlet[ByteString] = Outlet.create("ParanoidS3Source.out")
+
+  implicit val mat:Materializer = ActorMaterializer()
+  implicit val ec:ExecutionContext = actorSystem.dispatcher
+  override def shape: SourceShape[ByteString] = SourceShape.of(out)
+
+  val logger = Logger(getClass)
+  /**
+    * extract given entries from the XML manually. This is necessary as we are in "paranoid mode", and can't
+    * rely on the XML being valid.
+    * @param paramsToFind Seq[String] giving the parameters to find
+    * @param body ByteString
+    * @return a Map, containing each `paramToFind` pointing to an Option which has the string value, if present.
+    *         NOTE: this assumes that the keys and data to extract are both UTF-8 compatible (but the overall document can break)
+    */
+  def findParams(paramsToFind:Seq[String], body:ByteString):Map[String,Option[String]] = {
+    val paramsToFindBytes = paramsToFind.map(ByteString(_))
+
+    def captureString(toFind:ByteString, haystack:ByteString,n:Int):Option[ByteString] = {
+      //now capture everything up to the next < character
+      for(i<-n+toFind.length to haystack.length){
+        if(haystack(i)=="<".charAt(0).toByte){
+          val result = haystack.slice(n+toFind.length+1,i)
+          return Some(result)
+        }
+      }
+      None
+    }
+
+    def locateString(toFind:ByteString, haystack:ByteString):Option[Int] = {
+      for(n<-0 to haystack.length-toFind.length){
+        val matcher = haystack.slice(n, n+toFind.length)
+        if(matcher==toFind){
+          return Some(n)
+        }
+      }
+      None
+    }
+
+    def findParamFuture(toFind: ByteString, haystack:ByteString):Future[Tuple2[ByteString, Option[ByteString]]] = Future {
+      locateString(toFind, haystack) match {
+        case Some(location)=>Tuple2(toFind, captureString(toFind, haystack, location))
+        case None=>Tuple2(toFind,None)
+      }
+    }
+
+    Await.result(Future.sequence(paramsToFindBytes.map(findParamFuture(_,body)))
+        .map(_.map(tuple=>Tuple2(tuple._1.utf8String, tuple._2.map(_.utf8String))))
+      .map(_.toMap)
+      , 10.seconds)
+  }
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger=Logger(getClass)
+
+    var onPage:Int = 0
+    var continuationToken:Option[String] = None
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = {
+        val headerSequence = Seq(
+          HttpHeader.parse("Host", s"$bucketName.s3.${region.getName}.amazonaws.com"),
+          HttpHeader.parse("Date", OffsetDateTime.now().format(DateTimeFormatter.RFC_1123_DATE_TIME)),
+        ).map({
+          case Ok(header, errors)=>header
+          case Error(err)=>throw new RuntimeException(err.toString)
+        })
+
+        val baseParams = "list-type=2&encoding-type=url"
+        //val baseParams = "delimiter=/&encoding-type=url&prefix"
+        val qParams = continuationToken match {
+          case Some(token)=>baseParams + s"&$token"
+          case None=>baseParams
+        }
+        val request = HttpRequest(HttpMethods.GET,
+          Uri(s"https://$bucketName.s3.${region.getName}.amazonaws.com/?$qParams"),
+          headerSequence,
+          HttpEntity.Empty,
+          HttpProtocol("HTTP/1.1"))
+
+        val signedRequest = signHttpRequest(request, region,"s3", credsProvider)
+        val response = Await.result(Http().singleRequest(request), 10 seconds)
+
+        //we are in paranoid mode, so can't assume that this is valid xml (yet). So, we buffer the content and manually scan for
+        //the continuationToken and isTruncated flags we require.
+        val body = Await.result(response.entity.getDataBytes().runWith(Sink.fold[ByteString,ByteString](ByteString.empty)(_.concat(_)), mat), 10 seconds)
+        push(out, body)
+        val flags:Map[String,Option[String]] = findParams(Seq("NextContinuationToken","KeyCount","IsTruncated"), body)
+
+        flags("IsTruncated") match {
+          case Some(flag)=>
+            if(flag=="true"){
+              continuationToken = flags("NextContinuationToken")
+            } else {
+              completeStage()
+            }
+          case None=>completeStage()
+        }
+      }
+
+    })
+  }
+}

--- a/app/helpers/ParanoidS3Source.scala
+++ b/app/helpers/ParanoidS3Source.scala
@@ -105,13 +105,12 @@ class ParanoidS3Source(bucketName:String, region:Region, credsProvider: AWSCrede
           case None=>baseParams
         }
         val request = HttpRequest(HttpMethods.GET,
-          Uri(s"https://$bucketName.s3.${region.getName}.amazonaws.com/?$qParams"),
-          headerSequence,
-          HttpEntity.Empty,
-          HttpProtocol("HTTP/1.1"))
+          Uri(s"https://$bucketName.s3.${region.getName}.amazonaws.com?$qParams"),
+          headerSequence)
 
-        val signedRequest = signHttpRequest(request, region,"s3", credsProvider)
-        val response = Await.result(Http().singleRequest(request), 10 seconds)
+        val signedRequest = Await.result(signHttpRequest(request, region,"s3", credsProvider), 10 seconds)
+        logger.debug(s"Signed request is ${signedRequest.toString()}")
+        val response = Await.result(Http().singleRequest(signedRequest), 10 seconds)
 
         //we are in paranoid mode, so can't assume that this is valid xml (yet). So, we buffer the content and manually scan for
         //the continuationToken and isTruncated flags we require.

--- a/app/helpers/S3ClientManager.scala
+++ b/app/helpers/S3ClientManager.scala
@@ -15,28 +15,23 @@ import play.api.Configuration
 @Singleton
 class S3ClientManager @Inject() (config:Configuration) {
 
-  def getS3Client(profileName:Option[String]=None):AmazonS3 = {
-    val provider = new AWSCredentialsProviderChain(
-      new ProfileCredentialsProvider(profileName.getOrElse("default")),
-      new ContainerCredentialsProvider(),
-      new InstanceProfileCredentialsProvider()
-    )
-    AmazonS3ClientBuilder.standard().withCredentials(provider).build()
-  }
+  def credentialsProvider(profileName:Option[String]=None) = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider(profileName.getOrElse("default")),
+    new ContainerCredentialsProvider(),
+    new InstanceProfileCredentialsProvider()
+  )
+
+  def getS3Client(profileName:Option[String]=None):AmazonS3 =
+    AmazonS3ClientBuilder.standard().withCredentials(credentialsProvider(profileName)).build()
+
 
   def getAlpakkaS3Client(profileName:Option[String]=None)(implicit system:ActorSystem,mat:Materializer) = {
-    val provider = new AWSCredentialsProviderChain(
-      new ProfileCredentialsProvider(profileName.getOrElse("default")),
-      new ContainerCredentialsProvider(),
-      new InstanceProfileCredentialsProvider()
-    )
-
     val regionProvider =
       new AwsRegionProvider {
         def getRegion: String = config.getOptional[String]("externalData.awsRegion").getOrElse("eu-west-1")
       }
 
-    val settings = new S3Settings(MemoryBufferType,None,provider,regionProvider,false,None,ListBucketVersion2)
+    val settings = new S3Settings(MemoryBufferType,None,credentialsProvider(profileName),regionProvider,false,None,ListBucketVersion2)
     new S3Client(settings)  //uses the implicit ActorSystem and Materializer pointers
   }
 }

--- a/app/helpers/S3Error.scala
+++ b/app/helpers/S3Error.scala
@@ -1,0 +1,11 @@
+package helpers
+
+import scala.util.Try
+
+case class S3Error (code:String, message:String, requestId:String, hostId:String)
+
+object S3Error extends ((String, String,String,String)=>S3Error) {
+  def fromMap(data:Map[String,String]):Try[S3Error] = Try {
+    new S3Error(data("Code"), data("Message"), data("RequestId"), data("HostId"))
+  }
+}

--- a/app/helpers/S3Signer.scala
+++ b/app/helpers/S3Signer.scala
@@ -169,7 +169,10 @@ trait S3Signer {
     }
     logger.debug(s"encodedUrl: $canonicalUrl")
 
-    val canonicalQueryString = uriQueryParams.map(entry=>URLEncoder.encode(entry._1,"UTF-8")+"="+URLEncoder.encode(entry._2,"UTF-8")).mkString("&")
+    val canonicalQueryString = uriQueryParams
+      .map(entry=>URLEncoder.encode(entry._1,"UTF-8")+"="+URLEncoder.encode(entry._2,"UTF-8"))
+      .toList.sorted
+      .mkString("&")
     logger.debug(s"canonicalQueryString: $canonicalQueryString")
 
     val updatedHeaders = if(headers.keys.exists(_=="x-amz-content-sha256")){

--- a/app/helpers/S3Signer.scala
+++ b/app/helpers/S3Signer.scala
@@ -1,0 +1,223 @@
+package helpers
+
+import java.net.URLEncoder
+import java.security.MessageDigest
+import java.time.{OffsetDateTime, ZoneOffset, ZonedDateTime}
+import java.time.format.DateTimeFormatter
+
+import akka.http.scaladsl.model.HttpHeader.ParsingResult.{Error, Ok}
+import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Flow, Sink}
+import akka.util.ByteString
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.Region
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import play.api.Logger
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/** this trait implements logic for signing S3 requests over HTTP */
+/* see https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html*/
+
+trait S3Signer {
+  protected val logger:Logger
+  implicit val mat:Materializer
+  implicit val ec:ExecutionContext
+
+  val aws_compatible_date = DateTimeFormatter.ofPattern("uuuuMMdd")
+  val aws_compatible_datetime = DateTimeFormatter.ofPattern("uuuuMMdd'T'HHmmss'Z'")
+  protected def digestString(str:String) = {
+    val checksummer = MessageDigest.getInstance("SHA-256")
+    checksummer.digest(str.getBytes("UTF-8")).map("%02x".format(_)).mkString
+  }
+
+  protected def hmacString(key:String,str:String) = {
+    val secretKeySpec = new SecretKeySpec(key.getBytes("UTF-8"),"SHA-256")
+    val hmaccer = Mac.getInstance("HmacSHA256")
+    hmaccer.init(secretKeySpec)
+    hmaccer.doFinal(str.getBytes("UTF-8")).map("%02x".format(_)).mkString
+  }
+
+  /**
+    * splits down a standard query string into a map of key-value pairs
+    * @param queryString
+    * @return
+    */
+  protected def convertQueryString(queryString:Option[String]):Map[String,String] = {
+    def makeTuple(str:String):(String,String) = {
+      val parts = str.split("=")
+      Tuple2(parts.head, parts(1))
+    }
+
+    queryString.map(_.split("&").map(el=>makeTuple(el)).toMap).getOrElse(Map())
+  }
+
+  protected def makeHttpHeader(key:String,value:String):HttpHeader = HttpHeader.parse(key, value) match {
+    case Ok(result, errors)=>result
+    case Error(errors)=>throw new RuntimeException(errors.toString)
+  }
+
+  protected def headersToMap(headers: Seq[HttpHeader]) = headers.map(head=>Tuple2(head.name, head.value)).toMap
+
+  /**
+    * Asynchronously signs the given [[HttpRequest]] object using the credentials provider given
+    * @param req Incoming HttpRequest
+    * @param region AWS region to access
+    * @param serviceName service name
+    * @param credsProvider AWSCredentialsProvider instance (or chain) that gives us credentials
+    * @return a Future with the updated [[HttpRequest]]
+    */
+  def signHttpRequest(req:HttpRequest, region:Region, serviceName:String, credsProvider:AWSCredentialsProvider, timestamp:Option[OffsetDateTime]=None) = {
+    import scala.collection.immutable.Seq
+    val checksummer = MessageDigest.getInstance("SHA-256")
+    val requestTime = timestamp.getOrElse(OffsetDateTime.now(ZoneOffset.UTC))
+
+    val contentHashFuture = if(req.entity.isKnownEmpty()) {
+      Future(ByteString(checksummer.digest("".getBytes("UTF-8"))))
+    } else {
+      req.entity.getDataBytes()
+        .via(new ContentHashingFlow("SHA-256"))
+        .runWith(Sink.reduce[ByteString](_.concat(_)), mat)
+    }
+
+    val contentHashHexFuture = contentHashFuture.map(bs=>bs.map("%02x".format(_)).mkString)
+
+    val updatedHeadersFuture = contentHashHexFuture.map(hash=>
+      req.headers ++ Seq(
+        makeHttpHeader("x-amz-date",requestTime.format(aws_compatible_datetime)),
+        makeHttpHeader("x-amz-content-sha256",hash)
+      )
+    )
+
+    val canonStringFuture = updatedHeadersFuture.map(headers=> {
+      val hash = contentHashHexFuture.value.get.get //this is safe, because updatedHeadersFuture is mapped from contentHashHexFuture; therefore if we got here, it succeeded.
+      calculateCanonicalString(req.method.value, req.uri.path.toString(), convertQueryString(req.uri.rawQueryString), headersToMap(headers), Some(hash))
+    })
+
+    canonStringFuture.onComplete({
+      case Success(str)=>logger.debug(s"canonicalString is $str")
+      case Failure(err)=>logger.error(s"Canonical string failed", err)
+    })
+
+    val stringToSignFuture = canonStringFuture.map(cs=>stringToSign(region.getName, serviceName, cs, requestTime))
+
+    stringToSignFuture.onComplete({
+      case Success(str)=>logger.debug(s"stringToSign is $str")
+      case Failure(err)=>logger.error(s"stringToSign failed", err)
+    })
+    val credentials = credsProvider.getCredentials
+    val signingKeyResult = signingKey(credentials.getAWSSecretKey, serviceName, region.getName, requestTime)
+    val sig = stringToSignFuture.map(sts=>finalSignature(signingKeyResult, sts))
+
+    Future.sequence(Seq(sig, updatedHeadersFuture)).map(results=>{
+      val finalSig = results.head.asInstanceOf[String]
+      val signedHeaders = results(1).asInstanceOf[Seq[HttpHeader]]
+      val signedHeadersString = signedHeaders.map(_.name().toLowerCase()).sorted.mkString(";")
+      val finalHeaders =  signedHeaders ++ Seq(
+        makeHttpHeader("Authorization", s"AWS4-HMAC-SHA256 Credential=${credentials.getAWSAccessKeyId}/${requestTime.format(aws_compatible_date)}/$region/$serviceName/aws4_request,SignedHeaders=$signedHeadersString,Signature=$finalSig")
+      )
+
+      logger.debug(s"Final headers are: $finalHeaders")
+      req.copy(headers=finalHeaders)
+    })
+  }
+
+  /**
+    * Step one of the algorithm: calculate the canonical string
+    * @param httpMethod
+    * @param uriPath
+    * @param uriQueryParams
+    * @param headers
+    * @param payloadHash
+    * @return
+    */
+  protected def calculateCanonicalString(httpMethod:String, uriPath: String, uriQueryParams:Map[String,String],
+                               headers:Map[String,String], payloadHash:Option[String]) = {
+    val checksummer = MessageDigest.getInstance("SHA-256")
+
+    val canonicalUrl = uriPath.split("/").map(section=>URLEncoder.encode(section,"UTF-8")).mkString("/")
+    logger.debug(s"encodedUrl: $canonicalUrl")
+
+    val canonicalQueryString = uriQueryParams.map(entry=>URLEncoder.encode(entry._1,"UTF-8")+"="+URLEncoder.encode(entry._2,"UTF-8")).mkString("&")
+    logger.debug(s"canonicalQueryString: $canonicalQueryString")
+
+    val updatedHeaders = if(headers.keys.exists(_=="x-amz-content-sha256")){
+      headers
+    } else {
+      headers ++ "x-amz-content-sha256"->checksummer.digest("".getBytes("UTF-8")).map("%02x".format(_)).mkString
+    }
+
+    checksummer.reset()
+
+    val canonicalHeaders = headers.keys.toList.sorted.map(header=>{
+      header.toLowerCase + ":" + headers(header).trim
+    }).mkString("\n") + "\n"
+    logger.debug(s"canonicalHeaders: $canonicalHeaders")
+
+    val signedHeaders = headers.keys.map(_.toLowerCase).toList.sorted.mkString(";")
+    logger.debug(s"signedHeaders: $signedHeaders")
+
+    val hashedPayload = payloadHash match {
+      case Some(hexDigest)=>hexDigest
+      case None=>checksummer.digest("".getBytes("UTF-8")).map("%02x".format(_)).mkString
+    }
+    logger.debug(s"hashedPayload: $hashedPayload")
+
+    s"""$httpMethod
+       |$canonicalUrl
+       |$canonicalQueryString
+       |$canonicalHeaders
+       |$signedHeaders
+       |$hashedPayload""".stripMargin
+  }
+
+  /**
+    * Step two - create a string to sign
+    * @param region AWS region name (string)
+    * @param serviceName AWS service name (String)
+    * @param canonicalRequestString Canonical request string as provided by `calculateCanonicalString`
+    */
+  protected def stringToSign(region:String, serviceName:String, canonicalRequestString: String, requestTime:OffsetDateTime) = {
+    val checksummer = MessageDigest.getInstance("SHA-256")
+    val timestamp = requestTime.format(aws_compatible_datetime)
+    logger.debug(s"timestamp is $timestamp")
+    val scope = s"${requestTime.format(aws_compatible_date)}/$region/$serviceName/aws4_request"
+    logger.debug(s"scope is $scope")
+    val canonRequestDigest = checksummer.digest(canonicalRequestString.getBytes("UTF-8")).map("%02x".format(_)).mkString
+    logger.debug(s"Digest of canonical string is $canonRequestDigest")
+
+    s"""AWS4-HMAC-SHA256
+       |$timestamp
+       |$scope
+       |$canonRequestDigest""".stripMargin
+  }
+
+  /**
+    * Step three - Calculate signing key
+    */
+  protected def signingKey(secretAccessKey:String, serviceName:String, awsRegion:String, requestTime:OffsetDateTime) = {
+    val dateValue = requestTime.format(aws_compatible_date)
+    logger.debug(s"dateValue is $dateValue")
+    val dateKey = hmacString("AWS4" + secretAccessKey, dateValue)
+    logger.debug(s"dateKey is $dateKey")
+    val dateRegionKey = hmacString(dateKey, awsRegion)
+    logger.debug(s"dateRegionKey is $dateRegionKey")
+    val dateRegionServiceKey = hmacString(dateRegionKey, serviceName)
+    logger.debug(s"dateRegionServiceKey is $dateRegionServiceKey")
+
+    hmacString(dateRegionServiceKey, "aws4_request")
+  }
+
+  /**
+    * Step four - use the signing key on the string to sign
+    * @param signingKey provided from step three
+    * @param stringToSign provided from step two
+    * @return
+    */
+  protected def finalSignature(signingKey:String, stringToSign:String) = {
+    hmacString(signingKey, stringToSign)
+  }
+}

--- a/app/helpers/S3Signer.scala
+++ b/app/helpers/S3Signer.scala
@@ -170,7 +170,7 @@ trait S3Signer {
     logger.debug(s"encodedUrl: $canonicalUrl")
 
     val canonicalQueryString = uriQueryParams
-      .map(entry=>URLEncoder.encode(entry._1,"UTF-8")+"="+URLEncoder.encode(entry._2,"UTF-8"))
+      .map(entry=>URLEncoder.encode(entry._1,"UTF-8")+"=" + entry._2)
       .toList.sorted
       .mkString("&")
     logger.debug(s"canonicalQueryString: $canonicalQueryString")

--- a/app/helpers/S3ToArchiveEntryFlow.scala
+++ b/app/helpers/S3ToArchiveEntryFlow.scala
@@ -49,7 +49,8 @@ class S3ToArchiveEntryFlow @Inject() (s3ClientMgr: S3ClientManager, config:Confi
           } catch {
             case ex:Throwable=>
               logger.error(s"Could not create ArchiveEntry: ", ex)
-              pull(in)
+              failStage(ex) //temp for debugging
+              //pull(in)
           }
         }
       })

--- a/app/helpers/S3ToArchiveEntryFlow.scala
+++ b/app/helpers/S3ToArchiveEntryFlow.scala
@@ -49,8 +49,8 @@ class S3ToArchiveEntryFlow @Inject() (s3ClientMgr: S3ClientManager, config:Confi
           } catch {
             case ex:Throwable=>
               logger.error(s"Could not create ArchiveEntry: ", ex)
-              failStage(ex) //temp for debugging
-              //pull(in)
+              //failStage(ex) //temp for debugging
+              pull(in)
           }
         }
       })

--- a/app/helpers/S3XMLProcessor.scala
+++ b/app/helpers/S3XMLProcessor.scala
@@ -1,0 +1,171 @@
+package helpers
+
+import java.time.Instant
+
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.alpakka.s3.impl.ListBucketResult
+import akka.stream.alpakka.s3.scaladsl.ListBucketResultContents
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import akka.util.ByteString
+
+import scala.xml.pull.XMLEventReader
+import play.api.Logger
+
+import scala.io.Source
+import scala.util.{Failure, Success, Try}
+import scala.xml.pull._
+
+class S3XMLProcessor extends GraphStage[FlowShape[ByteString,ListBucketResultContents]]{
+  private val in:Inlet[ByteString] = Inlet.create("S3XMLProcessor.in")
+  private val out:Outlet[ListBucketResultContents] = Outlet.create("S3XMLProcessor.out")
+
+  private val logger=Logger(getClass)
+
+  override def shape: FlowShape[ByteString, ListBucketResultContents] = FlowShape.of(in, out)
+
+  def listBucketResultFor(captures: Map[String, String], bucketName:String): Option[ListBucketResultContents] = try {
+    val lastModTime = Instant.parse(captures("LastModified"))
+    Some(ListBucketResultContents(bucketName, captures("Key"), captures("ETag"), captures("Size").toLong, lastModTime, captures("StorageClass")))
+  } catch {
+    case ex:Throwable=>
+      logger.error(s"Could not convert $captures into ListbucketResultContents: ", ex)
+      None
+  }
+
+  private def captureFromXml(xml:XMLEventReader, currNode:List[String],allCaptures:Map[String,String]):Map[String,String] =
+    if(xml.hasNext){
+      xml.next match {
+        case EvElemStart(_, label, attrs, scope)=>
+          logger.debug(s"\telem start: $label")
+          captureFromXml(xml, label :: currNode, allCaptures)
+        case EvText(text)=>
+          if(currNode.nonEmpty) {
+            logger.debug(s"\ttext: $text, currentCapture: ${currNode.head}")
+
+            val updatedText = allCaptures.get(currNode.head) match {
+              case Some(existingText) => existingText + text
+              case None => text
+            }
+            val updatedCaptures = allCaptures ++ Map(currNode.head -> updatedText)
+            logger.debug(updatedCaptures.toString)
+            captureFromXml(xml, currNode, updatedCaptures)
+          } else {
+            captureFromXml(xml, currNode, allCaptures)
+          }
+        case EvElemEnd(_, label)=>
+          logger.debug(s"\telem end: $label")
+          if(currNode.isEmpty){
+            allCaptures
+          } else {
+            captureFromXml(xml, currNode.tail, allCaptures)
+          }
+        case _=>
+          captureFromXml(xml, currNode, allCaptures)
+      }
+    } else {
+      allCaptures
+    }
+
+
+  def parseContentNode(xml:XMLEventReader, bucketName:String):Option[ListBucketResultContents] = {
+    val allCaptures = captureFromXml(xml, List.empty, Map.empty)
+    listBucketResultFor(allCaptures, bucketName)
+  }
+
+  def parseDoc(xml:XMLEventReader)(cb:Either[S3Error, ListBucketResultContents]=>Unit): Unit = {
+    def loop(currNode: List[String], bucketName:String, inBucketName:Boolean=false): Unit = {
+      logger.debug(s"in loop: $currNode")
+      logger.debug(s"xml.hasNext: ${xml.hasNext}")
+      if(xml.hasNext){
+        xml.next match {
+          case EvElemStart(prefix, label, attrs, scope)=>
+            logger.debug(s"start element: $label")
+            if(label=="Contents"){
+              logger.debug("Got contents")
+              parseContentNode(xml, bucketName) match {
+                case Some(result)=>
+                  logger.debug(s"Got $result")
+                  cb(Right(result))
+                case None=>logger.error(s"Could not build ListBucketResult")
+              }
+            } else if(label=="Error"){
+              val errorData = captureFromXml(xml, List.empty, Map.empty)
+              S3Error.fromMap(errorData) match {
+                case Success(err)=>cb(Left(err))
+                case Failure(excp)=>
+                  logger.error("Could not generate error entity: ", excp)
+              }
+            }
+
+            if(label=="Name"){
+              loop(label::currNode, bucketName, inBucketName = true)
+            } else {
+              loop(label::currNode, bucketName)
+            }
+
+          case EvElemEnd(prefix, label)=>
+            logger.debug(s"end element: $label")
+            if(label=="Bucket"){
+              loop(currNode.tail, bucketName)
+            } else {
+              loop(currNode.tail, bucketName, inBucketName)
+            }
+          case EvText(text)=>
+            logger.debug(s"text: '$text'")
+            if(inBucketName){
+              logger.debug(s"Got bucketname $text")
+              loop(currNode, bucketName + text.trim, inBucketName)
+            } else {
+              loop(currNode, bucketName, inBucketName)
+            }
+
+          case EvEntityRef(entity)=>
+            logger.debug(s"entity: $entity")
+            loop(currNode, bucketName, inBucketName)
+          case _=>
+            logger.debug("Got nothing")
+            loop(currNode, bucketName, inBucketName)
+        }
+      }
+    }
+    loop(List.empty, "")
+  }
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger = Logger(getClass)
+
+    var processingDoc:Boolean = false
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+        //elem is an XML document, that can't necessarily be trusted...
+        logger.debug("xml document:")
+        logger.debug(elem.utf8String)
+
+        val xml = new XMLEventReader(Source.fromBytes(elem.toByteBuffer.array(), "UTF-8"))
+        processingDoc = true
+        parseDoc(xml)(entryOrError=>{
+          while(!isAvailable(out)) {
+            logger.debug("output not available, waiting...")
+            Thread.sleep(500L)
+          }
+          entryOrError match {
+            case Right(entry)=>push(out, entry)
+            case Left(s3error)=>
+              logger.error(s"Got an error from S3: ${s3error.toString}")
+              failStage(new RuntimeException(s3error.toString))
+          }
+
+        })
+        processingDoc = false
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = {
+        if(!processingDoc) pull(in)
+      }
+    })
+  }
+}

--- a/app/helpers/S3XMLProcessor.scala
+++ b/app/helpers/S3XMLProcessor.scala
@@ -140,8 +140,8 @@ class S3XMLProcessor extends GraphStage[FlowShape[ByteString,ListBucketResultCon
       override def onPush(): Unit = {
         val elem = grab(in)
         //elem is an XML document, that can't necessarily be trusted...
-        logger.debug("xml document:")
-        logger.debug(elem.utf8String)
+        logger.info("xml document:")
+        logger.info(elem.utf8String)
 
         val xml = new XMLEventReader(Source.fromBytes(elem.toByteBuffer.array(), "UTF-8"))
         processingDoc = true

--- a/app/models/ScanTarget.scala
+++ b/app/models/ScanTarget.scala
@@ -2,4 +2,4 @@ package models
 
 import java.time.ZonedDateTime
 
-case class ScanTarget (bucketName:String, enabled:Boolean, lastScanned:Option[ZonedDateTime], scanInterval:Long, scanInProgress:Boolean, lastError:Option[String])
+case class ScanTarget (bucketName:String, enabled:Boolean, lastScanned:Option[ZonedDateTime], scanInterval:Long, scanInProgress:Boolean, lastError:Option[String], proxyBucket:String, paranoid:Option[Boolean])

--- a/app/services/BucketScanner.scala
+++ b/app/services/BucketScanner.scala
@@ -4,11 +4,11 @@ import java.time.ZonedDateTime
 import java.time.temporal.{ChronoUnit, IsoFields, TemporalUnit}
 
 import akka.actor.{Actor, ActorSystem, Timers}
+import akka.http.scaladsl.Http
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.{ActorMaterializer, KillSwitches, Materializer}
 import com.google.inject.Injector
 import com.gu.scanamo.{ScanamoAlpakka, Table}
-import com.sksamuel.elastic4s.{Index, Indexes}
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.bulk.BulkResponseItem
 import helpers._
@@ -158,6 +158,21 @@ class BucketScanner @Inject()(config:Configuration, ddbClientMgr:DynamoClientMan
 
     completionPromise
   }
+
+  /**
+    * Performs a scan in "paranoid" mode, i.e. assume that S3 will return invalid XML that will break the standard SDK (it does sometimes....)
+    * @param target [[ScanTarget]] indicating bucket to process
+    * @return a Promise[Unit] which completes when the scan finishes
+    */
+//  def doScanParanoid(target:ScanTarget):Promise[Unit] = {
+//    val region = config.get[String]("externalData.awsRegion")
+//    val hostname = s"s3-$region.amazonaws.com"
+//    val urlString = s"https://$hostname/${target.bucketName}"
+//
+//    val connectionFlow = Http().cachedHostConnectionPoolHttps(hostname,443)
+//
+//
+//  }
 
   def doScanDeleted(target:ScanTarget):Promise[Unit] = {
     val completionPromise = Promise[Unit]()

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,8 @@ lazy val commonSettings = Seq(
 
 scalaVersion := "2.12.2"
 
+val akkaVersion = "2.5.18"
+
 lazy val `archivehunter` = (project in file("."))
   .enablePlugins(PlayScala)
   .dependsOn(common)
@@ -42,15 +44,17 @@ lazy val `archivehunter` = (project in file("."))
       "com.lightbend.akka" %% "akka-stream-alpakka-dynamodb" % "0.20",
       "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "0.20",
       "com.gu" %% "scanamo-alpakka" % "1.0.0-M8",
-      "com.typesafe.akka" %% "akka-cluster-tools" % "2.5.11",
+      "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
       "com.lightbend.akka.discovery" %% "akka-discovery-aws-api" % "0.18.0",
-      "com.typesafe.akka" %% "akka-cluster" % "2.5.11",
-      "com.typesafe.akka" %% "akka-cluster-metrics" % "2.5.11",
+      "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
+      "com.typesafe.akka" %% "akka-cluster-metrics" % akkaVersion,
+      "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+      "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
+      // Only if you are using Akka Testkit
+      "com.typesafe.akka" %% "akka-testkit" % akkaVersion,
       jdbc, ehcache, ws)
   )
-
-
-val awsversion = "2.0.0-preview-10"
 
 val lambdaDeps = Seq(
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.0.0"

--- a/common/src/test/scala/com/theguardian/multimedia/archivehunter/ArchiveEntrySpec.scala
+++ b/common/src/test/scala/com/theguardian/multimedia/archivehunter/ArchiveEntrySpec.scala
@@ -4,7 +4,7 @@ import java.util.Date
 
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.ObjectMetadata
-import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, MimeType}
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, MimeType, StorageClass}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 
@@ -25,7 +25,7 @@ class ArchiveEntrySpec extends Specification with Mockito {
 
       val newEntry = Await.result(ArchiveEntry.fromS3("test-bucket","test/path/to/file.ext"), 5 seconds)
 
-      newEntry mustEqual ArchiveEntry(ArchiveEntry.makeDocId("test-bucket","test/path/to/file.ext"),"test-bucket","test/path/to/file.ext",Some("ext"),123456L,ZonedDateTime.of(2018,1,1,23,21,0,0,ZoneId.systemDefault()),"test-etag", MimeType("application","octet-stream"), false)
+      newEntry mustEqual ArchiveEntry(ArchiveEntry.makeDocId("test-bucket","test/path/to/file.ext"),"test-bucket","test/path/to/file.ext",Some("ext"),123456L,ZonedDateTime.of(2018,1,1,23,21,0,0,ZoneId.systemDefault()),"test-etag", MimeType("application","octet-stream") ,false, StorageClass.STANDARD)
     }
 
     "return any exception in the AWS SDK as a failed Try" in {

--- a/common/src/test/scala/com/theguardian/multimedia/archivehunter/IndexerSpec.scala
+++ b/common/src/test/scala/com/theguardian/multimedia/archivehunter/IndexerSpec.scala
@@ -5,7 +5,7 @@ import java.time.ZonedDateTime
 import com.sksamuel.elastic4s.embedded.LocalNode
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.index.CreateIndexResponse
-import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer, MimeType}
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer, MimeType, StorageClass}
 import org.elasticsearch.client.ElasticsearchClient
 import org.specs2.mutable._
 import org.specs2.specification.AfterAll
@@ -42,7 +42,8 @@ class IndexerSpec extends Specification with AfterAll {
         ZonedDateTime.now(),
         "etag_here",
         MimeType("application","octet-stream"),
-        proxied=false
+        proxied=false,
+        storageClass = StorageClass.STANDARD
       )
 
       val i = new Indexer("testindex")

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -46,6 +46,8 @@
     <logger name="controllers.ScanTargetController" level="INFO"/>
 
 
+    <logger name="S3LocationSpec" level="DEBUG"/>
+
     <root level="WARN">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="ASYNCFILE"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -47,6 +47,8 @@
 
 
     <logger name="S3LocationSpec" level="DEBUG"/>
+    <logger name="helpers.ParanoidS3Source" level="DEBUG"/>
+    <logger name="helpers.S3XMLProcessor" level="INFO"/>
 
     <root level="WARN">
         <appender-ref ref="STDOUT" />

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -38,17 +38,17 @@
     <logger name="services.AppStartup" level="DEBUG"/>
     <logger name="services.BucketScanner" level="INFO"/>
     <logger name="akka.cluster" level="DEBUG"/>
-    <logger name="helpers.S3ToArchiveEntryFlow" level="WARN"/>
+    <logger name="helpers.S3ToArchiveEntryFlow" level="DEBUG"/>
     <logger name="helpers.SearchHitToArchiveEntryFlow" level="WARN"/>
     <logger name="helpers.ArchiveEntryVerifyFlow" level="WARN"/>
-    <logger name="com.sksamuel.elastic4s.streams" level="WARN"/>
+    <logger name="com.sksamuel.elastic4s.streams" level="DEBUG"/>
     <logger name="controllers.SearchController" level="INFO"/>
     <logger name="controllers.ScanTargetController" level="INFO"/>
 
 
     <logger name="S3LocationSpec" level="DEBUG"/>
     <logger name="helpers.ParanoidS3Source" level="DEBUG"/>
-    <logger name="helpers.S3XMLProcessor" level="INFO"/>
+    <logger name="helpers.S3XMLProcessor" level="DEBUG"/>
 
     <root level="WARN">
         <appender-ref ref="STDOUT" />

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -38,17 +38,17 @@
     <logger name="services.AppStartup" level="DEBUG"/>
     <logger name="services.BucketScanner" level="INFO"/>
     <logger name="akka.cluster" level="DEBUG"/>
-    <logger name="helpers.S3ToArchiveEntryFlow" level="DEBUG"/>
+    <logger name="helpers.S3ToArchiveEntryFlow" level="WARN"/>
     <logger name="helpers.SearchHitToArchiveEntryFlow" level="WARN"/>
     <logger name="helpers.ArchiveEntryVerifyFlow" level="WARN"/>
-    <logger name="com.sksamuel.elastic4s.streams" level="DEBUG"/>
+    <logger name="com.sksamuel.elastic4s.streams" level="WARN"/>
     <logger name="controllers.SearchController" level="INFO"/>
     <logger name="controllers.ScanTargetController" level="INFO"/>
 
 
     <logger name="S3LocationSpec" level="DEBUG"/>
     <logger name="helpers.ParanoidS3Source" level="DEBUG"/>
-    <logger name="helpers.S3XMLProcessor" level="DEBUG"/>
+    <logger name="helpers.S3XMLProcessor" level="INFO"/>
 
     <root level="WARN">
         <appender-ref ref="STDOUT" />

--- a/frontend/__tests__/Entry/test_EntryDetails.jsx
+++ b/frontend/__tests__/Entry/test_EntryDetails.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {shallow,mount} from 'enzyme';
+import EntryDetails from '../../app/Entry/EntryDetails.jsx';
+import {BrowserRouter} from 'react-router-dom';
+
+describe("EntryDetails.extractFileInfo", ()=>{
+    it("should seperate a full path into path and filename", ()=>{
+        const d = new EntryDetails;
+
+        const result = d.extractFileInfo("path/to/some/file.ext");
+        console.log(result);
+        expect(result.filename).toEqual("file.ext");
+        expect(result.filepath).toEqual("path/to/some");
+    });
+});

--- a/frontend/__tests__/Entry/test_FileSizeView.jsx
+++ b/frontend/__tests__/Entry/test_FileSizeView.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import {shallow,mount} from 'enzyme';
+import FileSizeView from '../../app/Entry/FileSizeView.jsx';
+
+describe("FileSizeView", ()=>{
+    it("should correctly display kb",()=>{
+        const value = 2*1000;
+        const rendered = mount(<FileSizeView rawSize={value}/>);
+        expect(rendered.find('span').text()).toEqual("2 Kb");
+    })
+});

--- a/frontend/__tests__/Entry/test_FileSizeView.jsx
+++ b/frontend/__tests__/Entry/test_FileSizeView.jsx
@@ -3,9 +3,33 @@ import {shallow,mount} from 'enzyme';
 import FileSizeView from '../../app/Entry/FileSizeView.jsx';
 
 describe("FileSizeView", ()=>{
+    it("should correctly display bytes",()=>{
+        const value = 2;
+        const rendered = mount(<FileSizeView rawSize={value}/>);
+        expect(rendered.find('span').text()).toEqual("2 bytes");
+    });
+
     it("should correctly display kb",()=>{
         const value = 2*1000;
         const rendered = mount(<FileSizeView rawSize={value}/>);
         expect(rendered.find('span').text()).toEqual("2 Kb");
-    })
+    });
+
+    it("should correctly display Mb",()=>{
+        const value = 2*1000*1000;
+        const rendered = mount(<FileSizeView rawSize={value}/>);
+        expect(rendered.find('span').text()).toEqual("2 Mb");
+    });
+
+    it("should correctly display Gb",()=>{
+        const value = 2*1000*1000*1000;
+        const rendered = mount(<FileSizeView rawSize={value}/>);
+        expect(rendered.find('span').text()).toEqual("2 Gb");
+    });
+
+    it("should correctly display Tb",()=>{
+        const value = 2*1000*1000*1000*1000;
+        const rendered = mount(<FileSizeView rawSize={value}/>);
+        expect(rendered.find('span').text()).toEqual("2 Tb");
+    });
 });

--- a/frontend/__tests__/Entry/test_FileSizeView.jsx
+++ b/frontend/__tests__/Entry/test_FileSizeView.jsx
@@ -32,4 +32,16 @@ describe("FileSizeView", ()=>{
         const rendered = mount(<FileSizeView rawSize={value}/>);
         expect(rendered.find('span').text()).toEqual("2 Tb");
     });
+
+    it("should round to 3sf by default",()=>{
+        const value = 2.0123*1000*1000*1000*1000;
+        const rendered = mount(<FileSizeView rawSize={value}/>);
+        expect(rendered.find('span').text()).toEqual("2.01 Tb");
+    });
+
+    it("should round to the provided precision",()=>{
+        const value = 2.0123*1000*1000*1000*1000;
+        const rendered = mount(<FileSizeView rawSize={value} precision={1}/>);
+        expect(rendered.find('span').text()).toEqual("2 Tb");
+    });
 });

--- a/frontend/app/Entry/EntryDetails.jsx
+++ b/frontend/app/Entry/EntryDetails.jsx
@@ -8,11 +8,29 @@ class EntryDetails extends React.Component {
         entry: PropTypes.object.isRequired
     };
 
+    extractFileInfo(fullpath){
+        const parts = fullpath.split("/");
+        const len = parts.length;
+        if(len===0){
+            return {
+                filename: parts[0],
+                filepath: ""
+            }
+        }
+
+        return {
+            filename: parts[len-1],
+            filepath: parts.slice(0,len-1).join("/")
+        }
+    }
+
     render(){
         if(!this.props.entry){
             return <div className="entry-details">
             </div>
         }
+        const fileinfo = this.extractFileinfo(this.props.entry.path);
+
         return <div className="entry-details">
                 <EntryPreview entryId={this.props.entry.id}
                               hasProxy={this.props.entry.proxied}
@@ -23,8 +41,12 @@ class EntryDetails extends React.Component {
                 <table className="metadata-table">
                     <tbody>
                     <tr>
+                        <td className="metadata-heading">Name</td>
+                        <td className="metadata-entry">{fileinfo.filename}</td>
+                    </tr>
+                    <tr>
                         <td className="metadata-heading">File path</td>
-                        <td className="metadata-entry">{this.props.entry.path}</td>
+                        <td className="metadata-entry">{fileinfo.filepath}</td>
                     </tr>
                     <tr>
                         <td className="metadata-heading">Catalogue</td>

--- a/frontend/app/Entry/EntryDetails.jsx
+++ b/frontend/app/Entry/EntryDetails.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import EntryPreview from './EntryPreview.jsx';
 import EntryThumbnail from './EntryThumbnail.jsx';
+import FileSizeView from './FileSizeView.jsx';
 
 class EntryDetails extends React.Component {
     static propTypes = {
@@ -54,7 +55,7 @@ class EntryDetails extends React.Component {
                     </tr>
                     <tr>
                         <td className="metadata-heading">File size</td>
-                        <td className="metadata-entry">{this.props.entry.size}</td>
+                        <td className="metadata-entry"><FileSizeView rawSize={this.props.entry.size}/></td>
                     </tr>
                     <tr>
                         <td className="metadata-heading">Data type</td>

--- a/frontend/app/Entry/EntryDetails.jsx
+++ b/frontend/app/Entry/EntryDetails.jsx
@@ -30,7 +30,7 @@ class EntryDetails extends React.Component {
             return <div className="entry-details">
             </div>
         }
-        const fileinfo = this.extractFileinfo(this.props.entry.path);
+        const fileinfo = this.extractFileInfo(this.props.entry.path);
 
         return <div className="entry-details">
                 <EntryPreview entryId={this.props.entry.id}

--- a/frontend/app/Entry/FileSizeView.jsx
+++ b/frontend/app/Entry/FileSizeView.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 
 class FileSizeView extends React.Component {
     static propTypes = {
-        rawSize: PropTypes.number.isRequired
+        rawSize: PropTypes.number.isRequired,
+        precision: PropTypes.number  //how many significant figures to round to.
     };
 
     constructor(props){
@@ -27,9 +28,23 @@ class FileSizeView extends React.Component {
         return postfixes[thousands];
     }
 
+    /**
+     * round a number to given precision, but remove any trailing zeroes for a nicer display
+     * @param num number to round
+     * @param precision number of significant figures to retain
+     * @returns {*} rounded number
+     */
+    withPrecision(num, precision){
+        const rounded = num.toPrecision(precision);
+        const asString = rounded.toString();
+        if(asString.endsWith("0") || asString.endsWith(".")) return this.withPrecision(num, precision-1);
+        return rounded;
+    }
+
     render(){
+        const actualPrecision = this.props.precision ? this.props.precision : 3;
         const result = this.countThousands(this.props.rawSize, 0);
-        return <span className="file-size">{result.value} {this.getPostfix(result.thousands)}</span>
+        return <span className="file-size">{this.withPrecision(result.value, actualPrecision)} {this.getPostfix(result.thousands)}</span>
     }
 }
 

--- a/frontend/app/Entry/FileSizeView.jsx
+++ b/frontend/app/Entry/FileSizeView.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class FileSizeView extends React.Component {
+    static propTypes = {
+        rawSize: PropTypes.number.isRequired
+    };
+
+    constructor(props){
+        super(props);
+    }
+
+    countThousands(num, iteration){
+        if(num>1000){
+            return this.countThousands(num/1000,iteration+1)
+        } else {
+            return {
+                value: num,
+                thousands: iteration
+            }
+        }
+    }
+
+    getPostfix(thousands){
+        const postfixes = ["b", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb"];
+        if(thousands>postfixes.length) return "ridiculous";
+        return postfixes[thousands];
+    }
+
+    render(){
+        const result = this.countThousands(this.props.rawSize, 0);
+        return <span className="file-size">{result.value} {this.getPostfix(result.thousands)}</span>
+    }
+}
+
+export default FileSizeView;

--- a/frontend/app/Entry/FileSizeView.jsx
+++ b/frontend/app/Entry/FileSizeView.jsx
@@ -22,7 +22,7 @@ class FileSizeView extends React.Component {
     }
 
     getPostfix(thousands){
-        const postfixes = ["b", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb"];
+        const postfixes = ["bytes", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb"];
         if(thousands>postfixes.length) return "ridiculous";
         return postfixes[thousands];
     }

--- a/frontend/app/search/BasicSearchComponent.jsx
+++ b/frontend/app/search/BasicSearchComponent.jsx
@@ -19,7 +19,7 @@ class BasicSearchComponent extends React.Component {
             error:null,
             searchResults: [],
             totalHits: -1,
-            limit: 100,
+            limit: 1000,
             showingPreview: null
         };
 

--- a/test/AkkaTestkitSpecs2Support.scala
+++ b/test/AkkaTestkitSpecs2Support.scala
@@ -1,0 +1,14 @@
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit}
+import org.specs2.mutable.After
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/* A tiny class that can be used as a Specs2 ‘context’. */
+abstract class AkkaTestkitSpecs2Support extends TestKit(ActorSystem())
+  with After
+  with ImplicitSender {
+  // make sure we shut down the actor system after all tests have run
+  def after = Await.result(system.terminate(), 30 seconds)
+}

--- a/test/ParanoidS3SourceSpec.scala
+++ b/test/ParanoidS3SourceSpec.scala
@@ -1,0 +1,40 @@
+import akka.stream.Attributes
+import akka.util.ByteString
+import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
+import com.amazonaws.profile.path.cred.CredentialsDefaultLocationProvider
+import com.amazonaws.regions.{Region, Regions}
+import helpers.ParanoidS3Source
+import org.specs2.mutable._
+
+import scala.collection.immutable.Seq
+
+class ParanoidS3SourceSpec extends Specification {
+  sequential
+
+  "ParanoidS3Source.findParams" should {
+    "extract strings from a pseudo-xml byte string source" in new AkkaTestkitSpecs2Support {
+      val fakeData =
+        """<?xml version="1.0" encoding="UTF-8"?>
+          |<root>
+          |  <firstKey>firstValue</firstKey>
+          |  <secondKey>secondValue</secondKey>
+          |  <composite>
+          |     <another>
+          |       <thirdKey>thirdValue</thirdKey>
+          |     </another>
+          |   </composite>
+          |</root>"""".stripMargin
+      val fakeCredsProvider = new AWSCredentialsProviderChain(new InstanceProfileCredentialsProvider())
+
+      val test = new ParanoidS3Source("testBucket",Region.getRegion(Regions.EU_WEST_1), fakeCredsProvider)
+      val result = test.findParams(Seq("firstKey","thirdKey","missingKey"),ByteString(fakeData))
+
+      println(result)
+
+      result("firstKey") must beSome("firstValue")
+      result("thirdKey") must beSome("thirdValue")
+      result("missingKey") must beNone
+      result.contains("secondKey") mustEqual false
+    }
+  }
+}

--- a/test/S3LocationSpec.scala
+++ b/test/S3LocationSpec.scala
@@ -82,5 +82,62 @@ class S3LocationSpec extends Specification {
       val headerMap = result.headers.map(hdr=>Tuple2(hdr.name(), hdr.value())).toMap
       headerMap("Authorization") mustEqual "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=fea454ca298b7da1c68078a5d1bdbfbbe0d65c699e0f91ac7a200a0136783543"
     }
+
+    "sign a GET request with value parameters correctly" in new AkkaTestkitSpecs2Support {
+      val logger=Logger(getClass)
+      val mat = ActorMaterializer()
+      implicit val ec = system.dispatcher
+      val test = new TestClass(logger, mat, ec)
+
+      val credentialsProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"))
+
+      val headers = Seq(HttpHeader.parse("Host", "examplebucket.s3.amazonaws.com")).map({
+        case Ok(result, errors)=>result
+        case Error(errs)=>throw new RuntimeException(errs.toString)
+      })
+
+      val testInput = HttpRequest(HttpMethod.custom("GET"),
+        Uri("https://examplebucket.s3.amazonaws.com/?max-keys=2&prefix=J"),
+        headers
+      )
+
+      val fakeTime = OffsetDateTime.of(2013, 5, 24, 0,0,0,0,ZoneOffset.UTC)
+      val result = Await.result(test.signHttpRequest(testInput,Region.getRegion(Regions.US_EAST_1),"s3", credentialsProvider, Some(fakeTime)), 10 seconds)
+
+      val headerMap = result.headers.map(hdr=>Tuple2(hdr.name(), hdr.value())).toMap
+      headerMap("Authorization") mustEqual "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7"
+    }
+
+    "sign a PUT request with data correctly" in new AkkaTestkitSpecs2Support {
+      val logger=Logger(getClass)
+      val mat = ActorMaterializer()
+      implicit val ec = system.dispatcher
+      val test = new TestClass(logger, mat, ec)
+
+      val credentialsProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"))
+
+      val headers = Seq(
+        HttpHeader.parse("Host", "examplebucket.s3.amazonaws.com"),
+        HttpHeader.parse("Date", "Fri, 24 May 2013 00:00:00 GMT"),
+        HttpHeader.parse("x-amz-storage-class", "REDUCED_REDUNDANCY")
+      ).map({
+        case Ok(result, errors)=>result
+        case Error(errs)=>throw new RuntimeException(errs.toString)
+      })
+
+      val testData = HttpEntity("Welcome to Amazon S3.")
+
+      val testInput = HttpRequest(HttpMethod.custom("PUT"),
+        Uri("https://examplebucket.s3.amazonaws.com/test$file.text"),
+        headers,
+        entity = testData
+      )
+
+      val fakeTime = OffsetDateTime.of(2013, 5, 24, 0,0,0,0,ZoneOffset.UTC)
+      val result = Await.result(test.signHttpRequest(testInput,Region.getRegion(Regions.US_EAST_1),"s3", credentialsProvider, Some(fakeTime)), 10 seconds)
+
+      val headerMap = result.headers.map(hdr=>Tuple2(hdr.name(), hdr.value())).toMap
+      headerMap("Authorization") mustEqual "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class,Signature=98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd"
+    }
   }
 }

--- a/test/S3LocationSpec.scala
+++ b/test/S3LocationSpec.scala
@@ -15,14 +15,6 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 import scala.collection.immutable.Seq
 
-/* A tiny class that can be used as a Specs2 ‘context’. */
-abstract class AkkaTestkitSpecs2Support extends TestKit(ActorSystem())
-  with After
-  with ImplicitSender {
-  // make sure we shut down the actor system after all tests have run
-  def after = Await.result(system.terminate(), 30 seconds)
-}
-
 class S3LocationSpec extends Specification {
   sequential
   class TestClass(loggerval:Logger, m:Materializer, ecval:ExecutionContext) extends S3Signer {
@@ -127,7 +119,7 @@ class S3LocationSpec extends Specification {
 
       val testData = HttpEntity("Welcome to Amazon S3.")
 
-      val testInput = HttpRequest(HttpMethod.custom("PUT"),
+      val testInput = HttpRequest(HttpMethods.PUT,
         Uri("https://examplebucket.s3.amazonaws.com/test$file.text"),
         headers,
         entity = testData

--- a/test/S3LocationSpec.scala
+++ b/test/S3LocationSpec.scala
@@ -13,16 +13,18 @@ import play.api.Logger
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
+import scala.collection.immutable.Seq
 
 /* A tiny class that can be used as a Specs2 ‘context’. */
 abstract class AkkaTestkitSpecs2Support extends TestKit(ActorSystem())
   with After
   with ImplicitSender {
   // make sure we shut down the actor system after all tests have run
-  def after = system.terminate()
+  def after = Await.result(system.terminate(), 30 seconds)
 }
 
 class S3LocationSpec extends Specification {
+  sequential
   class TestClass(loggerval:Logger, m:Materializer, ecval:ExecutionContext) extends S3Signer {
     override implicit val mat:Materializer = m
     override protected val logger=loggerval
@@ -31,22 +33,13 @@ class S3LocationSpec extends Specification {
 
   "S3Signer" should {
     "sign a sample GET request correctly" in new AkkaTestkitSpecs2Support {
-      import scala.collection.immutable.Seq
+      /* example taken from https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html */
       val logger=Logger(getClass)
       val mat = ActorMaterializer()
       implicit val ec = system.dispatcher
       val test = new TestClass(logger, mat, ec)
 
       val credentialsProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"))
-//      val testInput = new HttpRequest(
-//        "GET",
-//        "https://examplebucket.s3.amazonaws.com/test.txt",
-//        Seq(
-//          HttpHeader("Range", "bytes=0-9")
-//        ),
-//        HttpEntity.NoEntity,
-//        HttpProtocol.HTTP_1_1
-//      )
 
       val headers = Seq(HttpHeader.parse("Range", "bytes=0-9"),HttpHeader.parse("Host", "examplebucket.s3.amazonaws.com")).map({
         case Ok(result, errors)=>result
@@ -63,6 +56,31 @@ class S3LocationSpec extends Specification {
 
       val headerMap = result.headers.map(hdr=>Tuple2(hdr.name(), hdr.value())).toMap
       headerMap("Authorization") mustEqual "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
+    }
+
+    "sign a GET request with parameters correctly" in new AkkaTestkitSpecs2Support {
+      val logger=Logger(getClass)
+      val mat = ActorMaterializer()
+      implicit val ec = system.dispatcher
+      val test = new TestClass(logger, mat, ec)
+
+      val credentialsProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"))
+
+      val headers = Seq(HttpHeader.parse("Host", "examplebucket.s3.amazonaws.com")).map({
+        case Ok(result, errors)=>result
+        case Error(errs)=>throw new RuntimeException(errs.toString)
+      })
+
+      val testInput = HttpRequest(HttpMethod.custom("GET"),
+        Uri("https://examplebucket.s3.amazonaws.com/?lifecycle"),
+        headers
+      )
+
+      val fakeTime = OffsetDateTime.of(2013, 5, 24, 0,0,0,0,ZoneOffset.UTC)
+      val result = Await.result(test.signHttpRequest(testInput,Region.getRegion(Regions.US_EAST_1),"s3", credentialsProvider, Some(fakeTime)), 10 seconds)
+
+      val headerMap = result.headers.map(hdr=>Tuple2(hdr.name(), hdr.value())).toMap
+      headerMap("Authorization") mustEqual "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=fea454ca298b7da1c68078a5d1bdbfbbe0d65c699e0f91ac7a200a0136783543"
     }
   }
 }

--- a/test/S3LocationSpec.scala
+++ b/test/S3LocationSpec.scala
@@ -1,0 +1,68 @@
+import java.time.{OffsetDateTime, ZoneOffset}
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpHeader.ParsingResult.{Error, Ok}
+import akka.http.scaladsl.model._
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.{ImplicitSender, TestKit}
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials, BasicSessionCredentials}
+import com.amazonaws.regions.{Region, Regions}
+import helpers.S3Signer
+import org.specs2.mutable._
+import play.api.Logger
+
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+
+/* A tiny class that can be used as a Specs2 ‘context’. */
+abstract class AkkaTestkitSpecs2Support extends TestKit(ActorSystem())
+  with After
+  with ImplicitSender {
+  // make sure we shut down the actor system after all tests have run
+  def after = system.terminate()
+}
+
+class S3LocationSpec extends Specification {
+  class TestClass(loggerval:Logger, m:Materializer, ecval:ExecutionContext) extends S3Signer {
+    override implicit val mat:Materializer = m
+    override protected val logger=loggerval
+    override implicit val ec:ExecutionContext = ecval
+  }
+
+  "S3Signer" should {
+    "sign a sample GET request correctly" in new AkkaTestkitSpecs2Support {
+      import scala.collection.immutable.Seq
+      val logger=Logger(getClass)
+      val mat = ActorMaterializer()
+      implicit val ec = system.dispatcher
+      val test = new TestClass(logger, mat, ec)
+
+      val credentialsProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"))
+//      val testInput = new HttpRequest(
+//        "GET",
+//        "https://examplebucket.s3.amazonaws.com/test.txt",
+//        Seq(
+//          HttpHeader("Range", "bytes=0-9")
+//        ),
+//        HttpEntity.NoEntity,
+//        HttpProtocol.HTTP_1_1
+//      )
+
+      val headers = Seq(HttpHeader.parse("Range", "bytes=0-9"),HttpHeader.parse("Host", "examplebucket.s3.amazonaws.com")).map({
+        case Ok(result, errors)=>result
+        case Error(errs)=>throw new RuntimeException(errs.toString)
+      })
+
+      val testInput = HttpRequest(HttpMethod.custom("GET"),
+        Uri("https://examplebucket.s3.amazonaws.com/test.txt"),
+        headers
+      )
+
+      val fakeTime = OffsetDateTime.of(2013, 5, 24, 0,0,0,0,ZoneOffset.UTC)
+      val result = Await.result(test.signHttpRequest(testInput,Region.getRegion(Regions.US_EAST_1),"s3", credentialsProvider, Some(fakeTime)), 10 seconds)
+
+      val headerMap = result.headers.map(hdr=>Tuple2(hdr.name(), hdr.value())).toMap
+      headerMap("Authorization") mustEqual "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
+    }
+  }
+}

--- a/test/S3XMLProcessorSpec.scala
+++ b/test/S3XMLProcessorSpec.scala
@@ -1,0 +1,51 @@
+import java.time.Instant
+
+import akka.stream.alpakka.s3.scaladsl.ListBucketResultContents
+import helpers.{S3Error, S3XMLProcessor}
+import org.specs2.mock.Mockito
+import org.specs2.mutable._
+import org.mockito.Mockito.{times, verify}
+
+import scala.io.Source
+import scala.xml.pull.XMLEventReader
+
+class S3XMLProcessorSpec extends Specification with Mockito {
+  "S3XMLProcessor.parseDoc" should {
+    "handle parsing a sample XML document and call the callback with ListBucketResultContents" in {
+      val sampleDoc = """<?xml version="1.0" encoding="UTF-8"?>
+                        |<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        |    <Name>bucket</Name>
+                        |    <Prefix/>
+                        |    <KeyCount>205</KeyCount>
+                        |    <MaxKeys>1000</MaxKeys>
+                        |    <IsTruncated>false</IsTruncated>
+                        |    <Contents>
+                        |        <Key>my-image.jpg</Key>
+                        |        <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                        |        <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                        |        <Size>434234</Size>
+                        |        <StorageClass>STANDARD</StorageClass>
+                        |    </Contents>
+                        |</ListBucketResult>""".stripMargin
+
+      var resultsCollector:Seq[ListBucketResultContents] = Seq()
+      val xml = new XMLEventReader(Source.fromString(sampleDoc))
+      val test = new S3XMLProcessor()
+
+      val mockCB = mock[Function1[Either[S3Error, ListBucketResultContents],Unit]]
+      val result = test.parseDoc(xml)(mockCB)
+
+      val expectedResult = ListBucketResultContents(
+                  "bucket",
+                  "my-image.jpg",
+                  "fba9dede5f27731c9771645a39863328",
+                  434234L,
+                  Instant.parse("2009-10-12T17:50:30.000Z"),
+                  "STANDARD"
+                )
+
+      verify(mockCB, times(1)).apply(Right(expectedResult))
+      1 mustEqual 1
+    }
+  }
+}


### PR DESCRIPTION
Any byte character is valid in s3 key names, but not in the XML results that come back.... this trips up the Alpakka client.

This PR adds a new Akka Source that makes manual requests to the S3 REST interface, appropriately signed, to get back XML listings *with url-encoded keys* that seem to work.  A second Akka flow converts this listing into a stream of ListBucketContentsResult objects which can then be passed through the same stream elements as for the usual flow.

There are also a couple of improvements to the UI, separating filename and path and pretty-formatting the file size in the Entry Details sidebar.