### PR TITLE
Fix for intermittent browser interface failures

### DIFF
--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -111,7 +111,11 @@ with PanDomainAuthActions {
             Ok(ObjectListResponse("ok", "entry", results.result.to[ArchiveEntry], results.result.totalHits.toInt).asJson)
         })
       }
-    )
+    ).recover({
+      case err:Throwable=>
+        logger.error("Could not do browse search: ", err)
+        InternalServerError(GenericErrorResponse("error", err.toString).asJson)
+    })
   }
 
   def lightboxSearch(startAt:Int, pageSize:Int) = APIAuthAction.async {request=>

--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -50,6 +50,10 @@ with PanDomainAuthActions {
           case None =>
             NotFound(GenericErrorResponse("not_found", fileId).asJson)
         }
+    }).recover({
+      case err:Throwable=>
+        logger.error("Could not get entry: ", err)
+        InternalServerError(GenericErrorResponse("error", err.toString).asJson)
     })
   }
 
@@ -71,6 +75,10 @@ with PanDomainAuthActions {
           case Right(results) =>
             val resultList = results.result.to[ArchiveEntry] //using the ArchiveEntryHitReader trait
             Ok(ObjectListResponse[IndexedSeq[ArchiveEntry]]("ok","entry",resultList,results.result.totalHits.toInt).asJson)
+        }).recover({
+          case err:Throwable=>
+            logger.error("Could not do browse search: ", err)
+            InternalServerError(GenericErrorResponse("error", err.toString).asJson)
         })
       case None => Future(BadRequest(GenericErrorResponse("error", "you must specify a query string with ?q={string}").asJson))
     }
@@ -90,6 +98,10 @@ with PanDomainAuthActions {
         logger.info("Got ES response:")
         logger.info(results.body.getOrElse("[empty body]"))
         Ok(BasicSuggestionsResponse.fromEsResponse(results.result.termSuggestion("sg")).asJson)
+    }).recover({
+      case err:Throwable=>
+        logger.error("Could not do suggestions search: ", err)
+        InternalServerError(GenericErrorResponse("error", err.toString).asJson)
     })
   }
 
@@ -99,6 +111,7 @@ with PanDomainAuthActions {
         Future(BadRequest(GenericErrorResponse("bad_request", error.toString).asJson))
       },
       request=> {
+        logger.info(s"search params are ${request.toSearchParams}")
         esClient.execute {
           search(indexName) query {
             boolQuery().must(request.toSearchParams)
@@ -131,6 +144,10 @@ with PanDomainAuthActions {
         InternalServerError(GenericErrorResponse("search_error", err.toString).asJson)
       case Right(results)=>
         Ok(ObjectListResponse("ok","entry", results.result.to[ArchiveEntry], results.result.totalHits.toInt).asJson)
+    }).recover({
+      case err:Throwable=>
+        logger.error("Could not do browse search: ", err)
+        InternalServerError(GenericErrorResponse("error", err.toString).asJson)
     })
   }
 }

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/MediaMetadataMapConverters.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/MediaMetadataMapConverters.scala
@@ -69,7 +69,7 @@ trait MediaMetadataMapConverters {
       value("bit_rate").asInstanceOf[Double],
       value("nb_programs").asInstanceOf[Int],
       value("duration").asInstanceOf[Double],
-      value("size").asInstanceOf[Int],
+      value("size").asInstanceOf[Long],
     )
 
   protected def mappingToMediaMetadata(value:Map[String,AnyVal]) = {


### PR DESCRIPTION
Browser interface backend was failing with uncaught exceptions.

This fix does two things:

- implements exception catching and rendering to something useful in the log
- fixes the root cause of the error that was causing the blowup