### PR TITLE
Set proxy location on WARNING message

### DIFF
--- a/app/services/ProxyFrameworkQueue.scala
+++ b/app/services/ProxyFrameworkQueue.scala
@@ -375,7 +375,7 @@ class ProxyFrameworkQueue @Inject() (config: Configuration,
       })
 
     case HandleWarning(msg, jobDesc, rq, receiptHandle, originalSender)=>
-      val updatedJd = jobDesc.copy(jobStatus = JobStatus.ST_WARNING, log = msg.decodedLog.map(_.fold(
+      val updatedJd = jobDesc.copy(completedAt = Some(ZonedDateTime.now), jobStatus = JobStatus.ST_WARNING, log = msg.decodedLog.map(_.fold(
         err=>s"Could not decode job log ${msg.log}: $err",
         logContent=>logContent
       )))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -90,6 +90,7 @@ akka.actor {
   }
 }
 
+//see https://discuss.lightbend.com/t/configuring-akka-http-backend/127/2 for a good explanation of this
 play.akka.dev-mode.akka {
   actor {
     provider = "local"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -90,6 +90,19 @@ akka.actor {
   }
 }
 
+play.akka.dev-mode.akka {
+  actor {
+    provider = "local"
+  }
+
+  remote {
+    netty.tcp {
+      hostname = "localhost"
+      port = 0
+    }
+  }
+}
+
 akka.remote {
   log-remote-lifecycle-events = off
   netty.tcp {

--- a/frontend/app/JobsList/JobStatusIcon.jsx
+++ b/frontend/app/JobsList/JobStatusIcon.jsx
@@ -9,6 +9,8 @@ class JobStatusIcon extends React.Component {
 
     render(){
         switch(this.props.status){
+            case "ST_WARNING":
+                return <span data-tip="Warning" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="exclamation-triangle" style={{color:"yellow"}}/></span>;
             case "ST_PENDING":
                 return <span data-tip="Pending" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="clock"/></span>;
             case "ST_RUNNING":


### PR DESCRIPTION
If a WARNING message is received, but the message contains a valid proxy location, then we should set that location anyway.  This goes with proxy framework PR https://github.com/guardian/ArchiveHunterProxyFramework/pull/5, which uses this mechanism to report files already existing.