### PR TITLE
Proxy media on ingest

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -18,6 +18,8 @@ class Module extends AbstractModule with AkkaGuiceSupport {
     bindActor[ProxiesRelinker]("proxiesRelinker")
     bindActor[GlacierRestoreActor]("glacierRestoreActor")
     bindActor[JobPurgerActor]("jobPurgerActor")
+    bindActor[IngestProxyQueue]("ingestProxyQueue")
+
     bind(classOf[AppStartup]).asEagerSingleton() //do app startup
   }
 }

--- a/app/controllers/BrowseCollectionController.scala
+++ b/app/controllers/BrowseCollectionController.scala
@@ -59,33 +59,6 @@ extends AbstractController(controllerComponents) with PanDomainAuthActions with 
     withScanTargetAsync(collectionName){ target=> Future(block(target)) }
 
   /**
-    * iterate through the S3 bucket recursively, until there are no more prefixes available.
-    * @param baseRequest
-    * @param s3Client
-    * @param continuationToken
-    * @param currentSummaries
-    * @return
-    */
-  def recurseGetFolders(baseRequest:ListObjectsRequest, s3Client:AmazonS3,
-                        continuationToken:Option[String]=None, currentSummaries:Seq[String]=Seq()):Seq[String] =
-  {
-    val finalRequest = continuationToken match {
-      case None=>baseRequest
-      case Some(token)=>baseRequest.withMarker(token)
-    }
-
-    val result = s3Client.listObjects(finalRequest)
-    val updatedList = currentSummaries ++ result.getCommonPrefixes.asScala
-
-    Option(result.getNextMarker) match {
-      case Some(marker) =>
-        recurseGetFolders(baseRequest, s3Client, Some(marker), updatedList)
-      case None=>
-        updatedList
-    }
-  }
-
-  /**
     * get all of the "subfolders" ("common prefix" in s3 parlance) for the provided bucket, but only if it
     * is one that is registered as managed by us.
     * this is to drive the tree view in the browse window

--- a/app/controllers/JobController.scala
+++ b/app/controllers/JobController.scala
@@ -37,7 +37,8 @@ class JobController @Inject() (override val config:Configuration, override val c
                                ddbClientManager:DynamoClientManager,
                                override val refresher:InjectableRefresher,
                                override val wsClient:WSClient,
-                              @Named("etsProxyActor") etsProxyActor:ActorRef)
+                              @Named("etsProxyActor") etsProxyActor:ActorRef,
+                               proxyLocationDAO:ProxyLocationDAO)
                               (implicit actorSystem:ActorSystem)
   extends AbstractController(controllerComponents) with Circe with JobModelEncoder with ZonedDateTimeEncoder with PanDomainAuthActions with QueryRemaps {
 
@@ -49,7 +50,6 @@ class JobController @Inject() (override val config:Configuration, override val c
   private  val tableName:String = config.get[String]("proxies.tableName")
 
   protected implicit val indexer = new Indexer(indexName)
-  protected val proxyLocationDAO = new ProxyLocationDAO(tableName)
 
   def renderListAction(block: ()=>Future[List[Either[DynamoReadError, JobModel]]]) = APIAuthAction.async {
       val resultFuture = block()

--- a/app/controllers/ProxiesController.scala
+++ b/app/controllers/ProxiesController.scala
@@ -56,7 +56,7 @@ class ProxiesController @Inject()(override val config:Configuration,
   protected val tableName:String = config.get[String]("proxies.tableName")
   private val table = Table[ProxyLocation](tableName)
   private implicit val dynamoClient = ddbClientMgr.getNewAlpakkaDynamoClient(awsProfile)
-  private val s3client = s3ClientMgr.getS3Client(awsProfile)
+  private implicit val s3client = s3ClientMgr.getS3Client(awsProfile)
 
   def proxyForId(fileId:String, proxyType:Option[String]) = APIAuthAction.async {
     try {

--- a/app/controllers/ProxiesController.scala
+++ b/app/controllers/ProxiesController.scala
@@ -131,6 +131,7 @@ class ProxiesController @Inject()(override val config:Configuration,
         Future(InternalServerError(GenericErrorResponse("error",ex.toString).asJson))
     }
   }
+
   /**
     * endpoint that performs a scan for potential proxies for the given file.
     * if there is only one result, it is automatically associated.

--- a/app/helpers/CreateProxySink.scala
+++ b/app/helpers/CreateProxySink.scala
@@ -3,7 +3,7 @@ package helpers
 import akka.actor.ActorRef
 import akka.stream.{Attributes, Inlet, SinkShape}
 import akka.stream.stage.{AbstractInHandler, GraphStage, GraphStageLogic}
-import com.theguardian.multimedia.archivehunter.common.ArchiveEntry
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ProxyLocationDAO}
 import com.theguardian.multimedia.archivehunter.common.cmn_services.ProxyGenerators
 import javax.inject.{Inject, Named}
 import play.api.Logger
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-class CreateProxySink @Inject() (proxyGenerators: ProxyGenerators, @Named("etsProxyActor")etsProxyActor:ActorRef) extends GraphStage[SinkShape[ArchiveEntry]]{
+class CreateProxySink @Inject() (proxyGenerators: ProxyGenerators, @Named("etsProxyActor")etsProxyActor:ActorRef)(implicit proxyLocationDAO:ProxyLocationDAO) extends GraphStage[SinkShape[ArchiveEntry]]{
   private final val in:Inlet[ArchiveEntry] = Inlet.create("CreateProxySink.in")
   private val logger = Logger(getClass)
 

--- a/app/helpers/HasThumbnailFilter.scala
+++ b/app/helpers/HasThumbnailFilter.scala
@@ -18,18 +18,19 @@ import scala.concurrent.duration._
   * @param ddbClientManager injected [[DynamoClientManager]] instance
   * @param config injected [[ArchiveHunterConfiguration]] instance
   */
