### PR TITLE
Per-item proxying via Elastic Transcoder

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -14,6 +14,8 @@ class Module extends AbstractModule with AkkaGuiceSupport {
     bindActor[LegacyProxiesScanner]("legacyProxiesScannerActor")
     bindActor[BulkThumbnailer]("bulkThumbnailerActor")
     bindActor[DynamoCapacityActor]("dynamoCapacityActor")
+    bindActor[ETSProxyActor]("etsProxyActor")
+
     bind(classOf[AppStartup]).asEagerSingleton() //do app startup
   }
 }

--- a/app/controllers/ProxiesController.scala
+++ b/app/controllers/ProxiesController.scala
@@ -213,9 +213,8 @@ class ProxiesController @Inject()(config:Configuration, cc:ControllerComponents,
     implicit val indexer = new Indexer(indexName)
     implicit val client = esClientMgr.getClient()
     try {
-      val pt = ProxyType.withName(typeStr)
+      val pt = ProxyType.withName(typeStr.toUpperCase)
       indexer.getById(fileId).map(entry=>{
-        //FIXME: hardcoded proxy type
         etsProxyActor ! ETSProxyActor.CreateMediaProxy(entry, pt)
         Ok(GenericErrorResponse("ok","proxying started").asJson)
       }).recoverWith({

--- a/app/helpers/CreateProxySink.scala
+++ b/app/helpers/CreateProxySink.scala
@@ -3,7 +3,7 @@ package helpers
 import akka.stream.{Attributes, Inlet, SinkShape}
 import akka.stream.stage.{AbstractInHandler, GraphStage, GraphStageLogic}
 import com.theguardian.multimedia.archivehunter.common.ArchiveEntry
-import com.theguardian.multimedia.archivehunter.common.services.ProxyGenerators
+import com.theguardian.multimedia.archivehunter.common.cmn_services.ProxyGenerators
 import javax.inject.Inject
 import play.api.Logger
 

--- a/app/models/TranscoderMessage.scala
+++ b/app/models/TranscoderMessage.scala
@@ -1,0 +1,54 @@
+package models
+import com.amazonaws.services.elastictranscoder.model.JobOutput
+import io.circe._
+import io.circe.parser
+import io.circe.generic.auto._
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder}
+
+/*
+  * Data models for expected JSON messages from Elastic Transcoder
+  */
+
+trait ExpectedMessages {}
+
+object TranscoderState extends Enumeration {
+  val PROGRESSING, COMPLETED, WARNING, ERROR = Value
+}
+
+trait TranscoderMessageDecoder {
+  implicit val transcoderStateEncoder = Encoder.enumEncoder(TranscoderState)
+  implicit val transcoderStateDecoder = Decoder.enumDecoder(TranscoderState)
+}
+
+case class ETSOutput(id:String, presetId:String, status:String,duration:Option[Long],fileSize:Option[Long],width:Option[Int],height:Option[Int],key:String)
+
+// Amazon Elastic Transcoding message structure
+case class AwsElasticTranscodeMsg ( state: TranscoderState.Value,
+                                    jobId: String,
+                                    pipelineId: String,
+                                    outputKeyPrefix:Option[String],
+                                    errorCode: Option[Int],
+                                    messageDetails: Option[String],
+                                    userMetadata:Option[Map[String,String]],
+                                    outputs:Option[Seq[ETSOutput]]) extends ExpectedMessages
+
+// Amazon Simple Queueing Service (SQS) message structure
+case class AwsSqsMsg (
+                       Type: String,
+                       MessageId: String,
+                       TopicArn: String,
+                       Subject: String,
+                       Message: String,
+                       Timestamp: String,
+                     )
+ extends TranscoderMessageDecoder {
+  def getETSMessage: Either[io.circe.Error, AwsElasticTranscodeMsg] =
+    io.circe.parser.parse(Message).flatMap(_.as[AwsElasticTranscodeMsg])
+}
+
+object AwsSqsMsg extends TranscoderMessageDecoder {
+  def fromJsonString(str:String):Either[io.circe.Error, AwsSqsMsg] = {
+    io.circe.parser.parse(str).flatMap(_.as[AwsSqsMsg])
+  }
+}

--- a/app/services/AppStartup.scala
+++ b/app/services/AppStartup.scala
@@ -1,16 +1,18 @@
 package services
 
-import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props}
 import akka.cluster.singleton.{ClusterSingletonManager, ClusterSingletonManagerSettings, ClusterSingletonProxy, ClusterSingletonProxySettings}
 import akka.management.AkkaManagement
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import javax.inject.{Inject, Named}
+import play.api.inject.Injector
 import play.api.{Configuration, Logger}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-class AppStartup @Inject() (@Named("bucketScannerActor") bucketScanner:ActorRef, actorSystem:ActorSystem, config:Configuration)(implicit system:ActorSystem){
+class AppStartup @Inject()(@Named("bucketScannerActor") bucketScanner:ActorRef, actorSystem:ActorSystem,
+                            config:Configuration, injector:Injector)(implicit system:ActorSystem){
   private val logger = Logger(getClass)
 
   implicit val ec:ExecutionContext = system.dispatcher
@@ -19,4 +21,13 @@ class AppStartup @Inject() (@Named("bucketScannerActor") bucketScanner:ActorRef,
 
   AkkaManagement(system).start()
   ClusterBootstrap(system).start()
+
+  logger.info("Starting up master timer")
+
+  system.actorOf(ClusterSingletonManager.props(
+    singletonProps = Props(injector.instanceOf(classOf[ClockSingleton])),
+    terminationMessage = PoisonPill,
+    settings = ClusterSingletonManagerSettings(system)
+  ), name="ClockSingleton"
+  )
 }

--- a/app/services/BucketScanner.scala
+++ b/app/services/BucketScanner.scala
@@ -41,7 +41,7 @@ object BucketScanner {
 
 class BucketScanner @Inject()(config:Configuration, ddbClientMgr:DynamoClientManager, s3ClientMgr:S3ClientManager,
                               esClientMgr:ESClientManager, scanTargetDAO: ScanTargetDAO, injector:Injector)(implicit system:ActorSystem)
-  extends Actor with Timers with ZonedTimeFormat with ArchiveEntryRequestBuilder{
+  extends Actor with ZonedTimeFormat with ArchiveEntryRequestBuilder{
   import BucketScanner._
 
   import com.sksamuel.elastic4s.http.ElasticDsl._
@@ -55,9 +55,6 @@ class BucketScanner @Inject()(config:Configuration, ddbClientMgr:DynamoClientMan
   val table = Table[ScanTarget](config.get[String]("externalData.scanTargets"))
 
   override val indexName: String = config.get[String]("externalData.indexName")
-
-  //actor-local timer - https://doc.akka.io/docs/akka/2.5/actors.html#actors-timers
-  timers.startPeriodicTimer(TickKey, RegularScanTrigger, Duration(config.get[Long]("scanner.masterSchedule"),SECONDS))
 
   def listScanTargets() = {
     val alpakkaClient = ddbClientMgr.getNewAlpakkaDynamoClient(config.getOptional[String]("externalData.awsProfile"))

--- a/app/services/ClockSingleton.scala
+++ b/app/services/ClockSingleton.scala
@@ -1,0 +1,50 @@
+package services
+
+import akka.actor.{Actor, ActorRef, Timers}
+import com.theguardian.multimedia.archivehunter.common.{ArchiveHunterConfiguration, ExtValueConverters}
+import javax.inject.{Inject, Named}
+import play.api.Logger
+import services.BucketScanner.{RegularScanTrigger, TickKey}
+import services.ClockSingleton.RapidClockTick
+import services.DynamoCapacityActor.TimedStateCheck
+
+import scala.concurrent.duration._
+
+object ClockSingleton {
+  trait CSMsg
+
+  case object RapidClockTick
+  case object SlowClockTick
+  case object ScanTick
+
+}
+
+/**
+  * this actor implements a simple "clock" that sends periodic updates to other actors that need to run timed operations.
+  * the idea of isolating the timers in this way is to ensure that there is only one actor in the cluster sending timing pulses,
+  * but the actors doing the work can fan-out and run in parallel.
+  */
+class ClockSingleton @Inject() (@Named("dynamoCapacityActor") dynamoCapacityActor:ActorRef,
+                                @Named("etsProxyActor") etsProxyActor:ActorRef,
+                                @Named("bucketScannerActor") bucketScanner:ActorRef,
+                                config:ArchiveHunterConfiguration,
+                               ) extends Actor with Timers with ExtValueConverters{
+  import ClockSingleton._
+  private val logger=Logger(getClass)
+
+  timers.startPeriodicTimer(RapidClockTick, RapidClockTick, 10.seconds)
+  timers.startPeriodicTimer(SlowClockTick, SlowClockTick, 1.minutes)
+  timers.startPeriodicTimer(ScanTick, ScanTick, Duration(config.get[Long]("scanner.masterSchedule"),SECONDS))
+
+  override def receive: Receive = {
+    case RapidClockTick=>
+      logger.debug("ClockSingleton: RapidClockTick")
+      dynamoCapacityActor ! DynamoCapacityActor.TimedStateCheck
+    case SlowClockTick=>
+      logger.debug("ClockSingleton: SlowClockTick")
+      etsProxyActor ! ETSProxyActor.CheckPipelinesStatus
+    case ScanTick=>
+      logger.debug("ClockSingleton: ScanTick")
+      bucketScanner ! BucketScanner.RegularScanTrigger
+  }
+}

--- a/app/services/ClockSingleton.scala
+++ b/app/services/ClockSingleton.scala
@@ -40,6 +40,7 @@ class ClockSingleton @Inject() (@Named("dynamoCapacityActor") dynamoCapacityActo
     case RapidClockTick=>
       logger.debug("ClockSingleton: RapidClockTick")
       dynamoCapacityActor ! DynamoCapacityActor.TimedStateCheck
+      etsProxyActor ! ETSProxyActor.CheckForNotifications
     case SlowClockTick=>
       logger.debug("ClockSingleton: SlowClockTick")
       etsProxyActor ! ETSProxyActor.CheckPipelinesStatus

--- a/app/services/DynamoCapacityActor.scala
+++ b/app/services/DynamoCapacityActor.scala
@@ -70,15 +70,13 @@ object DynamoCapacityActor {
   case class TestCheckListResponse(entries:Seq[DCAMsg])
 }
 
-class DynamoCapacityActor @Inject() (ddbClientMgr:DynamoClientManager, config:ArchiveHunterConfiguration) extends Actor with Timers {
+class DynamoCapacityActor @Inject() (ddbClientMgr:DynamoClientManager, config:ArchiveHunterConfiguration) extends Actor {
   import DynamoCapacityActor._
   private val logger = Logger(getClass)
 
   private var checkList:Seq[DCAMsg] = Seq()
   private val awsProfile = config.getOptional[String]("externalData.awsProfile")
   private val ddbClient = ddbClientMgr.getClient(awsProfile)
-
-  timers.startPeriodicTimer(TimedStateCheck, TimedStateCheck, 10.seconds)
 
   /**
     * converts an [[UpdateCapacityIndex]] request into a DynamoDB [[GlobalSecondaryIndexUpdate]] request.

--- a/app/services/ETSProxyActor.scala
+++ b/app/services/ETSProxyActor.scala
@@ -4,16 +4,20 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 import akka.actor.{Actor, ActorSystem}
-import com.amazonaws.services.elastictranscoder.model.Pipeline
-import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ETSClientManager}
+import akka.stream.{ActorMaterializer, Materializer}
+import com.amazonaws.services.elastictranscoder.model.{CreateJobOutput, CreateJobRequest, JobInput, Pipeline}
+import com.amazonaws.services.sqs.model.{DeleteMessageRequest, ReceiveMessageRequest}
+import com.theguardian.multimedia.archivehunter.common.clientManagers._
 import com.theguardian.multimedia.archivehunter.common.cmn_models._
 import com.theguardian.multimedia.archivehunter.common.errors.NothingFoundError
-import com.theguardian.multimedia.archivehunter.common.services.ProxyGenerators
-import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ArchiveHunterConfiguration, ProxyLocationDAO}
+import com.theguardian.multimedia.archivehunter.common.cmn_services.ProxyGenerators
+import com.theguardian.multimedia.archivehunter.common._
 import javax.inject.Inject
+import models.{AwsSqsMsg, TranscoderState}
 import org.apache.logging.log4j.LogManager
 import play.api.Logger
 
+import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -24,7 +28,7 @@ object ETSProxyActor {
     * public message to start proxy creation process
     * @param entry archive entry to proxy
     */
-  case class CreateMediaProxy(entry:ArchiveEntry) extends ETSMsg
+  case class CreateMediaProxy(entry:ArchiveEntry, proxyType: ProxyType.Value) extends ETSMsg
 
   /**
     * public message reply if something went wrong
@@ -32,56 +36,193 @@ object ETSProxyActor {
     */
   case class PreparationFailure(err:Throwable) extends  ETSMsg
 
+  /* --- Private messages --- */
   /**
     * private message dispatched when a pipeline is ready
     * @param entry
     * @param pipeline
     */
-  case class GotTranscodePipeline(entry:ArchiveEntry, jobDesc:JobModel, pipelineId:String) extends ETSMsg
+  case class GotTranscodePipeline(entry:ArchiveEntry, targetProxyBucket:String, jobDesc:JobModel, pipelineId:String, proxyType: ProxyType.Value) extends ETSMsg
 
   /**
     * private message dispatched when we need to find a pipeline
     * @param entry
     */
-  case class GetTranscodePipeline(entry:ArchiveEntry, targetProxyBucket:String, jobDesc:JobModel) extends ETSMsg
+  case class GetTranscodePipeline(entry:ArchiveEntry, targetProxyBucket:String, jobDesc:JobModel, proxyType: ProxyType.Value) extends ETSMsg
+
+  /**
+    * private messages dispatched when we get status updates from ETS
+    */
+  case class TranscodeFailed(jobDesc:JobModel, errorCode: Option[Int], message:String) extends ETSMsg
+  case class TranscodeProgress(jobDesc:JobModel) extends ETSMsg
+  case class TranscodeWarning(jobDesc:JobModel, errorCode:Option[Int], message:String) extends ETSMsg
+  case class TranscodeSuccess(jobDesc:JobModel, transcodeUrl:String) extends ETSMsg
+
+  /* --- Internal timer messages --- */
   /**
     * private message dispatched from a timer to check waiting pipelines
     */
   case object CheckPipelinesStatus extends ETSMsg
 
-  case class WaitingOperation(entry:ArchiveEntry, jobDesc:JobModel, pipelineId:String)
+  /**
+    * private message dispatched from a timer to check for any waiting messages on the queue
+    */
+  case object CheckForNotifications extends ETSMsg
+
+  /* --- State objects ---*/
+  /**
+    * state object that describes something we are waiting for
+    * @param entry
+    * @param jobDesc
+    * @param pipelineId
+    */
+  case class WaitingOperation(entry:ArchiveEntry, jobDesc:JobModel, pipelineId:String, targetProxyBucket:String,proxyType:ProxyType.Value)
 }
 
-class ETSProxyActor @Inject() (implicit config:ArchiveHunterConfiguration, etsClientMgr: ETSClientManager, scanTargetDAO: ScanTargetDAO, jobModelDAO: JobModelDAO,
+/**
+  * handle proxying via Elastic Transcoder.  The program flow is as follows:
+  *
+  * (client) -> CreateMediaProxy -> GetTranscodePipeline     ------------------------------------> GotTranscodePipeline -> [start transcodeJob, save JobDesc]
+  *                                          |                                                             |
+  *                                          \--> [create pipeline, save record for timed poll]            |
+  *                                                                   |                                    |
+  * (timer singleton) -> CheckPipelinesStatus -------------------------------------------------------------/
+  *
+  * (timer singleton) -> CheckForNotifications -> [pull messages from SQS] -> Transcode{Failed,Progress,Warning,Success} -> [update records]
+  *
+  * @param config implicitly provided [[ArchiveHunterConfiguration]]
+  * @param sqsClientMgr implicitly provided [[SQSClientManager]]
+  * @param etsClientMgr implicitly provided [[ETSClientManager]]
+  * @param s3ClientMgr implicitly provided [[S3ClientManager]]
+  * @param esClientMgr implicitly provided [[ESClientManager]]
+  * @param scanTargetDAO implicitly provided [[ScanTargetDAO]]
+  * @param jobModelDAO implicitly provided [[JobModelDAO]]
+  * @param ddbClientMgr implicitly provided [[DynamoClientManager]]
+  * @param actorSystem implicitly provided ActorSystem
+  */
+class ETSProxyActor @Inject() (implicit config:ArchiveHunterConfiguration,
+                               sqsClientMgr:SQSClientManager, etsClientMgr: ETSClientManager, s3ClientMgr:S3ClientManager, esClientMgr:ESClientManager,
+                               scanTargetDAO: ScanTargetDAO, jobModelDAO: JobModelDAO,
                             ddbClientMgr:DynamoClientManager, actorSystem: ActorSystem) extends Actor{
   import ETSProxyActor._
 
   implicit val ec:ExecutionContext = actorSystem.dispatcher
+  implicit val mat:Materializer = ActorMaterializer.create(actorSystem)
+
   val awsProfile = config.getOptional[String]("externalData.awsProfile")
   private implicit val etsClient = etsClientMgr.getClient(awsProfile)
   private implicit val ddbClient= ddbClientMgr.getClient(awsProfile)
+  private implicit val alpakkaDDBClient = ddbClientMgr.getNewAlpakkaDynamoClient(awsProfile)
   private implicit val logger = LogManager.getLogger(getClass)
+  private implicit val esClient = esClientMgr.getClient()
+  private implicit val s3Client = s3ClientMgr.getClient(awsProfile)
 
+  private val sqsClient = sqsClientMgr.getClient(awsProfile)
+  private val indexer = new Indexer(config.get[String]("externalData.indexName"))
   var pipelinesToCheck:Seq[WaitingOperation] = Seq()
 
   implicit val proxyLocationDAO = new ProxyLocationDAO(config.get[String]("proxies.tableName"))
 
+  /**
+    * recursively check the pipelinesToCheck list, removing from the list any that have become ready
+    * @param moreToCheck
+    * @param notReady
+    * @return
+    */
   protected def checkNextPipeline(moreToCheck:Seq[WaitingOperation], notReady:Seq[WaitingOperation]=Seq()):Seq[WaitingOperation] = {
     if(moreToCheck.isEmpty) return notReady
     val checking = moreToCheck.head
     val pipelineId = checking.pipelineId
     ProxyGenerators.getPipelineStatus(pipelineId) match {
       case Success(status)=>
-        logger.info(s"Status for ${moreToCheck.head} is $status")
-        if(status=="READY") { //FIXME: check this value
-          logger.info(s"Status is READY, informing actor")
-          self ! GotTranscodePipeline(checking.entry, checking.jobDesc, pipelineId)
-          checkNextPipeline(moreToCheck.tail, notReady)
+        logger.info(s"Status for $pipelineId is $status")
+        if(status.toLowerCase()=="active") { //FIXME: check this value
+          logger.info(s"Status is ACTIVE, informing actor")
+          self ! GotTranscodePipeline(checking.entry, checking.targetProxyBucket, checking.jobDesc, pipelineId, checking.proxyType)
+          checkNextPipeline(moreToCheck.tail,notReady)
         } else {
-          logger.info("Status is not READY, continuing")
-          checkNextPipeline(moreToCheck.tail, notReady ++ Seq(moreToCheck.head))
+          logger.info("Status is not ACTIVE, continuing")
+          checkNextPipeline(moreToCheck.tail,notReady ++ Seq(moreToCheck.head))
         }
     }
+  }
+
+
+  protected def randomAlphaNumericString(length: Int): String = {
+    val chars = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
+    randomStringFromCharList(length, chars)
+  }
+
+  protected def randomStringFromCharList(length: Int, chars: Seq[Char]): String = {
+    val sb = new StringBuilder
+    for (i <- 1 to length) {
+      val randomNum = util.Random.nextInt(chars.length)
+      sb.append(chars(randomNum))
+    }
+    sb.toString
+  }
+
+  def handleNextSqsMessage(rq:ReceiveMessageRequest, notificationsQueue:String):Boolean = {
+    val result = sqsClient.receiveMessage(rq)
+    val msgList = result.getMessages.asScala
+    if(msgList.isEmpty) return false
+
+    msgList.foreach(msg=>{
+      logger.debug(s"Received message ${msg.getMessageId}:")
+      logger.debug(s"\tAttributes: ${msg.getAttributes.asScala}")
+      logger.debug(s"\tReceipt Handle: ${msg.getReceiptHandle}")
+      logger.debug(s"\tBody: ${msg.getBody}")
+      AwsSqsMsg.fromJsonString(msg.getBody) match {
+        case Left(err)=>
+          logger.error(s"Could not parse message: ${err.toString}")
+        case Right(content)=>
+          content.getETSMessage match {
+            case Left(err)=>
+              logger.error(s"Could not parse inner ETS message: ${err.toString}")
+            case Right(etsMessage)=>
+              logger.info(s"Got parsed update message: $etsMessage")
+              etsMessage.userMetadata match {
+                case None=>
+                  logger.error("Can't process message with no user metadata! Need the internal Job ID")
+                case Some(md)=>
+                  md.get("archivehunter-job-id") match {
+                    case Some(jobId)=>
+                      jobModelDAO.jobForId(jobId).map({
+                        case None=>
+                          logger.error(s"Received message for non-existent job ID $jobId")
+                        case Some(Left(err))=>
+                          logger.error(s"Could not retrieve information for job ID $jobId: ${err.toString}")
+                        case Some(Right(jobDesc))=>
+                          etsMessage.state match {
+                            case TranscoderState.ERROR=>
+                              self ! TranscodeFailed(jobDesc,etsMessage.errorCode,etsMessage.messageDetails.getOrElse("not provided"))
+                            case TranscoderState.PROGRESSING=>
+                              self ! TranscodeProgress(jobDesc)
+                            case TranscoderState.COMPLETED=>
+                              val transcodePath = etsMessage.outputs.flatMap(_.headOption.map(_.key))
+                              logger.debug(s"transcodePath is $transcodePath")
+                              val transcodeUrl = jobDesc.transcodeInfo.flatMap(tcInfo=>
+                                transcodePath.map(tcPath=>s"s3://${tcInfo.destinationBucket}/$tcPath"))
+
+                              transcodeUrl match{
+                                case None=>
+                                  logger.error("Job completed but with no transcode URL? this must be a bug")
+                                case Some(actualTranscodeUrl)=>
+                                  self ! TranscodeSuccess(jobDesc, actualTranscodeUrl)
+                              }
+                            case TranscoderState.WARNING=>
+                              self ! TranscodeWarning(jobDesc, etsMessage.errorCode, etsMessage.messageDetails.getOrElse("not provided"))
+                          }
+                      })
+                    case None=>
+                      logger.error("Job message had user metadata but no archivehunter-job-id, can't process it.")
+                  }
+              }
+              sqsClient.deleteMessage(new DeleteMessageRequest().withQueueUrl(notificationsQueue).withReceiptHandle(msg.getReceiptHandle))
+          }
+      }
+    })
+    true
   }
 
   override def receive:Receive = {
@@ -89,17 +230,78 @@ class ETSProxyActor @Inject() (implicit config:ArchiveHunterConfiguration, etsCl
       * timed message, check on the operations we have waiting and trigger any that are ready.
       */
     case CheckPipelinesStatus=>
-      logger.debug(s"CheckPipelinesStatus: ${pipelinesToCheck.length}")
       if(pipelinesToCheck.nonEmpty){
         logger.info(s"Checking status on ${pipelinesToCheck.length} creating pipelines...")
         pipelinesToCheck = checkNextPipeline(pipelinesToCheck)
         logger.info(s"Check complete, now ${pipelinesToCheck.length} pipelines waiting")
       }
 
+    /** timed message, check for messages in the message queue and process them.
+      *
+      */
+    case CheckForNotifications=>
+      logger.debug("CheckForNotifications")
+      val notificationsQueue=config.get[String]("proxies.notificationsQueue")
+      val rq = new ReceiveMessageRequest().withQueueUrl(notificationsQueue)
+      var moreMessages=true
+      do {
+        moreMessages = handleNextSqsMessage(rq, notificationsQueue)
+      } while(moreMessages)
+    /**
+      * private message, sent when we get an error notification from the queue
+      */
+    case TranscodeFailed(jobDesc, errorCode, message)=>
+      logger.error(s"Transcode for job ${jobDesc.jobId} (${jobDesc.transcodeInfo.map(_.transcodeId)}) failed with error $message, logging")
+      val updatedJob = jobDesc.copy(jobStatus = JobStatus.ST_ERROR,log = Some(message),completedAt = Some(ZonedDateTime.now()))
+      jobModelDAO.putJob(updatedJob)
+
+    case TranscodeProgress(jobDesc)=>
+      logger.info(s"Transcode for job ${jobDesc.jobId} (${jobDesc.transcodeInfo.map(_.transcodeId)}) is progressing")
+      if(jobDesc.jobStatus!=JobStatus.ST_RUNNING){
+        val updatedJob = jobDesc.copy(jobStatus = JobStatus.ST_RUNNING)
+        jobModelDAO.putJob(updatedJob)
+      }
+
+    case TranscodeWarning(jobDesc, maybeErrorCode, message)=>
+      logger.warn(s"Transcode for job ${jobDesc.jobId} (${jobDesc.transcodeInfo.map(_.transcodeId)}) gave a warning: $message")
+      val updatedLog = jobDesc.log match {
+        case None=>message
+        case Some(existingMessage)=>existingMessage + "\n" + message
+      }
+      val updatedJob=jobDesc.copy(log=Some(updatedLog))
+      jobModelDAO.putJob(updatedJob)
+
+    case TranscodeSuccess(jobDesc, transcodeUrl)=>
+      jobDesc.transcodeInfo match {
+        case None =>
+          logger.error("job indicated as reported success has no transcode info! Can't register the success.")
+        case Some(transcodeInfo: TranscodeInfo) =>
+          logger.info(s"Transcode for job ${jobDesc.jobId} (${transcodeInfo.transcodeId}) reported success")
+          val updatedJob = jobDesc.copy(jobStatus = JobStatus.ST_SUCCESS, completedAt = Some(ZonedDateTime.now()))
+          val jobModelUpdateFuture = jobModelDAO.putJob(updatedJob)
+          val indexUpdateFuture = indexer.getById(jobDesc.sourceId).flatMap(entry=>indexer.indexSingleItem(entry.copy(proxied = true)))
+          //FIXME: hard-coding video type
+          val proxyLocationUpdateFuture = ProxyLocation.newInS3(transcodeUrl,jobDesc.sourceId,transcodeInfo.proxyType) match {
+            case Failure(err)=>
+              logger.error(s"Could not update proxy ref for $transcodeUrl (${transcodeInfo.proxyType}): ", err)
+              Future.failed(err)
+            case Success(proxyLocation)=>
+              proxyLocationDAO.saveProxy(proxyLocation)
+          }
+
+          Future.sequence(Seq(jobModelUpdateFuture, indexUpdateFuture, proxyLocationUpdateFuture)).onComplete({
+            case Success(results)=>
+              logger.info("Completed updating proxy data")
+            case Failure(err)=>
+              logger.error("Unable to update proxy records after completed transcode", err)
+          })
+      }
+
+
     /** private message, find an appropriate pipeline for the parameters and trigger immediately if so;
       * otherwise start the pipeline creation process and check it regularly
       */
-    case GetTranscodePipeline(entry:ArchiveEntry, targetProxyBucket:String, jobDesc:JobModel)=>
+    case GetTranscodePipeline(entry:ArchiveEntry, targetProxyBucket:String, jobDesc:JobModel, proxyType)=>
       logger.info(s"Looking for pipeline for $entry")
       ProxyGenerators.findPipelineFor(entry.bucket, targetProxyBucket) match {
         case Failure(err)=>
@@ -107,22 +309,43 @@ class ETSProxyActor @Inject() (implicit config:ArchiveHunterConfiguration, etsCl
           sender() ! PreparationFailure(err)
         case Success(pipelines)=>
           if(pipelines.isEmpty){  //nothing present, so we must create a pipeline.
-            val newPipelineName = s"archivehunter_${entry.bucket}_$targetProxyBucket"
+            val newPipelineName = s"archivehunter_${randomAlphaNumericString(10)}"
             ProxyGenerators.createEtsPipeline(newPipelineName, entry.bucket, targetProxyBucket) match {
               case Success(pipeline)=>
                 logger.info(s"Initiated creation of $newPipelineName, starting status check")
-                pipelinesToCheck = pipelinesToCheck ++ Seq(WaitingOperation(entry, jobDesc, pipeline.getId))
+                pipelinesToCheck = pipelinesToCheck ++ Seq(WaitingOperation(entry, jobDesc, pipeline.getId, targetProxyBucket, proxyType))
               case Failure(err)=>
                 logger.error(s"Could not create new pipeline for $newPipelineName", err)
                 sender() ! PreparationFailure(err)
             }
           } else {
             logger.info(s"Found ${pipelines.length} potential pipelines for ${entry.bucket} -> $targetProxyBucket, using the first")
-            self ! GotTranscodePipeline(entry, jobDesc, pipelines.head.getId)
+            self ! GotTranscodePipeline(entry, targetProxyBucket, jobDesc, pipelines.head.getId, proxyType)
           }
       }
 
-    case CreateMediaProxy(entry)=>
+    case GotTranscodePipeline(entry:ArchiveEntry, targetProxyBucket:String, jobDesc:JobModel, pipelineId: String, proxyType)=>
+      logger.info(s"Got transcode pipeline $pipelineId for $jobDesc")
+      val rq = new CreateJobRequest()
+        .withInput(new JobInput().withKey(entry.path))
+        //FIXME: hardcoded video option
+          .withOutput(new CreateJobOutput().withKey(entry.path).withPresetId(config.get[String]("proxies.videoPresetId")))
+          .withPipelineId(pipelineId)
+          .withUserMetadata(Map("archivehunter-job-id"->jobDesc.jobId, "archivehunter-source-id"->entry.id).asJava)
+
+      try {
+        val result = etsClient.createJob(rq)
+        val destinationUrl = s"s3://${}"
+        val updatedJobDesc = jobDesc.copy(transcodeInfo = Some(TranscodeInfo(transcodeId=result.getJob.getId,destinationBucket = targetProxyBucket,proxyType=proxyType)))
+        jobModelDAO.putJob(updatedJobDesc)
+        //we stop tracking the job here; rely on data coming back via the message queue to inform us what is happening
+        logger.info(s"Started transcode for ${entry.path} with ID ${result.getJob.getId}")
+      } catch {
+        case ex:Throwable=>
+          logger.error("Could not create proxy job: ", ex)
+      }
+
+    case CreateMediaProxy(entry, proxyType)=>
       val callbackUrl=config.get[String]("proxies.appServerUrl")
       logger.info(s"callbackUrl is $callbackUrl")
       val jobUuid = UUID.randomUUID()
@@ -143,7 +366,7 @@ class ETSProxyActor @Inject() (implicit config:ArchiveHunterConfiguration, etsCl
             logger.error("Nothing found to proxy")
             Future(Failure(NothingFoundError("media", "Nothing found to proxy")))
           case Some(uriToProxy)=>
-            val jobDesc = JobModel(UUID.randomUUID().toString,"proxy",Some(ZonedDateTime.now()),None,JobStatus.ST_PENDING,None,entry.id,SourceType.SRC_MEDIA)
+            val jobDesc = JobModel(UUID.randomUUID().toString,"proxy",Some(ZonedDateTime.now()),None,JobStatus.ST_PENDING,None,entry.id,None,SourceType.SRC_MEDIA)
 
             jobModelDAO.putJob(jobDesc).map({
               case Some(Left(dynamoError))=>
@@ -159,7 +382,7 @@ class ETSProxyActor @Inject() (implicit config:ArchiveHunterConfiguration, etsCl
       val originalSender = sender()
       preparationFuture.map({
         case Success((jobDesc, targetProxyBucket))=>
-          self ! ETSProxyActor.GetTranscodePipeline(entry, targetProxyBucket, jobDesc)
+          self ! ETSProxyActor.GetTranscodePipeline(entry, targetProxyBucket, jobDesc, proxyType)
         case Failure(err)=>
           logger.error("Could not prepare for transcode: ", err)
           sender ! PreparationFailure(err)

--- a/app/services/ETSProxyActor.scala
+++ b/app/services/ETSProxyActor.scala
@@ -1,0 +1,165 @@
+package services
+
+import java.time.ZonedDateTime
+import java.util.UUID
+
+import akka.actor.{Actor, ActorSystem}
+import com.amazonaws.services.elastictranscoder.model.Pipeline
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ETSClientManager}
+import com.theguardian.multimedia.archivehunter.common.cmn_models._
+import com.theguardian.multimedia.archivehunter.common.errors.NothingFoundError
+import com.theguardian.multimedia.archivehunter.common.services.ProxyGenerators
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ArchiveHunterConfiguration, ProxyLocationDAO}
+import javax.inject.Inject
+import org.apache.logging.log4j.LogManager
+import play.api.Logger
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+object ETSProxyActor {
+  trait ETSMsg
+
+  /**
+    * public message to start proxy creation process
+    * @param entry archive entry to proxy
+    */
+  case class CreateMediaProxy(entry:ArchiveEntry) extends ETSMsg
+
+  /**
+    * public message reply if something went wrong
+    * @param err
+    */
+  case class PreparationFailure(err:Throwable) extends  ETSMsg
+
+  /**
+    * private message dispatched when a pipeline is ready
+    * @param entry
+    * @param pipeline
+    */
+  case class GotTranscodePipeline(entry:ArchiveEntry, jobDesc:JobModel, pipelineId:String) extends ETSMsg
+
+  /**
+    * private message dispatched when we need to find a pipeline
+    * @param entry
+    */
+  case class GetTranscodePipeline(entry:ArchiveEntry, scanTarget: ScanTarget, jobDesc:JobModel) extends ETSMsg
+  /**
+    * private message dispatched from a timer to check waiting pipelines
+    */
+  case class CheckPipelinesStatus() extends ETSMsg
+
+  case class WaitingOperation(entry:ArchiveEntry, jobDesc:JobModel, pipelineId:String)
+}
+
+class ETSProxyActor @Inject() (implicit config:ArchiveHunterConfiguration, etsClientMgr: ETSClientManager, scanTargetDAO: ScanTargetDAO, jobModelDAO: JobModelDAO,
+     proxyLocationDAO: ProxyLocationDAO, ddbClientMgr:DynamoClientManager, actorSystem: ActorSystem) extends Actor{
+  import ETSProxyActor._
+
+  implicit val ec:ExecutionContext = actorSystem.dispatcher
+  val awsProfile = config.getOptional[String]("externalData.awsProfile")
+  private implicit val etsClient = etsClientMgr.getClient(awsProfile)
+  private implicit val ddbClient= ddbClientMgr.getClient(awsProfile)
+  private implicit val logger = LogManager.getLogger(getClass)
+
+  var pipelinesToCheck:Seq[WaitingOperation] = Seq()
+
+  protected def checkNextPipeline(moreToCheck:Seq[WaitingOperation], notReady:Seq[WaitingOperation]=Seq()):Seq[WaitingOperation] = {
+    if(moreToCheck.isEmpty) return notReady
+    val checking = moreToCheck.head
+    val pipelineId = checking.pipelineId
+    ProxyGenerators.getPipelineStatus(pipelineId) match {
+      case Success(status)=>
+        logger.info(s"Status for ${moreToCheck.head} is $status")
+        if(status=="READY") { //FIXME: check this value
+          logger.info(s"Status is READY, informing actor")
+          self ! GotTranscodePipeline(checking.entry, checking.jobDesc, pipelineId)
+          checkNextPipeline(moreToCheck.tail, notReady)
+        } else {
+          logger.info("Status is not READY, continuing")
+          checkNextPipeline(moreToCheck.tail, notReady ++ Seq(moreToCheck.head))
+        }
+    }
+  }
+
+  override def receive:Receive = {
+    /**
+      * timed message, check on the operations we have waiting and trigger any that are ready.
+      */
+    case CheckPipelinesStatus()=>
+      if(pipelinesToCheck.nonEmpty){
+        logger.info(s"Checking status on ${pipelinesToCheck.length} creating pipelines...")
+        pipelinesToCheck = checkNextPipeline(pipelinesToCheck)
+        logger.info(s"Check complete, now ${pipelinesToCheck.length} pipelines waiting")
+      }
+
+    /** private message, find an appropriate pipeline for the parameters and trigger immediately if so;
+      * otherwise start the pipeline creation process and check it regularly
+      */
+    case GetTranscodePipeline(entry:ArchiveEntry, scanTarget:ScanTarget, jobDesc:JobModel)=>
+      logger.info(s"Looking for pipeline for $entry")
+      ProxyGenerators.findPipelineFor(entry.bucket, scanTarget.proxyBucket) match {
+        case Failure(err)=>
+          logger.error(s"Could not look up pipelines for $entry", err)
+          sender() ! PreparationFailure(err)
+        case Success(pipelines)=>
+          if(pipelines.isEmpty){  //nothing present, so we must create a pipeline.
+            val newPipelineName = s"archivehunter_${entry.bucket}_${scanTarget.proxyBucket}"
+            ProxyGenerators.createEtsPipeline(newPipelineName, entry.bucket, scanTarget.proxyBucket) match {
+              case Success(pipeline)=>
+                logger.info(s"Initiated creation of $newPipelineName, starting status check")
+                pipelinesToCheck = pipelinesToCheck ++ Seq(WaitingOperation(entry, jobDesc, pipeline.getId))
+              case Failure(err)=>
+                logger.error(s"Could not create new pipeline for $newPipelineName", err)
+                sender() ! PreparationFailure(err)
+            }
+          } else {
+            logger.info(s"Found ${pipelines.length} potential pipelines for ${entry.bucket} -> ${scanTarget.proxyBucket}, using the first")
+            self ! GotTranscodePipeline(entry, jobDesc, pipelines.head.getId)
+          }
+      }
+
+    case CreateMediaProxy(entry)=>
+      val callbackUrl=config.get[String]("proxies.appServerUrl")
+      logger.info(s"callbackUrl is $callbackUrl")
+      val jobUuid = UUID.randomUUID()
+
+      val targetProxyBucketFuture = scanTargetDAO.targetForBucket(entry.bucket).map({
+        case None=>throw new RuntimeException(s"Entry's source bucket ${entry.bucket} is not registered")
+        case Some(Left(err))=>throw new RuntimeException(err.toString)
+        case Some(Right(target))=>Some(target.proxyBucket)
+      })
+
+      val preparationFuture = Future.sequence(Seq(targetProxyBucketFuture, ProxyGenerators.getUriToProxy(entry))).flatMap(results=> {
+        val targetProxyBucket = results.head.get
+        val maybeUriToProxy = results(1)
+        logger.info(s"Target proxy bucket is $targetProxyBucket")
+        logger.info(s"Source media is $maybeUriToProxy")
+        maybeUriToProxy match {
+          case None=>
+            logger.error("Nothing found to proxy")
+            Future(Failure(NothingFoundError("media", "Nothing found to proxy")))
+          case Some(uriToProxy)=>
+            val jobDesc = JobModel(UUID.randomUUID().toString,"proxy",Some(ZonedDateTime.now()),None,JobStatus.ST_PENDING,None,entry.id,SourceType.SRC_MEDIA)
+
+            jobModelDAO.putJob(jobDesc).map({
+              case Some(Left(dynamoError))=>
+                logger.error(s"Could not save new job description: $dynamoError")
+                Failure(new RuntimeException(dynamoError.toString))
+              case _=>  //either None or Some(Right(thing)) indicate success
+
+                Success(jobDesc)
+            })
+        }
+      })
+
+      val originalSender = sender()
+      preparationFuture.map({
+        case Success(jobDesc)=>
+          self ! GetPipelineFor(entry, jobDesc)
+        case Failure(err)=>
+          logger.error("Could not prepare for transcode: ", err)
+          sender ! PreparationFailure(err)
+      })
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,8 @@ lazy val `archivehunter` = (project in file("."))
       "com.sksamuel.elastic4s" %% "elastic4s-embedded" % elastic4sVersion % "test",
       "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
       "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % "0.20.0",
+      "com.lightbend.akka.discovery" %% "akka-discovery-dns" % "0.20.0",
+      "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % "0.20.0",
       "com.lightbend.akka.discovery" %% "akka-discovery-aws-api" % "0.18.0",
       "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster-metrics" % akkaVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val commonSettings = Seq(
 scalaVersion := "2.12.2"
 
 val akkaVersion = "2.5.18"
+val akkaClusterVersion = "0.20.0"
 
 lazy val `archivehunter` = (project in file("."))
   .enablePlugins(PlayScala)
@@ -48,11 +49,11 @@ lazy val `archivehunter` = (project in file("."))
       "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test",
       "com.sksamuel.elastic4s" %% "elastic4s-embedded" % elastic4sVersion % "test",
       "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
-      "com.lightbend.akka" %% "akka-management-cluster-http" % "0.6",
-      "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % "0.20.0",
-      "com.lightbend.akka.discovery" %% "akka-discovery-dns" % "0.20.0",
-      "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % "0.20.0",
-      "com.lightbend.akka.discovery" %% "akka-discovery-aws-api" % "0.18.0",
+      "com.lightbend.akka.management" %% "akka-management-cluster-http" % akkaClusterVersion,
+      "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaClusterVersion,
+      "com.lightbend.akka.discovery" %% "akka-discovery-dns" % akkaClusterVersion,
+      "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % akkaClusterVersion,
+      "com.lightbend.akka.discovery" %% "akka-discovery-aws-api" % akkaClusterVersion,
       "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster-metrics" % akkaVersion,
       "com.typesafe.akka" %% "akka-actor" % akkaVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ lazy val commonSettings = Seq(
     "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0",
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-elastictranscoder"% awsSdkVersion,
+    "com.amazonaws" % "aws-java-sdk-sqs"% awsSdkVersion,
     "com.dripower" %% "play-circe" % "2610.0",
     "com.sksamuel.elastic4s" %% "elastic4s-http" % elastic4sVersion,
     "com.sksamuel.elastic4s" %% "elastic4s-circe" % elastic4sVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,7 @@ lazy val `archivehunter` = (project in file("."))
       "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test",
       "com.sksamuel.elastic4s" %% "elastic4s-embedded" % elastic4sVersion % "test",
       "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
+      "com.lightbend.akka" %% "akka-management-cluster-http" % "0.6",
       "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % "0.20.0",
       "com.lightbend.akka.discovery" %% "akka-discovery-dns" % "0.20.0",
       "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % "0.20.0",

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -458,6 +458,7 @@ Resources:
             - !Sub arn:aws:elastictranscoder:*:${AWS::AccountId}:pipeline/*
             - !Sub arn:aws:elastictranscoder:*:${AWS::AccountId}:job/*
             - !Sub arn:aws:elastictranscoder:*:${AWS::AccountId}:preset/${VideoTranscodingPresetId}
+            - !Sub arn:aws:elastictranscoder:*:${AWS::AccountId}:preset/${AudioTranscodingPresetId}
       - PolicyName: TranscoderAccessList
         PolicyDocument:
           Version: 2012-10-17

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -157,6 +157,8 @@ Resources:
       KeySchema:
       - AttributeName: jobId
         KeyType: HASH
+      - AttributeName: startedAt
+        KeyType: RANGE
       ProvisionedThroughput:
         WriteCapacityUnits: 2
         ReadCapacityUnits: 10
@@ -296,6 +298,8 @@ Resources:
             - s3:GetObject
             - s3:PutObject
             Resource:
+            - arn:aws:s3:::archivehunter-*
+            - arn:aws:s3:::archivehunter-*/*
             - arn:aws:s3:::gnm-multimedia-*
             - arn:aws:s3:::gnm-multimedia-*/*
             - arn:aws:s3:::mm-archive-*
@@ -324,6 +328,82 @@ Resources:
               - "ecr:GetAuthorizationToken"
               - ecr:GetAuthorizationToken
             Resource: "*"
+
+  #see https://docs.aws.amazon.com/elastictranscoder/latest/developerguide/access-control.html
+  TranscodingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: elastictranscoder.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+      - PolicyName: BucketRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Sid: '1'
+            Effect: Allow
+            Action:
+            - s3:Get*
+            - s3:ListBucket
+            - s3:Put*
+            - s3:*MultipartUpload*
+            Resource: "*"
+      - PolicyName: SNSPublish
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Sid: '2'
+            Effect: Allow
+            Action: sns:Publish
+            Resource: "*"
+      - PolicyName: BlockBucketOps
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Sid: '3'
+            Effect: Deny
+            Action:
+            - sns:*Permission*
+            - sns:*Delete*
+            - sns:*Remove*
+            - s3:*Policy*
+            - s3:*Delete*
+            Resource: "*"
+
+  TranscodeUpdateTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+        - Endpoint: !GetAtt TranscodeUpdateMsg.Arn
+          Protocol: sqs
+
+  TranscodeUpdateMsg:
+    Type: AWS::SQS::Queue
+
+  SNSSubscriptionPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Id: MyQueuePolicy
+        Statement:
+        - Sid: Allow-SendMessage-From-SNS-Topic
+          Effect: Allow
+          Principal: "*"
+          Action:
+          - sqs:SendMessage
+          Resource: !GetAtt TranscodeUpdateMsg.Arn
+          Condition:
+            ArnEquals:
+              aws:SourceArn: !Ref TranscodeUpdateTopic
+      Queues:
+      - !GetAtt TranscodeUpdateMsg.QueueName
 
   InstanceRole:
     Type: AWS::IAM::Role

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -578,6 +578,7 @@ Resources:
             }
 
             cluster {
+              auto-down-unreachable-after = 30s
               bootstrap {
                 contact-point-discovery {
                   service-name = "${Stack}-${App}-${Stage}"

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -161,8 +161,6 @@ Resources:
       KeySchema:
       - AttributeName: jobId
         KeyType: HASH
-      - AttributeName: startedAt
-        KeyType: RANGE
       ProvisionedThroughput:
         WriteCapacityUnits: 2
         ReadCapacityUnits: 10
@@ -446,6 +444,35 @@ Resources:
             - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ProxyLocationTable}/index/*
             - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${JobHistoryTable}
             - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${JobHistoryTable}/index/*
+      - PolicyName: TranscoderAccess
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Effect: Allow
+            Action:
+            - "elastictranscoder:*"
+            Resource:
+            - !Sub arn:aws:elastictranscoder:*:${AWS::AccountId}:pipeline/*
+            - !Sub arn:aws:elastictranscoder:*:${AWS::AccountId}:job/*
+            - !Sub arn:aws:elastictranscoder:*:${AWS::AccountId}:preset/${VideoTranscodingPresetId}
+      - PolicyName: TranscoderAccessList
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Effect: Allow
+            Action:
+            - elastictranscoder:ListPipelines
+            Resource:
+            - "*"
+      - PolicyName: MessageQueueRead
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Effect: Allow
+            Action:
+              - sqs:*
+            Resource:
+              - !GetAtt TranscodeUpdateMsg.Arn
       - PolicyName: ContainerAccess
         PolicyDocument:
           Version: 2012-10-17
@@ -621,7 +648,7 @@ Resources:
 
             transcodingRole = "${TranscodingRole.Arn}"
 
-            notificationsQueue = "${TranscodeUpdateMsg.Arn}"
+            notificationsQueue = "${TranscodeUpdateMsg}"
             videoPresetId = "${VideoTranscodingPresetId}"
           }
 

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -76,6 +76,10 @@ Parameters:
     Description: Docker path to the image used for proxying.
     Type: String
     Default: guardianmultimedia/archivehunter-proxying:90
+  VideoTranscodingPresetId:
+    Description: ETS Preset ID to use when transcoding video proxies
+    Type: String
+    Default: 1387374611767-d52fja
 
 Resources:
   AccessorSG: #this group is exported and used by bucketmonitor yaml. defined here so that it can be marked for access to ES
@@ -610,6 +614,15 @@ Resources:
             #this should match the container name in ProxyingTaskDefinition
             taskContainerName = "${Stack}-${App}Proxy-${Stage}"
             appServerUrl = "https://${LoadBalancer.DNSName}"
+
+            completionNotification = "${TranscodeUpdateTopic}"
+            errorNotification = "${TranscodeUpdateTopic}"
+            warningNotification = "${TranscodeUpdateTopic}"
+
+            transcodingRole = "${TranscodingRole.Arn}"
+
+            notificationsQueue = "${TranscodeUpdateMsg.Arn}"
+            videoPresetId = "${VideoTranscodingPresetId}"
           }
 
           ecs {

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -80,7 +80,10 @@ Parameters:
     Description: ETS Preset ID to use when transcoding video proxies
     Type: String
     Default: 1387374611767-d52fja
-
+  AudioTranscodingPresetId:
+    Description: ETS Preset ID to use when transcoding video proxies
+    Type: String
+    Default: 1351620000001-300040
 Resources:
   AccessorSG: #this group is exported and used by bucketmonitor yaml. defined here so that it can be marked for access to ES
     Type: AWS::EC2::SecurityGroup
@@ -650,6 +653,7 @@ Resources:
 
             notificationsQueue = "${TranscodeUpdateMsg}"
             videoPresetId = "${VideoTranscodingPresetId}"
+            audioPresetId = "${AudioTranscodingPresetId}"
           }
 
           ecs {

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveHunterConfiguration.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveHunterConfiguration.scala
@@ -18,4 +18,5 @@ trait ExtValueConverters {
   }
 
   implicit def StringDouble(input:String):Double = augmentString(input).toDouble
+  implicit def StringLong(input:String):Long = augmentString(input).toLong
 }

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/clientManagers/ETSClientManager.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/clientManagers/ETSClientManager.scala
@@ -1,0 +1,10 @@
+package com.theguardian.multimedia.archivehunter.common.clientManagers
+
+import com.amazonaws.services.elastictranscoder.{AmazonElasticTranscoder, AmazonElasticTranscoderClientBuilder}
+import javax.inject.Singleton
+
+@Singleton
+class ETSClientManager extends ClientManagerBase[AmazonElasticTranscoder] {
+  override def getClient(profileName: Option[String]): AmazonElasticTranscoder =
+    AmazonElasticTranscoderClientBuilder.standard().withCredentials(credentialsProvider(profileName)).build()
+}

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/clientManagers/SQSClientManager.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/clientManagers/SQSClientManager.scala
@@ -1,0 +1,9 @@
+package com.theguardian.multimedia.archivehunter.common.clientManagers
+
+import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
+import javax.inject.Inject
+
+class SQSClientManager @Inject() extends ClientManagerBase[AmazonSQS] {
+  override def getClient(profileName: Option[String]): AmazonSQS =
+    AmazonSQSClientBuilder.standard().withCredentials(credentialsProvider(profileName)).build()
+}

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/JobModel.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/JobModel.scala
@@ -14,9 +14,9 @@ object SourceType extends Enumeration {
   val SRC_MEDIA, SRC_PROXY, SRC_THUMBNAIL = Value
 }
 
-case class JobModel (jobId:String, jobType:String, startedAt: Option[ZonedDateTime], completedAt: Option[ZonedDateTime], jobStatus: JobStatus.Value, log:Option[String], sourceId:String, sourceType: SourceType.Value)
+case class JobModel (jobId:String, jobType:String, startedAt: Option[ZonedDateTime], completedAt: Option[ZonedDateTime], jobStatus: JobStatus.Value, log:Option[String], sourceId:String, transcodeInfo: Option[TranscodeInfo], sourceType: SourceType.Value)
 
-trait JobModelEncoder {
+trait JobModelEncoder extends {
   implicit val jobStatusEncoder = Encoder.enumEncoder(JobStatus)
   implicit val jobStatusDecoder = Decoder.enumDecoder(JobStatus)
 
@@ -25,6 +25,13 @@ trait JobModelEncoder {
   )(
     pt=>pt.toString
   )
+
+  implicit val proxyTypeEncoder = Encoder.enumEncoder(ProxyType)
+  implicit val proxyTypeDecoder = Decoder.enumDecoder(ProxyType)
+
+  implicit val proxyTypeFormat = DynamoFormat.coercedXmap[ProxyType.Value, String, IllegalArgumentException](
+    input=>ProxyType.withName(input)
+  )(pt=>pt.toString)
 
   implicit val sourceTypeEncoder = Encoder.enumEncoder(SourceType)
   implicit val sourceTypeDecoder = Decoder.enumDecoder(SourceType)

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/TranscodeInfo.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/TranscodeInfo.scala
@@ -1,0 +1,5 @@
+package com.theguardian.multimedia.archivehunter.common.cmn_models
+
+import com.theguardian.multimedia.archivehunter.common.ProxyType
+
+case class TranscodeInfo(transcodeId:String,destinationBucket:String,proxyType:ProxyType.Value)

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_services/ContainerTaskManager.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_services/ContainerTaskManager.scala
@@ -1,4 +1,4 @@
-package com.theguardian.multimedia.archivehunter.common.services
+package com.theguardian.multimedia.archivehunter.common.cmn_services
 
 import com.theguardian.multimedia.archivehunter.common.ArchiveHunterConfiguration
 import com.theguardian.multimedia.archivehunter.common.clientManagers.ECSClientManager

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/services/ProxyGenerators.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/services/ProxyGenerators.scala
@@ -1,30 +1,135 @@
 package com.theguardian.multimedia.archivehunter.common.services
 
+import java.net.URI
 import java.time.ZonedDateTime
 import java.util.UUID
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
+import com.amazonaws.services.elastictranscoder.AmazonElasticTranscoder
+import com.amazonaws.services.elastictranscoder.model._
 import com.gu.scanamo.Table
 import com.theguardian.multimedia.archivehunter.common._
-import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, ETSClientManager, S3ClientManager}
 import com.theguardian.multimedia.archivehunter.common.errors.{ExternalSystemError, NothingFoundError}
 import com.theguardian.multimedia.archivehunter.common.cmn_models._
 import javax.inject.Inject
-import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.{LogManager, Logger}
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.ExecutionContext.Implicits.global
 import io.circe.generic.auto._
 
+object ProxyGenerators {
+  /**
+    * try to find an applicable uri to use as the proxy source.  This will use the main media unless it's in the Glacier storage class;
+    * otherwise it will try to find an existing proxy and use that.  Failing this, None will be returned
+    * @param entry [[ArchiveEntry]] instance representing the entry to proxy
+    * @param proxyLocationDAO implicitly provided [[ProxyLocationDAO]] object
+    * @param ddbClient implicitly provided [[AmazonDynamoDBAsync]] object
+    * @return
+    */
+  def getUriToProxy(entry: ArchiveEntry)(implicit proxyLocationDAO: ProxyLocationDAO, ddbClient:AmazonDynamoDBAsync, logger:Logger) = entry.storageClass match {
+    case StorageClass.GLACIER=>
+      logger.info(s"s3://${entry.bucket}/${entry.path} is in Glacier, can't proxy directly. Looking up any existing video proxy")
+      proxyLocationDAO.getProxy(entry.id,ProxyType.VIDEO).flatMap({
+        case None=>
+          proxyLocationDAO.getProxy(entry.id,ProxyType.AUDIO).map({
+            case None=>None
+            case Some(proxyLocation)=>
+              logger.info(s"Found audio proxy at s3://${proxyLocation.bucketName}/${proxyLocation.bucketPath}")
+              Some(s"s3://${proxyLocation.bucketName}/${proxyLocation.bucketPath}")
+          })
+        case Some(proxyLocation)=>
+          logger.info(s"Found video proxy at s3://${proxyLocation.bucketName}/${proxyLocation.bucketPath}")
+          Future(Some(s"s3://${proxyLocation.bucketName}/${proxyLocation.bucketPath}"))
+      })
+    case _=>
+      logger.info(s"s3://${entry.bucket}/${entry.path} is in ${entry.storageClass}, will try to proxy directly")
+      Future(Some(s"s3://${entry.bucket}/${entry.path}"))
+  }
+
+  /**
+    * checks existing pipelines in the account to try to find one that goes from the selected input to the selected
+    * output bucket
+    * @param inputBucket name of the required source bucket
+    * @param outputBucket name of the required destination bucket
+    * @return a Sequence containing zero or more pipelines. If no pipelines are found, the sequence is empty.
+    */
+  def findPipelineFor(inputBucket:String, outputBucket:String)(implicit etsClient:AmazonElasticTranscoder) = {
+    def getNextPage(matches:Seq[Pipeline], pageToken: Option[String]):Seq[Pipeline] = {
+      val rq = new ListPipelinesRequest()
+      val updatedRq = pageToken match {
+        case None=>rq
+        case Some(token)=>rq.withPageToken(token)
+      }
+
+      val result = etsClient.listPipelines(updatedRq).getPipelines.asScala
+      if(result.isEmpty){
+        matches
+      } else {
+        matches ++ result.filter(p=>p.getOutputBucket==outputBucket && p.getInputBucket==inputBucket)
+      }
+    }
+
+    Try {
+      val initialResult = getNextPage(Seq(), None)
+      initialResult.filterNot(p => p.getName.contains("archivehunter")) //filter out anything that is not ours
+    }
+  }
+
+  def getPipelineStatus(pipelineId:String)(implicit etsClient:AmazonElasticTranscoder) = Try {
+    val rq = new ReadPipelineRequest().withId(pipelineId)
+
+    val result = etsClient.readPipeline(rq)
+    result.getPipeline.getStatus
+  }
+
+  /**
+    * kick of the creation of a pipeline. NOTE: the Pipeline object returned will not be usable until it's in an active state.
+    * @param pipelineName name of the pipeline to create
+    * @param inputBucket input bucket it should point to
+    * @param outputBucket output bucket it should point to
+    * @return
+    */
+  def createEtsPipeline(pipelineName:String, inputBucket:String, outputBucket:String)(implicit etsClient:AmazonElasticTranscoder, config:ArchiveHunterConfiguration, logger:Logger) = {
+    val completionNotificationTopic = config.get[String]("proxies.completionNotification")
+    val errorNotificationTopic = config.get[String]("proxies.errorNotification")
+    val warningNotificationTopic = config.get[String]("proxies.warningNotification")
+    val transcodingRole = config.get[String]("proxies.transcodingRole")
+
+    val createRq = new CreatePipelineRequest()
+      .withInputBucket(inputBucket)
+      .withName(pipelineName)
+      .withNotifications(new Notifications().withCompleted(completionNotificationTopic).withError(errorNotificationTopic).withWarning(warningNotificationTopic))
+      .withOutputBucket(outputBucket)
+      .withRole(transcodingRole)
+
+    Try {
+      val result = etsClient.createPipeline(createRq)
+      val warnings = result.getWarnings.asScala
+      if(warnings.nonEmpty){
+        logger.warn("Warnings were receieved when creating pipeline:")
+        warnings.foreach(warning=>logger.warn(warning.toString))
+      }
+      result.getPipeline
+    }
+  }
+}
+
 class ProxyGenerators @Inject() (config:ArchiveHunterConfiguration, esClientMgr: ESClientManager, s3ClientMgr: S3ClientManager,
                                  ddbClientMgr: DynamoClientManager, scanTargetDAO: ScanTargetDAO, jobModelDAO:JobModelDAO,
-                                 containerTaskMgr:ContainerTaskManager) extends ZonedDateTimeEncoder with ProxyLocationEncoder {
-  private val logger = LogManager.getLogger(getClass)
+                                 containerTaskMgr:ContainerTaskManager, etsClientMgr:ETSClientManager) extends ZonedDateTimeEncoder with ProxyLocationEncoder {
+  private implicit val logger = LogManager.getLogger(getClass)
 
   private val indexName = config.getOptional[String]("elasticsearch.index").getOrElse("archivehunter")
   private val awsProfile = config.getOptional[String]("externalData.awsProfile")
   protected val tableName:String = config.get[String]("proxies.tableName")
   private val table = Table[ProxyLocation](tableName)
+  private val etsClient = etsClientMgr.getClient(awsProfile)
+
+  import ProxyGenerators._
 
   /**
     * try to start a thumbnail proxy job.  This will use the main media if available; if it's in Glacier an existing proxy will be tried.
@@ -64,25 +169,7 @@ class ProxyGenerators @Inject() (config:ArchiveHunterConfiguration, esClientMgr:
 
     val jobDesc = JobModel(UUID.randomUUID().toString,"thumbnail",Some(ZonedDateTime.now()),None,JobStatus.ST_PENDING,None,entry.id,SourceType.SRC_MEDIA)
 
-    val uriToProxyFuture = entry.storageClass match {
-      case StorageClass.GLACIER=>
-        logger.info(s"s3://${entry.bucket}/${entry.path} is in Glacier, can't proxy directly. Looking up any existing video proxy")
-        proxyLocationDAO.getProxy(entry.id,ProxyType.VIDEO).flatMap({
-          case None=>
-            proxyLocationDAO.getProxy(entry.id,ProxyType.AUDIO).map({
-              case None=>None
-              case Some(proxyLocation)=>
-                logger.info(s"Found audio proxy at s3://${proxyLocation.bucketName}/${proxyLocation.bucketPath}")
-                Some(s"s3://${proxyLocation.bucketName}/${proxyLocation.bucketPath}")
-            })
-          case Some(proxyLocation)=>
-            logger.info(s"Found video proxy at s3://${proxyLocation.bucketName}/${proxyLocation.bucketPath}")
-            Future(Some(s"s3://${proxyLocation.bucketName}/${proxyLocation.bucketPath}"))
-        })
-      case _=>
-        logger.info(s"s3://${entry.bucket}/${entry.path} is in ${entry.storageClass}, will try to proxy directly")
-        Future(Some(s"s3://${entry.bucket}/${entry.path}"))
-    }
+    val uriToProxyFuture = ProxyGenerators.getUriToProxy(entry)
 
     Future.sequence(Seq(targetProxyBucketFuture, uriToProxyFuture)).map(results=> {
       logger.debug("Saving job description...")
@@ -115,6 +202,78 @@ class ProxyGenerators @Inject() (config:ArchiveHunterConfiguration, esClientMgr:
       case err:Throwable=>
         logger.error("Could not start proxy job: ", err)
         Future(Failure(ExternalSystemError("archivehunter", err.toString)))
+    })
+  }
+
+  def startEtsProxy(toProxy:String, presetId:String, destinationBucket:String) = {
+    val toProxyUri = URI.create(toProxy)
+
+    findPipelineFor(toProxyUri.getHost,destinationBucket) match {
+      case Success(matches)=>
+        if(matches.nonEmpty) {
+          logger.info(s"Found ${matches.length} pipelines for ${toProxyUri.getHost}->$destinationBucket, using the first")
+          matches.head
+        } else {
+          logger.info(s"Found no matching pipelines for ${toProxyUri.getHost}->$destinationBucket, requesting creation")
+          createEtsPipeline(s"archivehunter_", toProxyUri.getHost,destinationBucket)
+          Failure()
+        }
+    }
+    val jobRq = new CreateJobRequest()
+      .withInput(new JobInput().withContainer("mp4").withKey(toProxyUri.getPath))
+      .withOutput(new CreateJobOutput().withKey(makeOutputFilename(toProxyUri.getPath)).withPresetId(presetId))
+      .withPipelineId(pipelineId)
+
+    try {
+      val result = etsClient.createJob(jobRq)
+      Success(result.getJob.getId)
+    } catch {
+      case ex:Throwable=>
+        Failure(ex)
+    }
+  }
+
+  /**
+    * try to start a media proxy
+    * @param entry
+    * @return
+    */
+  def createMediaProxy(entry: ArchiveEntry):Future[Try[String]] = {
+    implicit val s3Client = s3ClientMgr.getS3Client(awsProfile)
+    implicit val dynamoClient = ddbClientMgr.getClient(awsProfile)
+    implicit val proxyLocationDAO = new ProxyLocationDAO(tableName)
+
+    val callbackUrl=config.get[String]("proxies.appServerUrl")
+    logger.info(s"callbackUrl is $callbackUrl")
+    val jobUuid = UUID.randomUUID()
+
+    val targetProxyBucketFuture = scanTargetDAO.targetForBucket(entry.bucket).map({
+      case None=>throw new RuntimeException(s"Entry's source bucket ${entry.bucket} is not registered")
+      case Some(Left(err))=>throw new RuntimeException(err.toString)
+      case Some(Right(target))=>Some(target.proxyBucket)
+    })
+
+    Future.sequence(Seq(targetProxyBucketFuture, getUriToProxy(entry))).flatMap(results=> {
+      val targetProxyBucket = results.head.get
+      val maybeUriToProxy = results(1)
+      logger.info(s"Target proxy bucket is $targetProxyBucket")
+      logger.info(s"Source media is $maybeUriToProxy")
+      maybeUriToProxy match {
+        case None=>
+          logger.error("Nothing found to proxy")
+          Future(Failure(NothingFoundError("media", "Nothing found to proxy")))
+        case Some(uriToProxy)=>
+          val jobDesc = JobModel(UUID.randomUUID().toString,"proxy",Some(ZonedDateTime.now()),None,JobStatus.ST_PENDING,None,entry.id,SourceType.SRC_MEDIA)
+
+          jobModelDAO.putJob(jobDesc).map({
+            case Some(Left(dynamoError))=>
+              logger.error(s"Could not save new job description: $dynamoError")
+              Failure(new RuntimeException(dynamoError.toString))
+            case _=>  //either None or Some(Right(thing)) indicate success
+
+              Success("hello")
+          })
+      }
     })
   }
 

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/services/ProxyGenerators.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/services/ProxyGenerators.scala
@@ -205,32 +205,31 @@ class ProxyGenerators @Inject() (config:ArchiveHunterConfiguration, esClientMgr:
     })
   }
 
-  def startEtsProxy(toProxy:String, presetId:String, destinationBucket:String) = {
-    val toProxyUri = URI.create(toProxy)
-
-    findPipelineFor(toProxyUri.getHost,destinationBucket) match {
-      case Success(matches)=>
-        if(matches.nonEmpty) {
-          logger.info(s"Found ${matches.length} pipelines for ${toProxyUri.getHost}->$destinationBucket, using the first")
-          matches.head
-        } else {
-          logger.info(s"Found no matching pipelines for ${toProxyUri.getHost}->$destinationBucket, requesting creation")
-          createEtsPipeline(s"archivehunter_", toProxyUri.getHost,destinationBucket)
-          Failure()
-        }
-    }
-    val jobRq = new CreateJobRequest()
-      .withInput(new JobInput().withContainer("mp4").withKey(toProxyUri.getPath))
-      .withOutput(new CreateJobOutput().withKey(makeOutputFilename(toProxyUri.getPath)).withPresetId(presetId))
-      .withPipelineId(pipelineId)
-
-    try {
-      val result = etsClient.createJob(jobRq)
-      Success(result.getJob.getId)
-    } catch {
-      case ex:Throwable=>
-        Failure(ex)
-    }
+  def startEtsProxy(toProxy:String, presetId:String, destinationBucket:String)(implicit etsClient:AmazonElasticTranscoder) = {
+//    val toProxyUri = URI.create(toProxy)
+//
+//    findPipelineFor(toProxyUri.getHost,destinationBucket) match {
+//      case Success(matches)=>
+//        if(matches.nonEmpty) {
+//          logger.info(s"Found ${matches.length} pipelines for ${toProxyUri.getHost}->$destinationBucket, using the first")
+//          matches.head
+//        } else {
+//          logger.info(s"Found no matching pipelines for ${toProxyUri.getHost}->$destinationBucket, requesting creation")
+//          createEtsPipeline(s"archivehunter_", toProxyUri.getHost,destinationBucket)
+//        }
+//    }
+//    val jobRq = new CreateJobRequest()
+//      .withInput(new JobInput().withContainer("mp4").withKey(toProxyUri.getPath))
+//      .withOutput(new CreateJobOutput().withKey(makeOutputFilename(toProxyUri.getPath)).withPresetId(presetId))
+//      .withPipelineId(pipelineId)
+//
+//    try {
+//      val result = etsClient.createJob(jobRq)
+//      Success(result.getJob.getId)
+//    } catch {
+//      case ex:Throwable=>
+//        Failure(ex)
+//    }
   }
 
   /**

--- a/common/src/test/scala/com/theguardian/multimedia/archivehunter/ProxyGeneratorsSpec.scala
+++ b/common/src/test/scala/com/theguardian/multimedia/archivehunter/ProxyGeneratorsSpec.scala
@@ -1,0 +1,45 @@
+package com.theguardian.multimedia.archivehunter
+import com.amazonaws.services.elastictranscoder.AmazonElasticTranscoder
+import com.amazonaws.services.elastictranscoder.model.{Preset, ReadPresetResult}
+import com.theguardian.multimedia.archivehunter.common.cmn_services.ProxyGenerators
+import org.apache.logging.log4j.LogManager
+import org.specs2.mock.Mockito
+import org.specs2.mutable._
+
+class ProxyGeneratorsSpec extends Specification with Mockito{
+  "ProxyGenerators.outputFilenameFor" should {
+    "return an output filename with an updated file extension" in {
+      val mockedClient = mock[AmazonElasticTranscoder]
+      val logger = LogManager.getLogger(getClass)
+
+      val mockedResponse = new ReadPresetResult().withPreset(new Preset().withContainer("mp3"))
+      mockedClient.readPreset(any) returns mockedResponse
+
+      val result = ProxyGenerators.outputFilenameFor("xxxxxx","/path/to/my/file.wav")(mockedClient, logger)
+      result must beSuccessfulTry("/path/to/my/file.mp3")
+    }
+
+    "append the correct extension if the input filename has no extension" in {
+      val mockedClient = mock[AmazonElasticTranscoder]
+      val logger = LogManager.getLogger(getClass)
+
+      val mockedResponse = new ReadPresetResult().withPreset(new Preset().withContainer("mp3"))
+      mockedClient.readPreset(any) returns mockedResponse
+
+      val result = ProxyGenerators.outputFilenameFor("xxxxxx","/path/to/my/file")(mockedClient, logger)
+      result must beSuccessfulTry("/path/to/my/file.mp3")
+    }
+
+    "return an ETS exception as a failure" in {
+      val mockedClient = mock[AmazonElasticTranscoder]
+      val logger = LogManager.getLogger(getClass)
+
+      val expectedException = new RuntimeException("my hovercraft is full of eels")
+      val mockedResponse = new ReadPresetResult().withPreset(new Preset().withContainer("mp3"))
+      mockedClient.readPreset(any) throws expectedException
+
+      val result = ProxyGenerators.outputFilenameFor("xxxxxx","/path/to/my/file")(mockedClient, logger)
+      result must beFailedTry(expectedException)
+    }
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -87,6 +87,7 @@ akka.remote {
 
 akka.cluster {
   seed-nodes = ["akka.tcp://application@localhost:2552"]
+  auto-down-unreachable-after = 30s //important for EC2
 }
 
 akka.io.dns.resolver = async-dns

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -32,6 +32,15 @@ proxies {
   ecsTaskDefinitionName = "arn:aws:ecs:region:my-acct:task-definition/proxying-task-definition:1"
   taskContainerName = "container-within-task"
   appServerUrl = "http://localhost:9000"
+
+  completionNotification = "topicArn"
+  errorNotification = "topicArn"
+  warningNotification = "topicArn"
+
+  transcodingRole = "roleArn"
+
+  notificationsQueue = "queueUrl"
+  videoPresetId = "presetId"
 }
 
 ecs {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -41,6 +41,7 @@ proxies {
 
   notificationsQueue = "queueUrl"
   videoPresetId = "presetId"
+  audioPresetId = "presetId"
 }
 
 ecs {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -89,9 +89,13 @@ akka.cluster {
   seed-nodes = ["akka.tcp://application@localhost:2552"]
 }
 
+akka.io.dns.resolver = async-dns
+
 akka.discovery {
+  method = akka-dns
   # Set the following in your application.conf if you want to use this discovery mechanism:
   # method = aws-api-ec2-tag-based
+
 
   aws-api-ec2-tag-based {
 

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -7,12 +7,22 @@ Configuration:
     Console:
       name: STDOUT
       PatternLayout:
-        Pattern: "%m%n"
+        Pattern: "%date [%level] from %logger in %thread - %message%n%xException"
   Loggers:
     logger:
     -
       name: com.theguardian.multimedia.archivehunter.common.services.ProxyGenerators
-      level: INFO
+      level: DEBUG
+      additivity: false
+      AppenderRef:
+        ref: STDOUT
+    - name: services.ETSProxyActor
+      level: DEBUG
+      additivity: false
+      AppenderRef:
+        ref: STDOUT
+    - name: com.theguardian.multimedia.archivehunter.common.ProxyLocation$
+      level: DEBUG
       additivity: false
       AppenderRef:
         ref: STDOUT

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -57,6 +57,7 @@
     <logger name="helpers.CreateProxySink" level="INFO"/>
     <logger name="services.BulkThumbnailer" level="INFO"/>
     <logger name="services.DynamoCapacityActor" level="INFO"/>
+    <logger name="services.ClockSingleton" level="DEBUG"/>
 
     <root level="WARN">/
         <appender-ref ref="STDOUT" />

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -58,8 +58,9 @@
     <logger name="services.BulkThumbnailer" level="INFO"/>
     <logger name="services.DynamoCapacityActor" level="INFO"/>
     <logger name="services.ClockSingleton" level="DEBUG"/>
+    <logger name="services.ETSProxyActor" level="DEBUG"/>
 
-    <root level="WARN">/
+    <root level="WARN">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="ASYNCFILE"/>
         <!-- <appender-ref ref="Sentry" />-->

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -59,6 +59,8 @@
     <logger name="services.DynamoCapacityActor" level="INFO"/>
     <logger name="services.ClockSingleton" level="DEBUG"/>
     <logger name="services.ETSProxyActor" level="DEBUG"/>
+    <logger name="com.theguardian.multimedia.archivehunter.cmn_services.ProxyGenerators" level="DEBUG"/>
+    <logger name="com.theguardian.multimedia.archivehunter.common.ProxyLocation$" level="DEBUG"/>
 
     <root level="WARN">
         <appender-ref ref="STDOUT" />

--- a/conf/routes
+++ b/conf/routes
@@ -25,6 +25,7 @@ GET     /api/proxy/:id/playable         @controllers.ProxiesController.getPlayab
 GET     /api/proxy/:id                  @controllers.ProxiesController.proxyForId(id, proxyType:Option[String])
 
 POST    /api/proxy/generate/:id/thumbnail   @controllers.ProxiesController.generateThumbnail(id)
+POST    /api/proxy/generate/:id         @controllers.ProxiesController.generateProxy(id)
 
 POST    /api/job/:jobid/report          @controllers.JobController.updateStatus(jobid)
 GET     /api/job/all                    @controllers.JobController.getAllJobs(limit:Int ?=100, scanFrom:Option[String])

--- a/conf/routes
+++ b/conf/routes
@@ -25,7 +25,7 @@ GET     /api/proxy/:id/playable         @controllers.ProxiesController.getPlayab
 GET     /api/proxy/:id                  @controllers.ProxiesController.proxyForId(id, proxyType:Option[String])
 
 POST    /api/proxy/generate/:id/thumbnail   @controllers.ProxiesController.generateThumbnail(id)
-POST    /api/proxy/generate/:id         @controllers.ProxiesController.generateProxy(id)
+POST    /api/proxy/generate/:id/:typeStr     @controllers.ProxiesController.generateProxy(id, typeStr)
 
 POST    /api/job/:jobid/report          @controllers.JobController.updateStatus(jobid)
 GET     /api/job/all                    @controllers.JobController.getAllJobs(limit:Int ?=100, scanFrom:Option[String])

--- a/frontend/app/Entry/EntryDetails.jsx
+++ b/frontend/app/Entry/EntryDetails.jsx
@@ -48,6 +48,10 @@ class EntryDetails extends React.Component {
         this.setState({jobsAutorefresh: true});
     }
 
+    componentDidUpdate(oldProps,oldState){
+        //if the highlighted media changes, then disable auto-refresh
+        if(oldProps.entry !== this.props.entry && this.state.jobsAutorefresh) this.setState({jobsAutorefresh: false});
+    }
     render(){
         if(!this.props.entry){
             return <div className="entry-details">

--- a/frontend/app/Entry/EntryDetails.jsx
+++ b/frontend/app/Entry/EntryDetails.jsx
@@ -13,6 +13,16 @@ class EntryDetails extends React.Component {
         loadJobs: PropTypes.boolean
     };
 
+    constructor(props){
+        super(props);
+        this.state = {
+            jobsAutorefresh: false
+        };
+
+        this.jobsAutorefreshUpdated = this.jobsAutorefreshUpdated.bind(this);
+        this.proxyGenerationWasTriggered = this.proxyGenerationWasTriggered.bind(this);
+    }
+
     extractFileInfo(fullpath){
         const parts = fullpath.split("/");
         const len = parts.length;
@@ -29,6 +39,15 @@ class EntryDetails extends React.Component {
         }
     }
 
+    jobsAutorefreshUpdated(newValue){
+        this.setState({jobsAutorefresh: newValue});
+    }
+
+    proxyGenerationWasTriggered(){
+        console.log("new proxy generation was started");
+        this.setState({jobsAutorefresh: true});
+    }
+
     render(){
         if(!this.props.entry){
             return <div className="entry-details">
@@ -42,10 +61,14 @@ class EntryDetails extends React.Component {
                               fileExtension={this.props.entry.file_extension}
                               mimeType={this.props.entry.mimeType}
                               autoPlay={this.props.autoPlay}
+                              triggeredProxyGeneration={this.proxyGenerationWasTriggered}
                 />
 
             {
-                this.props.showJobs ? <EntryJobs entryId={this.props.entry.id} loadImmediate={this.props.loadJobs}/> : ""
+                this.props.showJobs ? <EntryJobs entryId={this.props.entry.id}
+                                                 loadImmediate={this.props.loadJobs}
+                                                 autoRefresh={this.state.jobsAutorefresh}
+                                                 autoRefreshUpdated={this.jobsAutorefreshUpdated}/> : ""
             }
 
                 <table className="metadata-table">

--- a/frontend/app/Entry/EntryPreview.jsx
+++ b/frontend/app/Entry/EntryPreview.jsx
@@ -12,7 +12,8 @@ class EntryPreview extends React.Component {
         mimeType: PropTypes.string.isRequired,
         fileExtension: PropTypes.string.isRequired,
         autoPlay: PropTypes.boolean,
-        hasProxy: PropTypes.bool.isRequired
+        hasProxy: PropTypes.bool.isRequired,
+        triggeredProxyGeneration: PropTypes.func
     };
 
     constructor(props){
@@ -75,7 +76,9 @@ class EntryPreview extends React.Component {
 
     initiateCreateProxy(){
         axios.post("/api/proxy/generate/" + this.props.entryId + "/" + this.state.selectedType.toLowerCase()).then(result=>{
-            this.setState({processMessage: "Proxy generation started"})
+            this.setState({processMessage: "Proxy generation started"}, ()=>{
+                if(this.props.triggeredProxyGeneration) this.props.triggeredProxyGeneration();
+            })
         }).catch(err=>{
             console.log(err);
             this.setState({processMessage: "Proxy generation failed, see console log"})

--- a/frontend/app/common/TimeIntervalComponent.jsx
+++ b/frontend/app/common/TimeIntervalComponent.jsx
@@ -14,6 +14,7 @@ class TimeIntervalComponent extends React.Component {
         super(props);
 
         this.state = {
+            daysSet: 0,
             hoursSet: 0,
             minutesSet: 0,
             secondsSet:0,
@@ -25,7 +26,7 @@ class TimeIntervalComponent extends React.Component {
 
     componentWillMount(){
         const d = moment.duration(this.props.value,"seconds");
-        this.setState({moment: d, hoursSet: d.hours(), minutesSet: d.minutes(), secondsSet: d.seconds()})
+        this.setState({moment: d, daysSet: d.days(), hoursSet: d.hours(), minutesSet: d.minutes(), secondsSet: d.seconds()})
     }
 
     componentDidUpdate(oldProps,oldState){
@@ -39,7 +40,7 @@ class TimeIntervalComponent extends React.Component {
 
     notifyParent(){
         console.log("notifyParent", this.state);
-        if(this.props.didUpdate) this.props.didUpdate(this.state.hoursSet*3600+this.state.minutesSet*60+this.state.secondsSet);
+        if(this.props.didUpdate) this.props.didUpdate(this.state.daysSet*(3600*24)+this.state.hoursSet*3600+this.state.minutesSet*60+this.state.secondsSet);
     }
 
     safeUpdateValue(key, newValue){
@@ -55,6 +56,10 @@ class TimeIntervalComponent extends React.Component {
             return <span className="duration">
                 <input className="time-interval"
                        type="number"
+                       value={this.state.daysSet}
+                       onChange={evt=>this.safeUpdateValue("daysSet", evt.target.value)}/> days
+                <input className="time-interval"
+                       type="number"
                        value={this.state.hoursSet}
                        onChange={evt=>this.safeUpdateValue("hoursSet", evt.target.value)}/> hours
                 <input className="time-interval"
@@ -68,12 +73,17 @@ class TimeIntervalComponent extends React.Component {
             </span>
         } else {
             let fmtStringParts = [];
+            if (this.state.daysSet > 0) fmtStringParts = fmtStringParts.concat(["d [days]"]);
             if (this.state.hoursSet > 0) fmtStringParts = fmtStringParts.concat(["h [hours]"]);
             if (this.state.minutesSet > 0) fmtStringParts = fmtStringParts.concat(["m [minutes]"]);
             if (this.state.secondsSet > 0) fmtStringParts = fmtStringParts.concat(["s [seconds]"]);
-            const formatString = fmtStringParts.join(", ");
+            if(fmtStringParts.length===0){
+                return <span className="duration">invalid duration</span>
+            } else {
+                const formatString = fmtStringParts.join(", ");
 
-            return <span className="duration">{this.state.moment.format(formatString)}</span>
+                return <span className="duration">{this.state.moment.format(formatString)}</span>
+            }
         }
     }
 }

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -15,10 +15,10 @@ import JobsList from './JobsList/JobsList.jsx';
 
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faStroopwafel, faCheckCircle, faTimesCircle, faRoad, faSearch,faThList,faWrench, faLightbulb, faFolderPlus, faFolderMinus, faFolder } from '@fortawesome/free-solid-svg-icons'
+import { faStroopwafel, faCheckCircle, faCheck, faTimes, faTimesCircle, faRoad, faSearch,faThList,faWrench, faLightbulb, faFolderPlus, faFolderMinus, faFolder } from '@fortawesome/free-solid-svg-icons'
 import { faChevronCircleDown,faChevronCircleRight,faTrashAlt, faFilm, faVolumeUp,faImage, faFile, faClock, faRunning, faExclamationTriangle} from '@fortawesome/free-solid-svg-icons'
 
-library.add(faStroopwafel, faCheckCircle, faTimesCircle, faRoad,faSearch,faThList,faWrench, faLightbulb, faChevronCircleDown, faChevronCircleRight, faTrashAlt, faFolderPlus, faFolderMinus, faFolder);
+library.add(faStroopwafel, faCheckCircle, faCheck, faTimes, faTimesCircle, faRoad,faSearch,faThList,faWrench, faLightbulb, faChevronCircleDown, faChevronCircleRight, faTrashAlt, faFolderPlus, faFolderMinus, faFolder);
 library.add(faFilm, faVolumeUp, faImage, faFile, faClock, faRunning, faExclamationTriangle);
 window.React = require('react');
 

--- a/lambda/input/src/main/scala/InputLambdaMain.scala
+++ b/lambda/input/src/main/scala/InputLambdaMain.scala
@@ -129,6 +129,8 @@ class InputLambdaMain extends RequestHandler[S3Event, Unit] {
       rec.getEventName match {
         case "ObjectCreated:Put"=>
           handleCreated(rec)
+        case "ObjectCreated:CompleteMultipartUpload"=>
+          handleCreated(rec)
         case "ObjectRemoved:Delete"=>
           handleRemoved(rec)
         case other:String=>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -338,3 +338,10 @@ p.information {
     text-transform: capitalize;
 }
 
+.command-link {
+    display: block;
+    font-size: 0.8em;
+    font-style: italic;
+    cursor:pointer;
+    text-decoration:underline;
+}

--- a/test/JobControllerSpec.scala
+++ b/test/JobControllerSpec.scala
@@ -39,11 +39,11 @@ class JobControllerSpec extends Specification with Mockito with MockitoMatchers 
       implicit val mockEsClient = mock[HttpClient]
       val c = new JobController(mockConfig,mockCC,mockJobModelDAO,mockesClientManager, mocks3ClientManager, mockddbClientManager)
 
-      val toTest1 = JobModel("test","test",None,None,JobStatus.ST_PENDING,None,"fake-source-id",SourceType.SRC_PROXY)
+      val toTest1 = JobModel("test","test",None,None,JobStatus.ST_PENDING,None,"fake-source-id",None,SourceType.SRC_PROXY)
       val result1 = Await.result(c.thumbnailJobOriginalMedia(toTest1),10 seconds)
       result1 must beLeft
 
-      val toTest2 = JobModel("test","test",None,None,JobStatus.ST_PENDING,None,"fake-source-id",SourceType.SRC_THUMBNAIL)
+      val toTest2 = JobModel("test","test",None,None,JobStatus.ST_PENDING,None,"fake-source-id",None,SourceType.SRC_THUMBNAIL)
       val result2 = Await.result(c.thumbnailJobOriginalMedia(toTest2),10 seconds)
       result2 must beLeft
     }
@@ -67,7 +67,7 @@ class JobControllerSpec extends Specification with Mockito with MockitoMatchers 
         override protected val proxyLocationDAO = mockProxyLocationDAO
       }
 
-      val toTest = JobModel("test","test",None,None,JobStatus.ST_PENDING,None,"fake-source-id",SourceType.SRC_MEDIA)
+      val toTest = JobModel("test","test",None,None,JobStatus.ST_PENDING,None,"fake-source-id",None,SourceType.SRC_MEDIA)
       val mockResponse = ArchiveEntry("fake-id","fake-bucket","fake-path",None,1234L,ZonedDateTime.now(),"fake-etag",MimeType("video","something"),false,StorageClass.STANDARD)
 
       mockIndexer.getById("fake-source-id")(mockEsClient).returns(Future(mockResponse))


### PR DESCRIPTION
Implement transcoding for audio and video via Elastic Transcoder. Also enable Akka Management HTTP API, so we can deal with removing or "downing" EC2 instances that have terminated.