### PR TITLE
Fixes Problem with Long Names in Folder Boxes

### DIFF
--- a/frontend/app/Lightbox/BulkSelectionsScroll.jsx
+++ b/frontend/app/Lightbox/BulkSelectionsScroll.jsx
@@ -44,7 +44,7 @@ class BulkSelectionsScroll extends React.Component {
 
                     return <div className={classList} onClick={()=>this.props.onSelected(entry.id)}>
                         <p className="entry-title dont-expand"><FontAwesomeIcon style={{marginRight: "0.5em"}} icon="hdd"/>{bulkInfo.name}</p>
-                        <p className="black small dont-expand"><FontAwesomeIcon style={{marginRight: "0.5em"}} icon="folder"/>{bulkInfo.pathArray.length>0 ? bulkInfo.pathArray.slice(-1) : ""}</p>
+                        <p className="black small dont-expand deal-with-long-names"><FontAwesomeIcon style={{marginRight: "0.5em"}} icon="folder"/>{bulkInfo.pathArray.length>0 ? bulkInfo.pathArray.slice(-1) : ""}</p>
                         <p className="black small dont-expand"><FontAwesomeIcon style={{marginRight: "0.5em"}} icon="list-ol"/>{entry.availCount} items</p>
                         <FontAwesomeIcon icon="trash-alt" className="clickable" style={{color: "red", float: "right"}} onClick={evt=>{
                             evt.stopPropagation();

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -162,6 +162,8 @@ div.entry-view {
 div.bulk-selection-view {
     height: 75px;
     width: 280px;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 .black {
@@ -575,4 +577,9 @@ li.list-grid {
 div.dialog-content {
     height: 200px;
     overflow-y: auto;
+}
+
+p.deal-with-long-names {
+    width: 282px;
+    overflow: hidden;
 }


### PR DESCRIPTION
Long names in folder boxes on the light box page are now dealt with gracefully.

![image](https://user-images.githubusercontent.com/10620802/54122813-04059000-43f6-11e9-9667-d363612d3635.png)

Tested on a machine running macOS 10.11.6.

@fredex42 