-class HasThumbnailFilter @Inject() (ddbClientManager:DynamoClientManager, config:ArchiveHunterConfiguration) extends GraphStage[FlowShape[ArchiveEntry,ArchiveEntry]]{
+class HasThumbnailFilter @Inject() (ddbClientManager:DynamoClientManager, config:ArchiveHunterConfiguration, proxyLocationDAO: ProxyLocationDAO)(implicit system:ActorSystem) extends GraphStage[FlowShape[ArchiveEntry,ArchiveEntry]]{
   private final val in:Inlet[ArchiveEntry] = Inlet.create("HasProxyFilter.in")
   private final val out:Outlet[ArchiveEntry] = Outlet.create("HasProxyFilter.out")
   private val logger = Logger(getClass)
+
+  private implicit val mat:Materializer = ActorMaterializer.create(system)
 
   override def shape: FlowShape[ArchiveEntry, ArchiveEntry] = FlowShape.of(in,out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
     val awsProfile = config.getOptional("externalData.awsProfile").map(_.mkString)
     val tableName = config.get[String]("proxies.tableName")
-    implicit val ddbClient = ddbClientManager.getClient(awsProfile)
-    private val proxyLocationDAO = new ProxyLocationDAO(tableName)
+    implicit val ddbClient = ddbClientManager.getNewAlpakkaDynamoClient(awsProfile)
 
     setHandler(in, new AbstractInHandler {
       override def onPush(): Unit = {

--- a/app/models/TranscoderMessage.scala
+++ b/app/models/TranscoderMessage.scala
@@ -35,7 +35,7 @@ case class AwsElasticTranscodeMsg ( state: TranscoderState.Value,
                                     userMetadata:Option[Map[String,String]],
                                     outputs:Option[Seq[ETSOutput]]) extends ExpectedMessages
 
-// Amazon Simple Queueing Service (SQS) message structure
+// Amazon Simple Queueing Service (SQS) message structure, used when sent via SNS
 case class AwsSqsMsg (
                        Type: String,
                        MessageId: String,

--- a/app/models/TranscoderMessage.scala
+++ b/app/models/TranscoderMessage.scala
@@ -1,5 +1,7 @@
 package models
 import com.amazonaws.services.elastictranscoder.model.JobOutput
+import com.theguardian.multimedia.archivehunter.common.{StorageClassEncoder, ZonedDateTimeEncoder}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.IngestMessage
 import io.circe._
 import io.circe.parser
 import io.circe.generic.auto._
@@ -42,9 +44,12 @@ case class AwsSqsMsg (
                        Message: String,
                        Timestamp: String,
                      )
- extends TranscoderMessageDecoder {
+ extends TranscoderMessageDecoder with ZonedDateTimeEncoder with StorageClassEncoder {
   def getETSMessage: Either[io.circe.Error, AwsElasticTranscodeMsg] =
     io.circe.parser.parse(Message).flatMap(_.as[AwsElasticTranscodeMsg])
+
+  def getIngestMessge: Either[io.circe.Error, IngestMessage] =
+    io.circe.parser.parse(Message).flatMap(_.as[IngestMessage])
 }
 
 object AwsSqsMsg extends TranscoderMessageDecoder {

--- a/app/services/ClockSingleton.scala
+++ b/app/services/ClockSingleton.scala
@@ -28,6 +28,7 @@ class ClockSingleton @Inject() (@Named("dynamoCapacityActor") dynamoCapacityActo
                                 @Named("etsProxyActor") etsProxyActor:ActorRef,
                                 @Named("bucketScannerActor") bucketScanner:ActorRef,
                                 @Named("jobPurgerActor") jobPurgerActor: ActorRef,
+                                @Named("ingestProxyQueue") ingestProxyQueue: ActorRef,
                                 config:ArchiveHunterConfiguration,
                                ) extends Actor with Timers with ExtValueConverters{
   import ClockSingleton._
@@ -44,6 +45,7 @@ class ClockSingleton @Inject() (@Named("dynamoCapacityActor") dynamoCapacityActo
       logger.debug("ClockSingleton: RapidClockTick")
       dynamoCapacityActor ! DynamoCapacityActor.TimedStateCheck
       etsProxyActor ! ETSProxyActor.CheckForNotifications
+      ingestProxyQueue ! IngestProxyQueue.CheckForNotifications
     case SlowClockTick=>
       logger.debug("ClockSingleton: SlowClockTick")
       etsProxyActor ! ETSProxyActor.CheckPipelinesStatus

--- a/app/services/ETSProxyActor.scala
+++ b/app/services/ETSProxyActor.scala
@@ -122,7 +122,7 @@ object ETSProxyActor {
   */
 class ETSProxyActor @Inject() (implicit config:ArchiveHunterConfiguration,
                                sqsClientMgr:SQSClientManager, etsClientMgr: ETSClientManager, s3ClientMgr:S3ClientManager, esClientMgr:ESClientManager,
-                               scanTargetDAO: ScanTargetDAO, jobModelDAO: JobModelDAO,
+                               scanTargetDAO: ScanTargetDAO, jobModelDAO: JobModelDAO, proxyLocationDAO:ProxyLocationDAO,
                             ddbClientMgr:DynamoClientManager, actorSystem: ActorSystem) extends Actor{
   import ETSProxyActor._
 
@@ -140,8 +140,6 @@ class ETSProxyActor @Inject() (implicit config:ArchiveHunterConfiguration,
   private val sqsClient = sqsClientMgr.getClient(awsProfile)
   private val indexer = new Indexer(config.get[String]("externalData.indexName"))
   var pipelinesToCheck:Seq[WaitingOperation] = Seq()
-
-  implicit val proxyLocationDAO = new ProxyLocationDAO(config.get[String]("proxies.tableName"))
 
   /**
     * recursively check the pipelinesToCheck list, removing from the list any that have become ready

--- a/app/services/IngestProxyQueue.scala
+++ b/app/services/IngestProxyQueue.scala
@@ -1,0 +1,184 @@
+package services
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Status}
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ProxyLocationDAO, ProxyType}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, S3ClientManager, SQSClientManager}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTargetDAO
+import com.theguardian.multimedia.archivehunter.common.cmn_services.ProxyGenerators
+import helpers.ProxyLocator
+import javax.inject.{Inject, Named}
+import models.AwsSqsMsg
+import play.api.{Configuration, Logger}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+object IngestProxyQueue {
+  trait IPQMsg
+
+  case object CheckForNotifications extends IPQMsg
+
+  /* private internal messages */
+  case class HandleNextSqsMessage(rq:ReceiveMessageRequest) extends IPQMsg
+
+  case class CheckRegisteredProxy(entry:ArchiveEntry) extends IPQMsg
+  case class CheckNonRegisteredProxy(entry:ArchiveEntry) extends IPQMsg
+
+  case class CheckRegisteredThumb(entry:ArchiveEntry) extends IPQMsg
+  case class CheckNonRegisteredThumb(entry: ArchiveEntry) extends IPQMsg
+  case class CreateNewThumbnail(entry:ArchiveEntry) extends IPQMsg
+
+}
+
+
+class IngestProxyQueue @Inject() (config:Configuration,
+                                  system:ActorSystem,
+                                  sqsClientManager: SQSClientManager,
+                                  proxyGenerators:ProxyGenerators,
+                                  proxyLocationDAO: ProxyLocationDAO,
+                                  s3ClientMgr:S3ClientManager,
+                                  dynamoClientMgr:DynamoClientManager,
+                                  @Named("etsProxyActor") etsProxyActor:ActorRef
+                                 )(implicit scanTargetDAO: ScanTargetDAO)
+  extends Actor {
+  import IngestProxyQueue._
+  private val logger = Logger(getClass)
+
+  private val sqsClient = sqsClientManager.getClient(config.getOptional[String]("externalData.awsProfile"))
+
+  //override this in testing
+  protected val ipqActor:ActorRef = self
+
+  private implicit val ec:ExecutionContext = system.dispatcher
+
+  private implicit val s3Client = s3ClientMgr.getClient(config.getOptional[String]("externalData.awsProfile"))
+  private implicit val ddbClient = dynamoClientMgr.getClient(config.getOptional[String]("externalData.awsProfile"))
+
+  override def receive: Receive = {
+    case CheckRegisteredThumb(entry)=>
+      val originalSender = sender()
+      proxyLocationDAO.getProxy(entry.id, ProxyType.THUMBNAIL).map({
+        case Some(proxyLocation)=>
+          logger.info(s"${entry.bucket}:${entry.path} already has a registered thumbnail at $proxyLocation")
+          originalSender ! Status.Success
+        case None=>
+          logger.info(s"${entry.bucket}:${entry.path} has no registered thumbnail")
+          ipqActor ! CheckNonRegisteredThumb(entry)
+      }).onComplete({
+        case Success(_)=>()
+        case Failure(err)=>
+          logger.error("Could not look up proxy data: ", err)
+          originalSender ! Status.Failure
+      })
+
+    case CheckNonRegisteredThumb(entry)=>
+      val originalSender = sender()
+      ProxyLocator.findProxyLocation(entry).map(results=>{
+        val foundProxies = results.collect({case Right(loc)=>loc}).filter(loc=>loc.proxyType==ProxyType.THUMBNAIL)
+        if(foundProxies.isEmpty){
+          logger.info(s"${entry.bucket}:${entry.path} has no locatable thumbnails in expected locations. Generating a new one...")
+          ipqActor ! CreateNewThumbnail(entry)
+        } else {
+          logger.info(s"${entry.bucket}:${entry.path}: Found existing potential thumbnails: $foundProxies")
+          //FIXME: should link back to item
+        }
+      }).onComplete({
+        case Success(_)=>()
+        case Failure(err)=>
+          logger.error(s"${entry.bucket}:${entry.path}:  Could not run proxy location find: ", err)
+          originalSender ! Status.Failure
+      })
+
+    case CreateNewThumbnail(entry)=>
+      val originalSender = sender()
+      proxyGenerators.createThumbnailProxy(entry).onComplete({
+        case Success(Success(result))=> //thread completed and we got a result
+          logger.info(s"${entry.bucket}:${entry.path}: started thumbnailing with ECS id $result")
+          originalSender ! Status.Success
+        case Success(Failure(err))=> //thread completed OK but we did not start a job
+          logger.error(s"${entry.bucket}:${entry.path}: Could not start thumbnailing:", err)
+          originalSender ! Status.Failure
+        case Failure(err)=>
+          logger.error(s"${entry.bucket}:${entry.path}: thumbnailing thread failed", err)
+          originalSender ! Status.Failure
+      })
+
+    case CheckNonRegisteredProxy(entry)=>
+      val originalSender = sender()
+      ProxyLocator.findProxyLocation(entry).map(results=>{
+        val foundProxies = results.collect({case Right(loc)=>loc}).filter(loc=>loc.proxyType!=ProxyType.THUMBNAIL)
+        if(foundProxies.isEmpty){
+          logger.info(s"${entry.bucket}:${entry.path} has no locatable proxies in expected locations. Generating a new one...")
+          etsProxyActor ! ETSProxyActor.CreateDefaultMediaProxy(entry)
+        } else {
+          logger.info(s"${entry.bucket}:${entry.path} has unregistered proxies: $foundProxies")
+          //FIXME: need to register proxies here
+        }
+      }).onComplete({
+        case Success(_)=>()
+        case Failure(err)=>
+          logger.error(s"${entry.bucket}:${entry.path}: findProxyLocation failed: ", err)
+          originalSender ! Status.Failure
+      })
+
+    case CheckRegisteredProxy(entry)=>
+      val possibleProxyTypes = Seq(ProxyType.AUDIO, ProxyType.VIDEO)
+      val originalSender = sender()
+
+      Future.sequence(possibleProxyTypes.map(pt=>proxyLocationDAO.getProxy(entry.id,pt))).map(results=>{
+        val validProxies = results.collect({case Some(proxyLocation)=>proxyLocation})
+        println(validProxies.toString)
+        if(validProxies.isEmpty){
+          logger.info(s"${entry.bucket}:${entry.path} has no known proxies, checking for loose...")
+          ipqActor ! CheckNonRegisteredProxy(entry)
+        } else {
+          logger.info(s"${entry.bucket}:${entry.path} has these known proxies: $validProxies")
+          originalSender ! Status.Success
+        }
+      }).onComplete({
+        case Success(_)=>
+          ()
+        case Failure(err)=>
+          logger.error("Could not check for existing proxies", err)
+          originalSender ! Status.Failure
+      })
+
+    //dispatched to pull all messages off the queue. This "recurses" by dispatching itself if there are messages left on the queue.
+    case HandleNextSqsMessage(rq:ReceiveMessageRequest)=>
+      val result = sqsClient.receiveMessage(rq)
+      val msgList = result.getMessages.asScala
+      if(msgList.nonEmpty){
+        msgList.foreach(msg=> {
+          logger.debug(s"Received message ${msg.getMessageId}:")
+          logger.debug(s"\tAttributes: ${msg.getAttributes.asScala}")
+          logger.debug(s"\tReceipt Handle: ${msg.getReceiptHandle}")
+          logger.debug(s"\tBody: ${msg.getBody}")
+
+          AwsSqsMsg.fromJsonString(msg.getBody).flatMap(_.getIngestMessge) match {
+            case Left(err)=>
+              logger.error(s"Could not decode message from queue: $err")
+              sender ! Status.Failure
+            case Right(finalMsg)=>
+              logger.info(s"Received notification of new item: ${finalMsg.archiveEntry}")
+              ipqActor ! CheckRegisteredThumb(finalMsg.archiveEntry)
+              ipqActor ! CheckRegisteredProxy(finalMsg.archiveEntry)
+          }
+        })
+        self ! HandleNextSqsMessage(rq)
+      } else {
+        sender ! Status.Success
+      }
+
+    case CheckForNotifications=>
+      logger.debug("CheckForNotifications")
+      val notificationsQueue=config.get[String]("ingest.notificationsQueue")
+      val rq = new ReceiveMessageRequest().withQueueUrl(notificationsQueue)
+      if(notificationsQueue=="queueUrl"){
+        logger.warn("ingest notifications queue not set up in applications.conf")
+      } else {
+        ipqActor ! HandleNextSqsMessage(rq)
+      }
+  }
+}

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -715,6 +715,7 @@ Resources:
               - sqs:*
             Resource:
               - !GetAtt TranscodeUpdateMsg.Arn
+              - !GetAtt IngestTranscodeMsg.Arn
       - PolicyName: ContainerAccess
         PolicyDocument:
           Version: 2012-10-17

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -1109,4 +1109,9 @@ Outputs:
     Description: URL of the message queue for notifications from the ingest lambda
     Value: !Ref IngestTranscodeMsg
     Export:
-      Name !Sub ${AWS::StackName}-IngestTranscodeMsg
+      Name: !Sub ${AWS::StackName}-IngestTranscodeMsg
+  IngestMessageQueueArn:
+    Description: URL of the message queue for notifications from the ingest lambda
+    Value: !GetAtt IngestTranscodeMsg.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-IngestTranscodeMsgArn

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -490,6 +490,9 @@ Resources:
       Queues:
       - !GetAtt TranscodeUpdateMsg.QueueName
 
+  IngestTranscodeMsg:
+    Type: AWS::SQS::Queue
+
   #Autodowning lambda - receive events from autoscaling to tell us when nodes go away.
   ScalingRule:
     Type: AWS::Events::Rule
@@ -918,6 +921,11 @@ Resources:
              domain = "${DeploymentDomain}"
              userProfileTable = "${UserProfileTable}"
           }
+
+          ingest {
+            notificationsQueue = "${IngestTranscodeMsg.QueueName}"
+          }
+
           akka.actor {
             provider = "cluster"
 
@@ -1097,3 +1105,8 @@ Outputs:
     Value: !GetAtt AccessorSG.GroupId
     Export:
       Name: !Sub ${AWS::StackName}-AccessorSG
+  IngestMessageQueueUrl:
+    Description: URL of the message queue for notifications from the ingest lambda
+    Value: !Ref IngestTranscodeMsg
+    Export:
+      Name !Sub ${AWS::StackName}-IngestTranscodeMsg

--- a/cloudformation/bucketmonitor.yaml
+++ b/cloudformation/bucketmonitor.yaml
@@ -18,7 +18,7 @@ Parameters:
     Description: Deployment stage
   BucketName:
     Type: String
-    Description: Name of the bucket to monitor (lambda will receive read-only access to this)
+    Description: Name of the buckets to monitor (lambda will receive read-only access to this)
   DeploymentBucket:
     Type: String
     Description: Name of the bucket where the deployment is stored
@@ -72,7 +72,7 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !Ref BucketMonitorLambda
       Principal: s3.amazonaws.com
-      SourceArn: !Sub arn:aws:s3:::${BucketName}
+      #SourceArn: !Sub arn:aws:s3:::${BucketName}
 
   MonitorLambdaRole:
     Type: AWS::IAM::Role
@@ -103,6 +103,11 @@ Resources:
                 - ec2:DescribeNetworkInterfaces
                 - ec2:DeleteNetworkInterface
               Resource: "*"
+            - Effect: Allow
+              Action:
+                - sqs:SendMessage
+              Resource:
+                - Fn::ImportValue: !Sub ${ArchiveHunterAppStack}-IngestTranscodeMsgArn
             - Effect: Allow
               Action:
                 - logs:CreateLogGroup

--- a/cloudformation/bucketmonitor.yaml
+++ b/cloudformation/bucketmonitor.yaml
@@ -46,6 +46,8 @@ Resources:
               - "https://"
               - Fn::ImportValue: !Sub ${ArchiveHunterAppStack}-ESEndpoint
               - ":443"
+          NOTIFICATION_QUEUE:
+            Fn::ImportValue: !Sub ${ArchiveHunterAppStack}-IngestTranscodeMsg
       Handler: InputLambdaMain
       FunctionName: !Sub archivehunter-input-${Stage}
       MemorySize: 768

--- a/cloudformation/bucketmonitor.yaml
+++ b/cloudformation/bucketmonitor.yaml
@@ -72,6 +72,10 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !Ref BucketMonitorLambda
       Principal: s3.amazonaws.com
+      ###This InvokePermission used to have the SourceArn specified. But if you want to monitor lots of buckets,
+      ###you have to set BucketName to * for the policy below.  And that then means that including SourceArn here
+      ###breaks the lambda by not allowing it to trigger.
+      ###Kept in but commented, for future reference.
       #SourceArn: !Sub arn:aws:s3:::${BucketName}
 
   MonitorLambdaRole:

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveEntry.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveEntry.scala
@@ -68,7 +68,7 @@ object ArchiveEntry extends ((String, String, String, Option[String], Long, Zone
 
 case class ArchiveEntry(id:String, bucket: String, path: String, file_extension: Option[String], size: scala.Long, last_modified: ZonedDateTime, etag: String, mimeType: MimeType, proxied: Boolean, storageClass:StorageClass, lightboxEntries:Seq[LightboxIndex], beenDeleted:Boolean=false) {
   private val logger = LogManager.getLogger(getClass)
-  def getProxy(proxyType: ProxyType.Value)(implicit proxyLocationDAO:ProxyLocationDAO, client:AmazonDynamoDBAsync) = proxyLocationDAO.getProxy(id,proxyType)
+  def getProxy(proxyType: ProxyType.Value)(implicit proxyLocationDAO:ProxyLocationDAO, client:DynamoClient) = proxyLocationDAO.getProxy(id,proxyType)
 
   /**
     * register a new proxy against this item.  This operation consists of saving the given proxy id to the proxies table,

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocationDAO.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocationDAO.scala
@@ -2,25 +2,44 @@ package com.theguardian.multimedia.archivehunter.common
 
 import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
+import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
 import com.gu.scanamo.query.UniqueKey
 import com.gu.scanamo.{DynamoFormat, Scanamo, ScanamoAlpakka, Table}
 import com.gu.scanamo.syntax._
+import javax.inject.Inject
+
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ProxyLocationDAO (tableName:String) extends ProxyLocationEncoder {
+class ProxyLocationDAO @Inject() (config:ArchiveHunterConfiguration) extends ProxyLocationEncoder {
   import com.gu.scanamo.syntax._
 
+  val tableName = config.get[String]("proxies.tableName")
   val table = Table[ProxyLocation](tableName)
   val proxyIdIndex = table.index("proxyIdIndex")
 
-  def getProxy(fileId: String, proxyType: ProxyType.Value)(implicit client:AmazonDynamoDBAsync):Future[Option[ProxyLocation]] = Future {
-    Scanamo.exec(client)(table.get('fileId->fileId and ('proxyType->proxyType.toString))).map({
-      case Left(err)=>throw new RuntimeException(err.toString)
-      case Right(location)=>location
+  /**
+    * Look up a proxy by main media ID and proxy type. This is the main method of locating proxies.
+    * @param fileId ID of the main media, same as appears in the ES index
+    * @param proxyType [[ProxyType]] value that indentifies the type of proxy we are looking for
+    * @param client implicitly provided (alpakka) DynamoDB client
+    * @return a Future that contains an Option. The Option is empty if no proxy is available or populated if one was found.
+    *         the future fails on a DB error; use recoverWith to process this.
+    */
+  def getProxy(fileId: String, proxyType: ProxyType.Value)(implicit client:DynamoClient):Future[Option[ProxyLocation]] =
+    ScanamoAlpakka.exec(client)(table.get('fileId->fileId and ('proxyType->proxyType.toString))).map({
+      case Some(Left(err))=>throw new RuntimeException(err.toString)
+      case Some(Right(location))=>Some(location)
+      case None=>None
     })
-  }
 
+  /**
+    * Look up proxy by proxy ID
+    * @param proxyId proxyID to look up
+    * @param client implicitly provided (alpakka) Dynamo client
+    * @return a Future that contains an Optioon. The Option is empty if no proxy is availalble or populated if one was found.
+    *         the future fails on a DB error; use recoverWith to process this.
+    */
   def getProxyByProxyId(proxyId:String)(implicit client:DynamoClient):Future[Option[ProxyLocation]] =
     ScanamoAlpakka.exec(client)(proxyIdIndex.query('proxyId->proxyId)).map(_.map({
       case Left(err)=>throw new RuntimeException(err.toString)
@@ -28,9 +47,52 @@ class ProxyLocationDAO (tableName:String) extends ProxyLocationEncoder {
     })).map(_.headOption) //the index should ensure that there is only one id with this value
 
 
+  /**
+    * Write the given [[ProxyLocation]] record to the database.  This will over-write any existing record with the same IDs.
+    * @param proxy [[ProxyLocation]] record to write
+    * @param client implicitly provided (alpakka) Dynamo client
+    * @return a Future containing an Option with either a DB error or a record.  Either None or Some(Right) indicates success.
+    */
   def saveProxy(proxy: ProxyLocation)(implicit client:DynamoClient) =
     ScanamoAlpakka.exec(client)(
       table.put(proxy)
     )
 
+  /**
+    * Delete the given [[ProxyLocation]] record by proxy ID.  This requires an initial lookup and then deletion on the main
+    * table's key
+    * @param proxyId proxy ID to delete
+    * @param client implicitly provided (alpakka) Dynamo client
+    * @return a Future containing either an error string or a DeleteItemResult.
+    */
+  def deleteProxyRecord(proxyId:String)(implicit client:DynamoClient):Future[Either[String,DeleteItemResult]] =
+    ScanamoAlpakka.exec(client)(
+      proxyIdIndex.query('proxyId->proxyId)
+    ).flatMap(results=>{
+      val errors = results.collect({case Left(err)=>err})
+      if(errors.nonEmpty){
+        Future(Left(errors.head.toString))
+      } else {
+        if(results.length>1){
+          Future(Left("Multiple proxy IDs present"))
+        } else {
+          val success = results.collect({case Right(result)=>result})
+          ScanamoAlpakka.exec(client)(
+            table.delete('fileId->success.head.fileId and ('proxyType->success.head.proxyType))
+          ).map(result=>Right(result))
+        }
+      }
+    })
+
+  /**
+    * Delete the give [[ProxyLocation]] record by main master ID and proxy type.
+    * @param fileId main media ID for the proxy location to delete
+    * @param proxyType proxy type to delete
+    * @param client implicitly provided (alpakka) Dynamo client
+    * @return a Future containing a DeleteItemResult
+    */
+  def deleteProxyRecord(fileId:String, proxyType:ProxyType.Value)(implicit client:DynamoClient) =
+    ScanamoAlpakka.exec(client)(
+      table.delete('fileId->fileId and ('proxyType->proxyType.toString))
+    )
 }

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/IngestMessage.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/IngestMessage.scala
@@ -1,0 +1,5 @@
+package com.theguardian.multimedia.archivehunter.common.cmn_models
+
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, MimeType}
+
+case class IngestMessage (archiveEntry:ArchiveEntry, ingestTaskId:String)

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -37,7 +37,7 @@
 
     <logger name="services.AppStartup" level="INFO"/>
     <logger name="services.BucketScanner" level="INFO"/>
-    <logger name="akka.cluster" level="INFO"/>
+    <logger name="akka.cluster" level="ERROR"/>
     <logger name="helpers.S3ToArchiveEntryFlow" level="WARN"/>
     <logger name="helpers.SearchHitToArchiveEntryFlow" level="WARN"/>
     <logger name="helpers.ArchiveEntryVerifyFlow" level="WARN"/>
@@ -70,6 +70,7 @@
     <logger name="services.ProxiesRelinker" level="INFO"/>
     <logger name="helpers.ProxyVerifyFlow" level="INFO"/>
     <logger name="services.JobPurgerActor" level="DEBUG"/>
+    <logger name="services.IngestProxyQueue" level="DEBUG"/>
 
     <logger name="requests.JobSearchRequest" level="DEBUG"/>
 

--- a/lambda/autodowning/src/main/scala/AutoDowningLambdaMain.scala
+++ b/lambda/autodowning/src/main/scala/AutoDowningLambdaMain.scala
@@ -86,7 +86,6 @@ class AutoDowningLambdaMain extends RequestHandler[java.util.LinkedHashMap[Strin
     * @param instance instance of the `Instance` class from EC2. Get this by calling `getEc2Info`
     * @return a Sequence of `Tag` instances.
     */
-  //def getEc2Tags(instance:Instance):Seq[Tag] = instance.getTags.asScala
   def getEc2Tags(instance:Instance):Seq[TagDescription] = {
     val rq = new DescribeTagsRequest().withFilters(
       new Filter().withName("resource-id").withValues(instance.getInstanceId),

--- a/lambda/input/src/main/scala/InputLambdaMain.scala
+++ b/lambda/input/src/main/scala/InputLambdaMain.scala
@@ -57,7 +57,6 @@ class InputLambdaMain extends RequestHandler[S3Event, Unit] with DocId with Zone
     val rq = new SendMessageRequest()
       .withQueueUrl(getNotificationQueue)
       .withMessageBody(msg.asJson.toString())
-      .withMessageDeduplicationId(taskId)
 
     val r = client.sendMessage(rq)
     println(s"Send message with ID ${r.getMessageId}")

--- a/lambda/input/src/main/scala/InputLambdaMain.scala
+++ b/lambda/input/src/main/scala/InputLambdaMain.scala
@@ -1,19 +1,15 @@
 import java.time.ZonedDateTime
-import java.util.UUID
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.amazonaws.services.lambda.runtime.events.S3Event
 import com.amazonaws.services.s3.event.S3EventNotification
-import com.amazonaws.services.s3.event.S3EventNotification.S3ObjectEntity
 import com.amazonaws.services.s3.model.{ObjectMetadata, S3Object}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
-import com.amazonaws.services.sqs
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
 import com.amazonaws.services.sqs.model.SendMessageRequest
 import com.google.inject.Guice
 import com.theguardian.multimedia.archivehunter.common._
 import org.apache.logging.log4j.LogManager
-import com.sksamuel.elastic4s.ElasticsearchClientUri
 import com.sksamuel.elastic4s.http.{HttpClient, HttpRequestClient}
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{IngestMessage, JobModelDAO, JobStatus}
 import org.apache.http.HttpHost

--- a/lambda/input/src/main/scala/InputLambdaMain.scala
+++ b/lambda/input/src/main/scala/InputLambdaMain.scala
@@ -1,4 +1,5 @@
 import java.time.ZonedDateTime
+import java.util.UUID
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.amazonaws.services.lambda.runtime.events.S3Event
@@ -6,14 +7,19 @@ import com.amazonaws.services.s3.event.S3EventNotification
 import com.amazonaws.services.s3.event.S3EventNotification.S3ObjectEntity
 import com.amazonaws.services.s3.model.{ObjectMetadata, S3Object}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.sqs
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import com.amazonaws.services.sqs.model.SendMessageRequest
 import com.google.inject.Guice
-import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, DocId, Indexer, MimeType}
+import com.theguardian.multimedia.archivehunter.common._
 import org.apache.logging.log4j.LogManager
 import com.sksamuel.elastic4s.ElasticsearchClientUri
 import com.sksamuel.elastic4s.http.{HttpClient, HttpRequestClient}
-import com.theguardian.multimedia.archivehunter.common.cmn_models.{JobModelDAO, JobStatus}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.{IngestMessage, JobModelDAO, JobStatus}
 import org.apache.http.HttpHost
 import org.elasticsearch.client.RestClient
+import io.circe.syntax._
+import io.circe.generic.auto._
 
 import collection.JavaConverters._
 import scala.concurrent.{Await, Future}
@@ -21,7 +27,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class InputLambdaMain extends RequestHandler[S3Event, Unit] with DocId {
+class InputLambdaMain extends RequestHandler[S3Event, Unit] with DocId with ZonedDateTimeEncoder with StorageClassEncoder {
   private final val logger = LogManager.getLogger(getClass)
 
   private val injector = Guice.createInjector(new Module)
@@ -37,9 +43,25 @@ class InputLambdaMain extends RequestHandler[S3Event, Unit] with DocId {
     HttpClient.fromRestClient(esClient)
   }
 
+  protected def getSqsClient() = AmazonSQSClientBuilder.defaultClient()
+
   protected def getIndexer(indexName: String) = new Indexer(indexName)
 
   protected def getJobModelDAO = injector.getInstance(classOf[JobModelDAO])
+
+  def sendIngestedMessage(entry:ArchiveEntry) = {
+    val client = getSqsClient()
+    val taskId = entry.id
+    println(s"Ingest has task ID $taskId")
+    val msg = IngestMessage(entry, taskId)
+    val rq = new SendMessageRequest()
+      .withQueueUrl(getNotificationQueue)
+      .withMessageBody(msg.asJson.toString())
+      .withMessageDeduplicationId(taskId)
+
+    val r = client.sendMessage(rq)
+    println(s"Send message with ID ${r.getMessageId}")
+  }
 
   /**
     * returns a user-friendly string representing the event data, for debugging
@@ -64,6 +86,7 @@ class InputLambdaMain extends RequestHandler[S3Event, Unit] with DocId {
       case other:Throwable=>throw other
     }
   }
+
   /**
     * deal with an item created notification by adding it to the index
     * @param rec S3EventNotification record describing the event
@@ -86,15 +109,16 @@ class InputLambdaMain extends RequestHandler[S3Event, Unit] with DocId {
 
     ArchiveEntry.fromS3(rec.getS3.getBucket.getName, rec.getS3.getObject.getKey).flatMap(entry => {
       println(s"Going to index $entry")
-      i.indexSingleItem(entry)
-    }).map({
-      case Success(indexid) =>
-        println(s"Document indexed with ID $indexid")
-        indexid
-      case Failure(exception) =>
-        println(s"Could not index document: ${exception.toString}")
-        exception.printStackTrace()
-        throw exception //fail this future so we enter the recover block below
+      i.indexSingleItem(entry).map({
+        case Success(indexid) =>
+          println(s"Document indexed with ID $indexid")
+          sendIngestedMessage(entry)
+          indexid
+        case Failure(exception) =>
+          println(s"Could not index document: ${exception.toString}")
+          exception.printStackTrace()
+          throw exception //fail this future so we enter the recover block below
+      })
     })
   }
 
@@ -158,6 +182,16 @@ class InputLambdaMain extends RequestHandler[S3Event, Unit] with DocId {
         })
       }
     })
+  }
+
+  protected def getNotificationQueue = sys.env.get("NOTIFICATION_QUEUE") match {
+    case Some(name)=>name
+    case None=>
+      Option(System.getProperty("NOTIFICATION_QUEUE")) match {
+        case Some(name)=>name
+        case None=>
+          throw new RuntimeException("You must specify NOTIFICATION_QUEUE in the environment")
+      }
   }
 
   protected def getIndexName = sys.env.get("INDEX_NAME") match {

--- a/lambda/input/src/test/scala/InputLambdaMainSpec.scala
+++ b/lambda/input/src/test/scala/InputLambdaMainSpec.scala
@@ -142,7 +142,6 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
       val expectedMessageRequest = new SendMessageRequest()
         .withQueueUrl("fake-queue")
         .withMessageBody(IngestMessage(testEntry,"test-id").asJson.toString())
-        .withMessageDeduplicationId("test-id")
 
       test.sendIngestedMessage(testEntry)
       there was one(mockSqsClient).sendMessage(expectedMessageRequest)

--- a/lambda/input/src/test/scala/InputLambdaMainSpec.scala
+++ b/lambda/input/src/test/scala/InputLambdaMainSpec.scala
@@ -6,14 +6,18 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.event.S3EventNotification
 import com.amazonaws.services.s3.event.S3EventNotification._
 import com.sksamuel.elastic4s.http.HttpClient
-import com.theguardian.multimedia.archivehunter.common.Indexer
+import com.theguardian.multimedia.archivehunter.common._
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.s3.model.ObjectMetadata
-import com.theguardian.multimedia.archivehunter.common.cmn_models.{JobModel, JobModelDAO, JobStatus, SourceType}
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.{SendMessageRequest, SendMessageResult}
+import com.theguardian.multimedia.archivehunter.common.cmn_models._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
+import io.circe.syntax._
+import io.circe.generic.auto._
 
 import collection.JavaConverters._
 import scala.concurrent.Future
@@ -23,10 +27,10 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 @RunWith(classOf[JUnitRunner])
-class InputLambdaMainSpec extends Specification with Mockito {
+class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeEncoder with StorageClassEncoder {
 
   "InputLambdaMain" should {
-    "call to index an item delivered via an S3Event" in {
+    "call to index an item delivered via an S3Event then call to dispatch a message to the main app" in {
       val fakeEvent = new S3Event(Seq(
         new S3EventNotificationRecord("aws-fake-region","ObjectCreated:Put","unit_test",
         "2018-01-01T11:12:13.000Z","1",
@@ -40,6 +44,8 @@ class InputLambdaMainSpec extends Specification with Mockito {
 
       val fakeContext = mock[Context]
       val mockIndexer = mock[Indexer]
+      val mockSendIngestedMessage = mock[Function1[ArchiveEntry, Unit]]
+
       mockIndexer.indexSingleItem(any,any,any)(any).returns(Future(Success("fake-entry-id")))
       val test = new InputLambdaMain {
         override protected def getElasticClient(clusterEndpoint: String): HttpClient = {
@@ -47,6 +53,8 @@ class InputLambdaMainSpec extends Specification with Mockito {
 
           m
         }
+
+        override def sendIngestedMessage(entry:ArchiveEntry) = mockSendIngestedMessage(entry)
 
         override protected def getClusterEndpoint = "testClusterEndpoint"
 
@@ -73,7 +81,7 @@ class InputLambdaMainSpec extends Specification with Mockito {
           ex.printStackTrace()
           throw ex
       }
-      1 mustEqual 1 //the actual test is that handleRequest does not raise an error
+      there was one(mockSendIngestedMessage).apply(any)
     }
   }
 
@@ -103,5 +111,41 @@ class InputLambdaMainSpec extends Specification with Mockito {
       there were two(mockDao).putJob(any[JobModel])
     }
 
+  }
+
+  "InputLambdaMain.sendIngestedMessage" should {
+    "send a message to SQS containing the created entry" in {
+      val testEntry = ArchiveEntry(
+        "test-id",
+        "fake-bucket",
+        "/path/to/file",
+        Some(".ext"),
+        1234L,
+        ZonedDateTime.now(),
+        "fake-etag",
+        MimeType("video","mp4"),
+        false,
+        StorageClass.STANDARD,
+        Seq(),
+        false
+      )
+
+      val mockSqsClient = mock[AmazonSQS]
+      val mockedResult = new SendMessageResult().withMessageId("fake-message-id")
+      mockSqsClient.sendMessage(any[SendMessageRequest]) returns mockedResult
+
+      val test = new InputLambdaMain {
+        override protected def getSqsClient() = mockSqsClient
+        override protected def getNotificationQueue() = "fake-queue"
+      }
+
+      val expectedMessageRequest = new SendMessageRequest()
+        .withQueueUrl("fake-queue")
+        .withMessageBody(IngestMessage(testEntry,"test-id").asJson.toString())
+        .withMessageDeduplicationId("test-id")
+
+      test.sendIngestedMessage(testEntry)
+      there was one(mockSqsClient).sendMessage(expectedMessageRequest)
+    }
   }
 }

--- a/test/IngestProxyQueueSpec.scala
+++ b/test/IngestProxyQueueSpec.scala
@@ -399,26 +399,14 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
           .withReceiptHandle("fake1")
           .withMessageAttributes(Map().asInstanceOf[Map[String,MessageAttributeValue]].asJava)
           .withBody(
-            AwsSqsMsg(
-              "faketype",
-              "id-msg-1",
-              "fakearn",
-              "",
               IngestMessage(fakeEntry1,"fake-id-1").asJson.toString,
-              "notime"
-            ).asJson.toString),
+          ),
         new Message().withMessageId("fake-message-2")
           .withReceiptHandle("fake2")
           .withMessageAttributes(Map().asInstanceOf[Map[String,MessageAttributeValue]].asJava)
           .withBody(
-            AwsSqsMsg(
-              "faketype",
-              "id-msg-1",
-              "fakearn",
-              "",
-              IngestMessage(fakeEntry2,"fake-id-2").asJson.toString,
-              "notime"
-            ).asJson.toString)
+              IngestMessage(fakeEntry2,"fake-id-2").asJson.toString
+          )
       ).asJavaCollection
 
       val msgResponse = new ReceiveMessageResult().withMessages(msgList)

--- a/test/IngestProxyQueueSpec.scala
+++ b/test/IngestProxyQueueSpec.scala
@@ -1,4 +1,5 @@
 import java.time.ZonedDateTime
+
 import akka.actor.Props
 import akka.testkit.TestProbe
 import com.theguardian.multimedia.archivehunter.common._
@@ -10,6 +11,7 @@ import org.specs2.mutable.Specification
 import play.api.Configuration
 import services.IngestProxyQueue
 import akka.pattern.ask
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBAsync}
 import com.amazonaws.services.sqs.AmazonSQS
 import com.amazonaws.services.sqs.model._
@@ -32,16 +34,16 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       val testConfig = Configuration.empty
       val mockSqsClientMgr = mock[SQSClientManager]
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
-      val mockDDBClient = mock[AmazonDynamoDBAsync]
-      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockDDBClient = mock[DynamoClient]
+      mockDDBlientMgr.getNewAlpakkaDynamoClient(any)(any, any) returns mockDDBClient
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -65,16 +67,16 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       val testConfig = Configuration.empty
       val mockSqsClientMgr = mock[SQSClientManager]
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
-      val mockDDBClient = mock[AmazonDynamoDBAsync]
-      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockDDBClient = mock[DynamoClient]
+      mockDDBlientMgr.getNewAlpakkaDynamoClient(any)(any, any) returns mockDDBClient
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -97,16 +99,16 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       val testConfig = Configuration.empty
       val mockSqsClientMgr = mock[SQSClientManager]
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
-      val mockDDBClient = mock[AmazonDynamoDBAsync]
-      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockDDBClient = mock[DynamoClient]
+      mockDDBlientMgr.getNewAlpakkaDynamoClient(any)(any, any) returns mockDDBClient
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -134,17 +136,17 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       val testConfig = Configuration.empty
       val mockSqsClientMgr = mock[SQSClientManager]
       val mockProxyGenerators = mock[ProxyGenerators]
-      mockProxyGenerators.createThumbnailProxy(any[ArchiveEntry]) returns Future(Success("fake-job-id"))
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      mockProxyGenerators.createThumbnailProxy(any[ArchiveEntry])(any) returns Future(Success("fake-job-id"))
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
-      val mockDDBClient = mock[AmazonDynamoDBAsync]
-      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockDDBClient = mock[DynamoClient]
+      mockDDBlientMgr.getNewAlpakkaDynamoClient(any)(any, any) returns mockDDBClient
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -167,17 +169,17 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       val testConfig = Configuration.empty
       val mockSqsClientMgr = mock[SQSClientManager]
       val mockProxyGenerators = mock[ProxyGenerators]
-      mockProxyGenerators.createThumbnailProxy(any[ArchiveEntry]) returns Future(Failure(new RuntimeException("boo!")))
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      mockProxyGenerators.createThumbnailProxy(any[ArchiveEntry])(any) returns Future(Failure(new RuntimeException("boo!")))
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
-      val mockDDBClient = mock[AmazonDynamoDBAsync]
-      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockDDBClient = mock[DynamoClient]
+      mockDDBlientMgr.getNewAlpakkaDynamoClient(any)(any, any) returns mockDDBClient
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -199,18 +201,18 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       implicit val timeout:akka.util.Timeout = 30 seconds
       val testConfig = Configuration.empty
       val mockSqsClientMgr = mock[SQSClientManager]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockProxyGenerators = mock[ProxyGenerators]
-      mockProxyGenerators.createThumbnailProxy(any[ArchiveEntry]) returns Future.failed(new RuntimeException("my hovercraft is full of eels"))
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      mockProxyGenerators.createThumbnailProxy(any[ArchiveEntry])(any) returns Future.failed(new RuntimeException("my hovercraft is full of eels"))
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
-      val mockDDBClient = mock[AmazonDynamoDBAsync]
-      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockDDBClient = mock[DynamoClient]
+      mockDDBlientMgr.getNewAlpakkaDynamoClient(any)(any, any) returns mockDDBClient
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -237,16 +239,16 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       val testConfig = Configuration.empty
       val mockSqsClientMgr = mock[SQSClientManager]
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
-      val mockDDBClient = mock[AmazonDynamoDBAsync]
-      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockDDBClient = mock[DynamoClient]
+      mockDDBlientMgr.getNewAlpakkaDynamoClient(any)(any, any) returns mockDDBClient
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -269,16 +271,16 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       val testConfig = Configuration.empty
       val mockSqsClientMgr = mock[SQSClientManager]
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
-      val mockDDBClient = mock[AmazonDynamoDBAsync]
-      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockDDBClient = mock[DynamoClient]
+      mockDDBlientMgr.getNewAlpakkaDynamoClient(any)(any, any) returns mockDDBClient
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -304,16 +306,16 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       val testConfig = Configuration.empty
       val mockSqsClientMgr = mock[SQSClientManager]
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
-      val mockDDBClient = mock[AmazonDynamoDBAsync]
-      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockDDBClient = mock[DynamoClient]
+      mockDDBlientMgr.getNewAlpakkaDynamoClient(any)(any, any) returns mockDDBClient
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -344,14 +346,14 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       mockSqsClientMgr.getClient(any) returns mockSqsClient
 
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -375,14 +377,14 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       mockSqsClientMgr.getClient(any) returns mockSqsClient
 
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -448,14 +450,14 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       mockSqsClientMgr.getClient(any) returns mockSqsClient
 
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))
@@ -476,14 +478,14 @@ class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTime
       mockSqsClientMgr.getClient(any) returns mockSqsClient
 
       val mockProxyGenerators = mock[ProxyGenerators]
-      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      implicit val mockProxyLocationDAO = mock[ProxyLocationDAO]
       val mockS3ClientMgr = mock[S3ClientManager]
       val mockDDBlientMgr = mock[DynamoClientManager]
       val mockEtsProxyActor = TestProbe()
       implicit val mockScanTargetDAO = mock[ScanTargetDAO]
       val mockedSelf = TestProbe()
 
-      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockS3ClientMgr,
         mockDDBlientMgr, mockEtsProxyActor.ref) {
         override protected val ipqActor = mockedSelf.ref
       }))

--- a/test/IngestProxyQueueSpec.scala
+++ b/test/IngestProxyQueueSpec.scala
@@ -1,8 +1,9 @@
+import java.time.ZonedDateTime
 import akka.actor.Props
 import akka.testkit.TestProbe
-import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ProxyLocation, ProxyLocationDAO, ProxyType}
+import com.theguardian.multimedia.archivehunter.common._
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, S3ClientManager, SQSClientManager}
-import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTargetDAO
+import com.theguardian.multimedia.archivehunter.common.cmn_models.{IngestMessage, ScanTargetDAO}
 import com.theguardian.multimedia.archivehunter.common.cmn_services.ProxyGenerators
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
@@ -10,12 +11,18 @@ import play.api.Configuration
 import services.IngestProxyQueue
 import akka.pattern.ask
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBAsync}
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model._
+import io.circe.syntax._
+import io.circe.generic.auto._
+import models.AwsSqsMsg
 
+import scala.collection.JavaConverters._
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class IngestProxyQueueSpec extends Specification with Mockito {
+class IngestProxyQueueSpec extends Specification with Mockito with ZonedDateTimeEncoder with StorageClassEncoder {
   sequential
 
   "IngestProxyQueue!CheckRegisteredThumb" should {
@@ -327,5 +334,163 @@ class IngestProxyQueueSpec extends Specification with Mockito {
     }
   }
 
+  "IngestProxyQueue!HandleNextSqsMessage" should {
+    "reply Success if the message list is empty" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockSqsClient = mock[AmazonSQS]
+      mockSqsClientMgr.getClient(any) returns mockSqsClient
 
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val rq = new ReceiveMessageRequest()
+      val msgList:java.util.Collection[Message] = Seq().asJavaCollection
+
+      val msgResponse = new ReceiveMessageResult().withMessages(msgList)
+      mockSqsClient.receiveMessage(rq) returns msgResponse
+      val response = Await.result(toTest ? IngestProxyQueue.HandleNextSqsMessage(rq), 30 seconds)
+
+      response mustEqual akka.actor.Status.Success
+    }
+
+    "dispatch CheckRegisteredThumb and CheckRegisteredProxy for each message, then dispatch HandleNextSqsMessage again" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockSqsClient = mock[AmazonSQS]
+      mockSqsClientMgr.getClient(any) returns mockSqsClient
+
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      //the match fails if you don't use withFixedOffsetZone as somewhere in the marshalling/unmarshalling the zone info is changed
+      val fakeEntry1 = ArchiveEntry("fake-id-1","fakebucket","/path/to/file",Some(".ext"),1234L,ZonedDateTime.now().withFixedOffsetZone(),"etag",MimeType("video","mp4"),false,StorageClass.STANDARD_IA,Seq(),false)
+      val fakeEntry2 = ArchiveEntry("fake-id-2","fakebucket","/path/to/file2",Some(".ext"),1234L,ZonedDateTime.now().withFixedOffsetZone(),"etag2",MimeType("video","mp4"),false,StorageClass.STANDARD_IA,Seq(),false)
+
+      val rq = new ReceiveMessageRequest()
+      val msgList:java.util.Collection[Message] = Seq(
+        new Message().withMessageId("fake-message-1")
+          .withReceiptHandle("fake1")
+          .withMessageAttributes(Map().asInstanceOf[Map[String,MessageAttributeValue]].asJava)
+          .withBody(
+            AwsSqsMsg(
+              "faketype",
+              "id-msg-1",
+              "fakearn",
+              "",
+              IngestMessage(fakeEntry1,"fake-id-1").asJson.toString,
+              "notime"
+            ).asJson.toString),
+        new Message().withMessageId("fake-message-2")
+          .withReceiptHandle("fake2")
+          .withMessageAttributes(Map().asInstanceOf[Map[String,MessageAttributeValue]].asJava)
+          .withBody(
+            AwsSqsMsg(
+              "faketype",
+              "id-msg-1",
+              "fakearn",
+              "",
+              IngestMessage(fakeEntry2,"fake-id-2").asJson.toString,
+              "notime"
+            ).asJson.toString)
+      ).asJavaCollection
+
+      val msgResponse = new ReceiveMessageResult().withMessages(msgList)
+      mockSqsClient.receiveMessage(rq) returns msgResponse
+      mockSqsClient.deleteMessage(any) returns new DeleteMessageResult()
+
+      toTest ! IngestProxyQueue.HandleNextSqsMessage(rq)
+
+      mockedSelf.expectMsg(IngestProxyQueue.CheckRegisteredThumb(fakeEntry1))
+      mockedSelf.expectMsg(IngestProxyQueue.CheckRegisteredProxy(fakeEntry1))
+
+      mockedSelf.expectMsg(IngestProxyQueue.CheckRegisteredThumb(fakeEntry2))
+      mockedSelf.expectMsg(IngestProxyQueue.CheckRegisteredProxy(fakeEntry2))
+
+      mockedSelf.expectMsg(IngestProxyQueue.HandleNextSqsMessage(rq))
+
+      there was one(mockSqsClient).deleteMessage(new DeleteMessageRequest().withQueueUrl(rq.getQueueUrl).withReceiptHandle("fake1"))
+      there was one(mockSqsClient).deleteMessage(new DeleteMessageRequest().withQueueUrl(rq.getQueueUrl).withReceiptHandle("fake2"))
+    }
+  }
+
+  "IngestProxyQueue!CheckForNotifications" should {
+    "construct an SQS request and dispatch HandleNextSqsMessage" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.from(Map("ingest.notificationsQueue"->"testQueueUrl"))
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockSqsClient = mock[AmazonSQS]
+      mockSqsClientMgr.getClient(any) returns mockSqsClient
+
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      toTest ! IngestProxyQueue.CheckForNotifications
+
+      mockedSelf.expectMsg(IngestProxyQueue.HandleNextSqsMessage(new ReceiveMessageRequest().withQueueUrl("testQueueUrl")
+        .withWaitTimeSeconds(10)
+        .withMaxNumberOfMessages(10)))
+    }
+
+    "dispatch failure if the queue name is set to default value" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.from(Map("ingest.notificationsQueue"->"queueUrl"))
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockSqsClient = mock[AmazonSQS]
+      mockSqsClientMgr.getClient(any) returns mockSqsClient
+
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val result = Await.result(toTest ? IngestProxyQueue.CheckForNotifications, 10 seconds)
+      result mustEqual akka.actor.Status.Failure
+      mockedSelf.expectNoMessage()
+    }
+  }
 }

--- a/test/IngestProxyQueueSpec.scala
+++ b/test/IngestProxyQueueSpec.scala
@@ -1,0 +1,331 @@
+import akka.actor.Props
+import akka.testkit.TestProbe
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ProxyLocation, ProxyLocationDAO, ProxyType}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, S3ClientManager, SQSClientManager}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTargetDAO
+import com.theguardian.multimedia.archivehunter.common.cmn_services.ProxyGenerators
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import play.api.Configuration
+import services.IngestProxyQueue
+import akka.pattern.ask
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBAsync}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+class IngestProxyQueueSpec extends Specification with Mockito {
+  sequential
+
+  "IngestProxyQueue!CheckRegisteredThumb" should {
+    "request location from proxyLocationDAO and return Success with no further action if a thumb exists" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockDDBClient = mock[AmazonDynamoDBAsync]
+      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val mockProxyLocation = mock[ProxyLocation]
+      mockProxyLocationDAO.getProxy(anyString,any)(any) returns Future(Some(mockProxyLocation))
+
+      val mockEntry = mock[ArchiveEntry]
+      mockEntry.id returns "fake-id"
+
+      mockedSelf.expectNoMessage(2 seconds)
+      val result = Await.result(toTest ? IngestProxyQueue.CheckRegisteredThumb(mockEntry), 30 seconds)
+      there was one(mockProxyLocationDAO).getProxy("fake-id",ProxyType.THUMBNAIL)(mockDDBClient)
+
+      result mustEqual akka.actor.Status.Success
+    }
+
+    "request location from proxyLocationDAO and dispatch CheckNonRegisteredThumb if no thumb exists" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockDDBClient = mock[AmazonDynamoDBAsync]
+      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val mockProxyLocation = mock[ProxyLocation]
+      mockProxyLocationDAO.getProxy(anyString,any)(any) returns Future(None)
+
+      val mockEntry = mock[ArchiveEntry]
+      mockEntry.id returns "fake-id"
+
+      toTest ! IngestProxyQueue.CheckRegisteredThumb(mockEntry)
+
+      mockedSelf.expectMsg(IngestProxyQueue.CheckNonRegisteredThumb(mockEntry))
+      there was one(mockProxyLocationDAO).getProxy("fake-id",ProxyType.THUMBNAIL)(mockDDBClient)
+    }
+
+    "signal a failure if the proxyLocationDAO lookup fails" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockDDBClient = mock[AmazonDynamoDBAsync]
+      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val mockProxyLocation = mock[ProxyLocation]
+      mockProxyLocationDAO.getProxy(anyString,any)(any) returns Future.failed(new RuntimeException("my hovercraft is full of eels"))
+
+      val mockEntry = mock[ArchiveEntry]
+      mockEntry.id returns "fake-id"
+
+      mockedSelf.expectNoMessage(2 seconds)
+      val result = Await.result(toTest ? IngestProxyQueue.CheckRegisteredThumb(mockEntry), 30 seconds)
+      there was one(mockProxyLocationDAO).getProxy("fake-id",ProxyType.THUMBNAIL)(mockDDBClient)
+
+      result mustEqual akka.actor.Status.Failure
+    }
+  }
+
+  //can't test CheckNonRegisteredThumb at present since it relies on a static object method
+
+  "IngestProxyQueue!CreateNewThumbnail" should {
+    "call out to ProxyGenerators to initiate job and return success" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockProxyGenerators = mock[ProxyGenerators]
+      mockProxyGenerators.createThumbnailProxy(any[ArchiveEntry]) returns Future(Success("fake-job-id"))
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockDDBClient = mock[AmazonDynamoDBAsync]
+      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val mockProxyLocation = mock[ProxyLocation]
+
+      val mockEntry = mock[ArchiveEntry]
+      mockEntry.id returns "fake-id"
+
+      mockedSelf.expectNoMessage(2 seconds)
+      val result = Await.result(toTest ? IngestProxyQueue.CreateNewThumbnail(mockEntry), 30 seconds)
+      there was one(mockProxyGenerators).createThumbnailProxy(mockEntry)
+
+      result mustEqual akka.actor.Status.Success
+    }
+
+    "return failure if the job does not trigger" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockProxyGenerators = mock[ProxyGenerators]
+      mockProxyGenerators.createThumbnailProxy(any[ArchiveEntry]) returns Future(Failure(new RuntimeException("boo!")))
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockDDBClient = mock[AmazonDynamoDBAsync]
+      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val mockProxyLocation = mock[ProxyLocation]
+
+      val mockEntry = mock[ArchiveEntry]
+      mockEntry.id returns "fake-id"
+
+      mockedSelf.expectNoMessage(2 seconds)
+      val result = Await.result(toTest ? IngestProxyQueue.CreateNewThumbnail(mockEntry), 30 seconds)
+      there was one(mockProxyGenerators).createThumbnailProxy(mockEntry)
+
+      result mustEqual akka.actor.Status.Failure
+    }
+
+    "return failure if the ProxyGenerators thread crashes" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockProxyGenerators = mock[ProxyGenerators]
+      mockProxyGenerators.createThumbnailProxy(any[ArchiveEntry]) returns Future.failed(new RuntimeException("my hovercraft is full of eels"))
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockDDBClient = mock[AmazonDynamoDBAsync]
+      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val mockProxyLocation = mock[ProxyLocation]
+
+      val mockEntry = mock[ArchiveEntry]
+      mockEntry.id returns "fake-id"
+
+      mockedSelf.expectNoMessage(2 seconds)
+      val result = Await.result(toTest ? IngestProxyQueue.CreateNewThumbnail(mockEntry), 30 seconds)
+      there was one(mockProxyGenerators).createThumbnailProxy(mockEntry)
+
+      result mustEqual akka.actor.Status.Failure
+    }
+  }
+
+  //can't test CheckNonRegisteredProxy at the moment because it uses a static object
+
+  "IngestProxyQueue!CheckRegisteredProxy" should {
+    "call to ProxyLocationDAO for video and audio proxies and dispatch CheckNonRegisteredProxy if neither is present" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockDDBClient = mock[AmazonDynamoDBAsync]
+      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val mockProxyLocation = mock[ProxyLocation]
+      mockProxyLocationDAO.getProxy(anyString,any)(any) returns Future(None)
+
+      val mockEntry = mock[ArchiveEntry]
+      mockEntry.id returns "fake-id"
+
+      toTest ! IngestProxyQueue.CheckRegisteredProxy(mockEntry)
+      mockedSelf.expectMsg(IngestProxyQueue.CheckNonRegisteredProxy(mockEntry))
+      there was one(mockProxyLocationDAO).getProxy("fake-id",ProxyType.VIDEO)(mockDDBClient)
+      there was one(mockProxyLocationDAO).getProxy("fake-id",ProxyType.AUDIO)(mockDDBClient)
+    }
+
+    "call to ProxyLocationDAO for video and audio proxies and dispatch Success back if either exists" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockDDBClient = mock[AmazonDynamoDBAsync]
+      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val mockProxyLocation = mock[ProxyLocation]
+      mockProxyLocationDAO.getProxy(anyString,any)(any) returns Future(None)
+      mockProxyLocationDAO.getProxy(anyString,org.mockito.Matchers.eq(ProxyType.VIDEO))(any) returns Future(Some(mockProxyLocation))
+
+      val mockEntry = mock[ArchiveEntry]
+      mockEntry.id returns "fake-id"
+
+      val response = Await.result(toTest ? IngestProxyQueue.CheckRegisteredProxy(mockEntry), 30 seconds)
+      mockedSelf.expectNoMessage(1.seconds) //don't need to delay as Await above has Await means we're guaranteed to run this once
+                                            //routine has completed
+      there was one(mockProxyLocationDAO).getProxy("fake-id",ProxyType.VIDEO)(mockDDBClient)
+      there was one(mockProxyLocationDAO).getProxy("fake-id",ProxyType.AUDIO)(mockDDBClient)
+      response mustEqual akka.actor.Status.Success
+    }
+
+    "call to ProxyLocationDAO for video and audio proxies and dispatch Failed back if any future returns a failure" in new AkkaTestkitSpecs2Support {
+      implicit val ec=system.dispatcher
+      implicit val timeout:akka.util.Timeout = 30 seconds
+      val testConfig = Configuration.empty
+      val mockSqsClientMgr = mock[SQSClientManager]
+      val mockProxyGenerators = mock[ProxyGenerators]
+      val mockProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockS3ClientMgr = mock[S3ClientManager]
+      val mockDDBlientMgr = mock[DynamoClientManager]
+      val mockDDBClient = mock[AmazonDynamoDBAsync]
+      mockDDBlientMgr.getClient(any) returns mockDDBClient
+      val mockEtsProxyActor = TestProbe()
+      implicit val mockScanTargetDAO = mock[ScanTargetDAO]
+      val mockedSelf = TestProbe()
+
+      val toTest = system.actorOf(Props(new IngestProxyQueue(testConfig, system, mockSqsClientMgr, mockProxyGenerators, mockProxyLocationDAO, mockS3ClientMgr,
+        mockDDBlientMgr, mockEtsProxyActor.ref) {
+        override protected val ipqActor = mockedSelf.ref
+      }))
+
+      val mockProxyLocation = mock[ProxyLocation]
+      mockProxyLocationDAO.getProxy(anyString,any)(any) returns Future(None)
+      mockProxyLocationDAO.getProxy(anyString,org.mockito.Matchers.eq(ProxyType.VIDEO))(any) returns Future.failed(new RuntimeException("kaboom"))
+
+      val mockEntry = mock[ArchiveEntry]
+      mockEntry.id returns "fake-id"
+
+      val response = Await.result(toTest ? IngestProxyQueue.CheckRegisteredProxy(mockEntry), 30 seconds)
+      mockedSelf.expectNoMessage(1.seconds) //don't need to delay as Await above has Await means we're guaranteed to run this once
+      //routine has completed
+      there was one(mockProxyLocationDAO).getProxy("fake-id",ProxyType.VIDEO)(mockDDBClient)
+      there was one(mockProxyLocationDAO).getProxy("fake-id",ProxyType.AUDIO)(mockDDBClient)
+      response mustEqual akka.actor.Status.Failure
+    }
+  }
+
+
+}


### PR DESCRIPTION
Adds a message queue which is posted to by the input lambda and listened to by the main app.  

The lambda posts when it has successfully added a new piece of media, and the main app responds to the message by triggering transcoding.

Also, ProxyLocationDAO is made injectable like the other DAOs