### PR TITLE
Remove default SQS policy for reply queue

### DIFF
--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -453,25 +453,6 @@ Resources:
   TranscodeUpdateMsg:
     Type: AWS::SQS::Queue
 
-  TranscodeUpdateMsgSubs:
-    Type: AWS::SQS::QueuePolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Id: MyQueuePolicy
-        Statement:
-        - Sid: Allow-SendMessage-From-SNS-Topic
-          Effect: Allow
-          Principal: "*"
-          Action:
-          - sqs:SendMessage
-          Resource: !GetAtt TranscodeUpdateMsg.Arn
-          Condition:
-            ArnEquals:
-              aws:SourceArn: !Ref TranscodeUpdateTopic
-      Queues:
-      - !GetAtt TranscodeUpdateMsg.QueueName
-
   IngestTranscodeMsg:
     Type: AWS::SQS::Queue
 


### PR DESCRIPTION
remove default queue policy from cloudformation as it appears to stop the "add" wizard from working - https://trello.com/c/h4FaMwLr/3007-main-app-cloudformation-sets-up-sqs-policy-wrongly