### PR TITLE
Fix for "deep archive" showing almost no folders

### DIFF
--- a/app/controllers/BrowseCollectionController.scala
+++ b/app/controllers/BrowseCollectionController.scala
@@ -61,11 +61,11 @@ extends AbstractController(controllerComponents) with PanDomainAuthActions with 
 
   /**
     * iterate through the S3 bucket recursively, until there are no more prefixes available.
-    * @param baseRequest
-    * @param s3Client
-    * @param continuationToken
-    * @param currentSummaries
-    * @return
+    * @param baseRequest ListObjectsRequest that contains details of what we want to list. This is updated to add pagination before actual sending to S3
+    * @param s3Client AmazonS3 client object
+    * @param continuationToken Optional continuation token. Defaults to None; for recursion purposes, don't specify when calling
+    * @param currentSummaries List of current ObjectSummary. Defaults to empty sequence; for recursion purposes, don't specify when calling
+    * @return list of folder names ("common prefixes") from the S3 bucket, as a List of strings
     */
   def recurseGetFolders(baseRequest:ListObjectsRequest, s3Client:AmazonS3,
                         continuationToken:Option[String]=None, currentSummaries:Seq[String]=Seq()):Seq[String] =

--- a/frontend/app/browse/BrowseComponent.jsx
+++ b/frontend/app/browse/BrowseComponent.jsx
@@ -8,6 +8,7 @@ import EntryDetails from "../Entry/EntryDetails.jsx";
 import BrowsePathSummary from "./BrowsePathSummary.jsx";
 import SearchManager from '../SearchManager/SearchManager.jsx';
 import CommonSearchView from "../common/CommonSearchView.jsx";
+import LoadingThrobber from "../common/LoadingThrobber.jsx";
 
 class BrowseComponent extends CommonSearchView {
     constructor(props){
@@ -344,6 +345,10 @@ class BrowseComponent extends CommonSearchView {
                         this.state.collectionNames.map(entry=><option id={entry} value={entry}>{entry}</option>)
                     }
                 </select>
+                <div className="fixed-row">
+                    <LoadingThrobber show={this.state.isLoading} small={true} caption="Loading..."/>
+                    <p className="information" style={{display: this.state.treeContents.length>0 || this.state.isLoading ? "none":"inline"}}>no folders to display</p>
+                </div>
                 <a style={{display: "none"}} onClick={this.doCancelAll}>{this.state.cancelUnderway ? "cancelling..." : "cancel all"}</a>
                 <Treebeard data={this.state.treeContents} onToggle={this.onToggle} style={this.treeStyle}/>
             </div>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -494,3 +494,8 @@ p.inline {
     padding-right: 3px;
     padding-left: 3px;
 }
+
+div.fixed-row {
+    width: 100%;
+    height: 32px;
+}


### PR DESCRIPTION
ensure that all folders in a bucket are recursed.  Display a loading throbber for long folder lists