### PR TITLE
Token-based download for external download app

### DIFF
--- a/app/controllers/BulkDownloadsController.scala
+++ b/app/controllers/BulkDownloadsController.scala
@@ -1,0 +1,128 @@
+package controllers
+
+import java.util.UUID
+
+import com.amazonaws.HttpMethod
+import com.amazonaws.services.s3.model.{GeneratePresignedUrlRequest, ResponseHeaderOverrides}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.{LightboxBulkEntry, LightboxBulkEntryDAO, LightboxEntryDAO}
+import javax.inject.Inject
+import models.{ServerTokenDAO, ServerTokenEntry}
+import play.api.{Configuration, Logger}
+import play.api.libs.circe.Circe
+import play.api.mvc.{AbstractController, ControllerComponents}
+import responses.{BulkDownloadInitiateResponse, GenericErrorResponse, ObjectGetResponse}
+import io.circe.generic.auto._
+import io.circe.syntax._
+import com.sksamuel.elastic4s.circe._
+import com.sksamuel.elastic4s.searches.sort.SortOrder
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{ESClientManager, S3ClientManager}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class BulkDownloadsController @Inject()(config:Configuration,serverTokenDAO: ServerTokenDAO,
+                                        lightboxBulkEntryDAO: LightboxBulkEntryDAO,
+                                        lightboxEntryDAO: LightboxEntryDAO,
+                                        esClientManager: ESClientManager,
+                                        s3ClientManager: S3ClientManager,
+                                        cc:ControllerComponents)
+  extends AbstractController(cc) with Circe {
+
+  private val logger = Logger(getClass)
+
+  import com.sksamuel.elastic4s.http.ElasticDsl._
+
+  val indexName = config.getOptional[String]("externalData.indexName").getOrElse("archivehunter")
+  private val profileName = config.getOptional[String]("externalData.awsProfile")
+  protected implicit val esClient = esClientManager.getClient()
+
+  private val indexer = new Indexer(config.get[String]("externalData.indexName"))
+
+  private def errorResponse(updatedToken:ServerTokenEntry) = serverTokenDAO
+    .put(updatedToken)
+    .map(saveResult=>{
+      Forbidden(GenericErrorResponse("forbidden","invalid or expired token").asJson)
+    })
+
+  protected def entriesForBulk(bulkEntry:LightboxBulkEntry) = esClient.execute {
+    search(indexName) query {
+      nestedQuery("lightboxEntries", {
+        matchQuery("lightboxEntries.memberOfBulk", bulkEntry.id)
+      })
+    } sortBy fieldSort("path.keyword")
+  }
+
+  /**
+    * take a one-time code generated in LightboxController, validate and expire it, then return the information of the
+    * associated LightboxBulkEntry
+    * @param codeValue value of the code
+    * @return a Json response containing the metadata of the
+    */
+  def initiateWithOnetimeCode(codeValue:String) = Action.async {
+    serverTokenDAO.get(codeValue).flatMap({
+      case None=>
+        Future(Forbidden(GenericErrorResponse("forbidden", "invalid or expired token").asJson))
+      case Some(Left(err))=>
+        Future(Forbidden(GenericErrorResponse("forbidden", "invalid or expired token").asJson))
+      case Some(Right(token))=>
+        val updatedToken = token.updateCheckExpired(maxUses=Some(1)).copy(uses = token.uses+1)
+        if(updatedToken.expired){
+          errorResponse(updatedToken)
+        } else {
+          token.associatedId match {
+            case None=>errorResponse(updatedToken)
+            case Some(associatedId)=>
+              lightboxBulkEntryDAO.entryForId(UUID.fromString(associatedId)).flatMap({
+                case Some(Left(err))=>errorResponse(updatedToken)
+                case None=>errorResponse(updatedToken)
+                case Some(Right(bulkEntry))=>
+                  serverTokenDAO
+                    .put(updatedToken)
+                    .flatMap(saveResult=>{
+                      entriesForBulk(bulkEntry).flatMap({
+                        case Right(esResult)=>
+                          val retrievalToken = ServerTokenEntry.create(duration=7200) //create a 2 hour token to cover the download.
+                          serverTokenDAO.put(retrievalToken).map({
+                            case None=>
+                              Ok(BulkDownloadInitiateResponse("ok",bulkEntry,retrievalToken.value,esResult.result.hits.hits.map(_.id)).asJson)
+                            case Some(Right(_))=>
+                              Ok(BulkDownloadInitiateResponse("ok",bulkEntry,retrievalToken.value,esResult.result.hits.hits.map(_.id)).asJson)
+                            case Some(Left(err))=>
+                              logger.error(s"Could not save retrieval token: $err")
+                              InternalServerError(GenericErrorResponse("db_error", s"Could not save retrieval token: $err").asJson)
+                          })
+                        case Left(err)=>
+                          logger.error(s"Could not search index for bulk entries: $err")
+                          Future(Forbidden(GenericErrorResponse("forbidden", "invalid or expired token").asJson))
+                      })
+                    })
+              })
+          }
+        }
+    })
+  }
+
+  def getDownloadIdWithToken(tokenValue:String, fileId:String) = Action.async {
+    serverTokenDAO.get(tokenValue).flatMap({
+      case None=>
+        Future(Forbidden(GenericErrorResponse("forbidden", "invalid or expired token").asJson))
+      case Some(Left(err))=>
+        Future(Forbidden(GenericErrorResponse("forbidden", "invalid or expired token").asJson))
+      case Some(Right(serverToken))=>
+        indexer.getById(fileId).map(archiveEntry=>{
+          val s3Client = s3ClientManager.getS3Client(profileName,archiveEntry.region)
+            try {
+              val rq = new GeneratePresignedUrlRequest(archiveEntry.bucket, archiveEntry.path, HttpMethod.GET)
+                .withResponseHeaders(new ResponseHeaderOverrides().withContentDisposition("attachment"))
+              val response = s3Client.generatePresignedUrl(rq)
+              Ok(ObjectGetResponse("ok","link",response.toString).asJson)
+            } catch {
+              case ex:Throwable=>
+                logger.error("Could not generate presigned s3 url: ", ex)
+                InternalServerError(GenericErrorResponse("error",ex.toString).asJson)
+            }
+        })
+    })
+  }
+}

--- a/app/controllers/LightboxController.scala
+++ b/app/controllers/LightboxController.scala
@@ -21,6 +21,7 @@ import play.api.mvc.{AbstractController, ControllerComponents}
 import responses._
 import io.circe.syntax._
 import io.circe.generic.auto._
+import models.{ServerTokenDAO, ServerTokenEntry}
 import play.api.libs.ws.WSClient
 import requests.SearchRequest
 import services.GlacierRestoreActor
@@ -38,7 +39,8 @@ class LightboxController @Inject() (override val config:Configuration,
                                     esClientMgr:ESClientManager,
                                     s3ClientMgr:S3ClientManager,
                                     @Named("glacierRestoreActor") glacierRestoreActor:ActorRef,
-                                    lightboxBulkEntryDAO: LightboxBulkEntryDAO)
+                                    lightboxBulkEntryDAO: LightboxBulkEntryDAO,
+                                    serverTokenDAO: ServerTokenDAO)
                                    (implicit val system:ActorSystem, injector:Injector)
   extends AbstractController(controllerComponents) with PanDomainAuthActions with Circe with ZonedDateTimeEncoder with RestoreStatusEncoder {
   private val logger=Logger(getClass)
@@ -325,5 +327,35 @@ class LightboxController @Inject() (override val config:Configuration,
         }
       }
     )
+  }
+
+  def bulkDownloadInApp(entryId:String) = APIAuthAction.async { request=>
+    implicit val lightboxEntryDAOImpl = lightboxEntryDAO
+    userProfileFromSession(request.session) match {
+      case None=>Future(BadRequest(GenericErrorResponse("session_error","no session present").asJson))
+      case Some(Left(err))=>
+        logger.error(s"Session is corrupted: ${err.toString}")
+        Future(InternalServerError(GenericErrorResponse("session_error","session is corrupted, log out and log in again").asJson))
+      case Some(Right(profile))=>
+        lightboxBulkEntryDAO.entryForId(UUID.fromString(entryId)).flatMap({
+          case None=>
+            Future(NotFound(GenericErrorResponse("not_found","No bulk with that ID is present").asJson))
+          case Some(Right(entry))=>
+            //create a token that is valid for 10 seconds
+            val token = ServerTokenEntry.create(associatedId = Some(entryId),duration=10)
+            serverTokenDAO.put(token).map({
+              case None=>
+                Ok(ObjectCreatedResponse("ok","link",s"archivehunter:bulkdownload:${token.value}").asJson)
+              case Some(Right(_))=>
+                Ok(ObjectCreatedResponse("ok","link",s"archivehunter:bulkdownload:${token.value}").asJson)
+              case Some(Left(err))=>
+                logger.error(s"Could not save token to database: $err")
+                InternalServerError(GenericErrorResponse("db_error", err.toString).asJson)
+            })
+          case Some(Left(err))=>
+            logger.error(s"Could not look up bulk entry in dynamo: ${err.toString}")
+            Future(InternalServerError(GenericErrorResponse("db_error",err.toString).asJson))
+        })
+    }
   }
 }

--- a/app/controllers/LightboxController.scala
+++ b/app/controllers/LightboxController.scala
@@ -130,7 +130,10 @@ class LightboxController @Inject() (override val config:Configuration,
                             case Some(Left(err))=>
                               InternalServerError(GenericErrorResponse("db_error",err.toString).asJson)
                           })
-
+                        }).recover({
+                          case err:Throwable=>
+                            logger.error("Could not save lightbox entry: ", err)
+                            InternalServerError(GenericErrorResponse("error", err.toString).asJson)
                         })
 
                       case Left(err)=>

--- a/app/helpers/LightboxHelper.scala
+++ b/app/helpers/LightboxHelper.scala
@@ -173,6 +173,7 @@ object LightboxHelper {
     val resultFutures = flow.run()
 
     Future.sequence(Seq(resultFutures._1, resultFutures._2)).map(addedCounts=>{
+      logger.info(s"addedCounts (dynamo) ${addedCounts.head}, addedCounts (ES) ${addedCounts(1)}")
       if(addedCounts.head != addedCounts(1)){
         logger.warn(s"Mismatch between dynamodb and elastic outputs - ${addedCounts.head} records saved to dynamo but ${addedCounts(1)} records saved to ES")
       }

--- a/app/helpers/LightboxHelper.scala
+++ b/app/helpers/LightboxHelper.scala
@@ -193,7 +193,7 @@ object LightboxHelper {
     * @param indexer
     * @param mat
     * @param ec
-    * @return a Future, containing an Int of the number of items removed
+    * @return a Future, containing an Int of the number of items removed.  If the stream errors then the future fails.
     */
   def removeBulkContents(indexName:String, userProfile:UserProfile, bulk:LightboxBulkEntry)
                         (implicit lightboxEntryDAO: LightboxEntryDAO, system:ActorSystem, esClient:HttpClient, indexer:Indexer, mat:Materializer, ec:ExecutionContext) = {

--- a/app/helpers/LightboxStreamComponents/RemoveLightboxEntrySink.scala
+++ b/app/helpers/LightboxStreamComponents/RemoveLightboxEntrySink.scala
@@ -36,6 +36,7 @@ class RemoveLightboxEntrySink (userEmail:String)(implicit lightboxEntryDAO:Light
               ctr+=1
             case Failure(err)=>
               logger.error(s"Could not delete lightbox entry $elem: ", err)
+              promise.failure(err)
               throw err
           })
 

--- a/app/helpers/LightboxStreamComponents/SaveLightboxEntryFlow.scala
+++ b/app/helpers/LightboxStreamComponents/SaveLightboxEntryFlow.scala
@@ -45,12 +45,17 @@ class SaveLightboxEntryFlow (bulkId:String,userProfile: UserProfile)
         override def onPush(): Unit = {
           val elem = grab(in)
 
-          Await.result(LightboxHelper.saveLightboxEntry(userProfile, elem, Some(bulkId)), 30 seconds) match {
+          val saveFuture = LightboxHelper.saveLightboxEntry(userProfile, elem, Some(bulkId)).recover({
+            case err:Throwable=>Failure(err) //ensure that an outer exception is caught too
+          })
+
+          Await.result(saveFuture, 30 seconds) match {
             case Success(entry)=>
               logger.info("Saved lightbox entry")
               ctr+=1
               push(out, (elem, entry))
             case Failure(err)=>
+              logger.error("Could not save lightbox entry", err)
               //fail the output immediately, this should get seen by the stream's user
               promise.failure(err)
               throw err

--- a/app/helpers/LightboxStreamComponents/SaveLightboxEntryFlow.scala
+++ b/app/helpers/LightboxStreamComponents/SaveLightboxEntryFlow.scala
@@ -51,6 +51,8 @@ class SaveLightboxEntryFlow (bulkId:String,userProfile: UserProfile)
               ctr+=1
               push(out, (elem, entry))
             case Failure(err)=>
+              //fail the output immediately, this should get seen by the stream's user
+              promise.failure(err)
               throw err
           }
         }
@@ -61,7 +63,8 @@ class SaveLightboxEntryFlow (bulkId:String,userProfile: UserProfile)
       })
 
       override def postStop(): Unit = {
-        promise.success(ctr)
+        //if we've already failed the promise no point generating random error messages
+        if(!promise.isCompleted) promise.success(ctr)
       }
     }
     (logic, promise.future)

--- a/app/helpers/LightboxStreamComponents/UpdateLightboxIndexInfoSink.scala
+++ b/app/helpers/LightboxStreamComponents/UpdateLightboxIndexInfoSink.scala
@@ -52,6 +52,7 @@ class UpdateLightboxIndexInfoSink (bulkId:String,userProfile: UserProfile, userA
               pull(in)
             case Failure(err)=>
               logger.error("Could not update lightbox info: ", err)
+              promise.failure(err)
               throw err
           }
         }

--- a/app/models/ArchiveEntryDownloadSynopsis.scala
+++ b/app/models/ArchiveEntryDownloadSynopsis.scala
@@ -1,0 +1,11 @@
+package models
+
+import com.theguardian.multimedia.archivehunter.common.ArchiveEntry
+
+case class ArchiveEntryDownloadSynopsis(entryId:String, path:String, fileSize:Long)
+
+object ArchiveEntryDownloadSynopsis extends ((String, String, Long)=>ArchiveEntryDownloadSynopsis) {
+  def fromArchiveEntry(entry:ArchiveEntry) = {
+    new ArchiveEntryDownloadSynopsis(entry.id, entry.path, entry.size)
+  }
+}

--- a/app/models/ServerTokenDAO.scala
+++ b/app/models/ServerTokenDAO.scala
@@ -1,0 +1,27 @@
+package models
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.gu.scanamo.{ScanamoAlpakka, Table}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.DynamoClientManager
+import com.theguardian.multimedia.archivehunter.common.cmn_helpers.ZonedTimeFormat
+import javax.inject.Inject
+import play.api.Configuration
+
+import scala.concurrent.ExecutionContext
+
+class ServerTokenDAO @Inject() (config:Configuration, ddbClientMgr:DynamoClientManager)(implicit actorSystem:ActorSystem) extends ZonedTimeFormat{
+  import com.gu.scanamo.syntax._
+
+  private implicit val mat:ActorMaterializer = ActorMaterializer.create(actorSystem)
+  private implicit val ec:ExecutionContext = actorSystem.dispatcher
+  protected val tableName = config.get[String]("serverToken.serverTokenTable")
+  private val awsProfile = config.getOptional[String]("externalData.awsProfile")
+  private val ddbClient = ddbClientMgr.getNewAlpakkaDynamoClient(awsProfile)
+
+  private val table = Table[ServerTokenEntry](tableName)
+
+  def put(entry:ServerTokenEntry) = ScanamoAlpakka.exec(ddbClient)(table.put(entry))
+
+  def get(tokenValue:String) = ScanamoAlpakka.exec(ddbClient)(table.get('value->tokenValue))
+}

--- a/app/models/ServerTokenEntry.scala
+++ b/app/models/ServerTokenEntry.scala
@@ -1,0 +1,60 @@
+package models
+
+import java.time.{Instant, ZonedDateTime}
+
+case class ServerTokenEntry (value:String, createdAt:ZonedDateTime, expiry:Option[ZonedDateTime], uses:Int, expired:Boolean, associatedId:Option[String]) {
+  /**
+    * return an updated version of the token with the expired flag set if expiry time is passed. If expiry time is not passed same object
+    * is returned
+    * @return a ServerTokenEntry
+    */
+  def updateCheckExpired(maxUses:Option[Int]=None):ServerTokenEntry = {
+    val firstCheck = expiry match {
+      case Some(actualExpiry) =>
+        if (actualExpiry.isBefore(ZonedDateTime.now())) {
+          this.copy(expired = true)
+        } else {
+          this
+        }
+    }
+
+    if(firstCheck==this){
+      maxUses match {
+        case Some(maxUsesValue)=>
+          if(uses>=maxUsesValue){
+            this.copy(expired = true)
+          } else {
+            this
+          }
+        case None=>this
+      }
+    } else firstCheck
+  }
+}
+
+object ServerTokenEntry extends ((String, ZonedDateTime, Option[ZonedDateTime], Int, Boolean,Option[String])=>ServerTokenEntry) {
+  def randomStringFromCharList(length: Int, chars: Seq[Char]): String = {
+    val sb = new StringBuilder
+    for (i <- 1 to length) {
+      val randomNum = util.Random.nextInt(chars.length)
+      sb.append(chars(randomNum))
+    }
+    sb.toString
+  }
+
+  def randomAlphaNumericString(length: Int): String = {
+    val chars = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
+    randomStringFromCharList(length, chars)
+  }
+
+  /**
+    * the standard way to create a token. Simply specify a duration or leave blank for 60s
+    * @param duration how long this token should be valid for
+    * @return a ServerTokenEntry (not saved to db)
+    */
+  def create(associatedId:Option[String]=None, duration:Int=60):ServerTokenEntry = {
+    val expiry:ZonedDateTime = ZonedDateTime.now().plusSeconds(duration.toLong)
+
+    ServerTokenEntry(randomAlphaNumericString(36),ZonedDateTime.now(),Some(expiry),0,false, associatedId)
+  }
+}

--- a/app/responses/BulkDownloadInitiateResponse.scala
+++ b/app/responses/BulkDownloadInitiateResponse.scala
@@ -1,0 +1,5 @@
+package responses
+
+import com.theguardian.multimedia.archivehunter.common.cmn_models.LightboxBulkEntry
+
+case class BulkDownloadInitiateResponse(status:String, metadata:LightboxBulkEntry, retrievalToken:String, entries:Seq[String])

--- a/app/responses/BulkDownloadInitiateResponse.scala
+++ b/app/responses/BulkDownloadInitiateResponse.scala
@@ -1,5 +1,6 @@
 package responses
 
 import com.theguardian.multimedia.archivehunter.common.cmn_models.LightboxBulkEntry
+import models.ArchiveEntryDownloadSynopsis
 
-case class BulkDownloadInitiateResponse(status:String, metadata:LightboxBulkEntry, retrievalToken:String, entries:Seq[String])
+case class BulkDownloadInitiateResponse(status:String, metadata:LightboxBulkEntry, retrievalToken:String, entries:Seq[ArchiveEntryDownloadSynopsis])

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -983,6 +983,10 @@ Resources:
              userProfileTable = "${UserProfileTable}"
           }
 
+          serverToken {
+            serverTokenTable = "${ServerTokensTable}"
+          }
+
           serverAuth {
             sharedSecret = "${ServerSharedSecret}"
           }

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -319,6 +319,26 @@ Resources:
       - Key: Stage
         Value: !Ref Stage
 
+  ServerTokensTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: value
+          AttributeType: S
+      KeySchema:
+        - AttributeName: value
+          KeyType: HASH
+      ProvisionedThroughput:
+        WriteCapacityUnits: 1
+        ReadCapacityUnits: 3
+      Tags:
+        - Key: App
+          Value: !Sub ${App}-webapp
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: Stage
+          Value: !Ref Stage
+
   ProxyLocationTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -686,6 +706,8 @@ Resources:
             - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ProxyFrameworkTable}/index/*
             - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${LightboxBulkEntryTable}
             - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${LightboxBulkEntryTable}/index/*
+            - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ServerTokensTable}
+            - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ServerTokensTable}/index/*
       - PolicyName: TranscoderAccess
         PolicyDocument:
           Version: 2012-10-17

--- a/cloudformation/make-dev-config.rb
+++ b/cloudformation/make-dev-config.rb
@@ -35,7 +35,8 @@ $settings_mapping = {
     "proxies.tableName"=> "ProxyLocationTable",
     "ingest.notificationsQueue" => "IngestTranscodeMsg",
     "lightbox.tableName" => "LightboxTable",
-    "lightbox.bulkTableName" => "LightboxBulkEntryTable"
+    "lightbox.bulkTableName" => "LightboxBulkEntryTable",
+    "serverToken.serverTokenTable" => "ServerTokensTable"
 }
 
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -58,6 +58,10 @@ proxyFramework {
   trackingTable = "ProxyFrameworkTable"
 }
 
+serverToken {
+  serverTokenTable = "mytable"
+}
+
 serverAuth {
   sharedSecret = "notsecret"
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -60,6 +60,8 @@ proxyFramework {
 
 serverToken {
   serverTokenTable = "mytable"
+  longLivedDuration = 7200  //how long a "long-lived" token should last, in seconds. Defaults to 2 hours if not set.
+  shortLivedDuration = 10   //how long a "short-lived" or immediate use token should last, in seconds. Defaults to 10 seconds if not set.
 }
 
 serverAuth {

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -42,6 +42,7 @@
     <logger name="helpers.S3ToArchiveEntryFlow" level="WARN"/>
     <logger name="helpers.SearchHitToArchiveEntryFlow" level="WARN"/>
     <logger name="helpers.ArchiveEntryVerifyFlow" level="WARN"/>
+    <logger name="helpers.LightboxStreamComponents.SaveLightboxEntryFlow" level="DEBUG"/>
     <logger name="com.sksamuel.elastic4s.streams" level="WARN"/>
     <logger name="controllers.SearchController" level="INFO"/>
     <logger name="controllers.ScanTargetController" level="INFO"/>

--- a/conf/routes
+++ b/conf/routes
@@ -66,6 +66,7 @@ DELETE  /api/lightbox/my/:fileId        @controllers.LightboxController.removeFr
 GET     /api/lightbox/my/bulks          @controllers.LightboxController.myBulks
 DELETE  /api/lightbox/bulk/:bulkId      @controllers.LightboxController.deleteBulk(bulkId)
 PUT     /api/lightbox/bulk/query        @controllers.LightboxController.haveBulkEntryFor
+GET     /api/lightbox/bulk/appDownload/:bulkId  @controllers.LightboxController.bulkDownloadInApp(bulkId)
 
 GET     /api/download/:fileId           @controllers.LightboxController.getDownloadLink(fileId)
 
@@ -79,6 +80,9 @@ POST    /api/proxyFramework/deployments             @controllers.ProxyFrameworkA
 POST    /api/proxyFramework/deploymentDirect        @controllers.ProxyFrameworkAdminController.addDeploymentDirect
 DELETE  /api/proxyFramework/deployments/:forRegion  @controllers.ProxyFrameworkAdminController.removeDeployment(forRegion)
 GET     /api/regions                    @controllers.ProxyFrameworkAdminController.getRegions
+
+GET     /api/bulk/:codeValue                @controllers.BulkDownloadsController.initiateWithOnetimeCode(codeValue)
+GET     /api/bulk/:tokenValue/get/:fileId   @controllers.BulkDownloadsController.getDownloadIdWithToken(tokenValue, fileId)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)

--- a/frontend/app/Lightbox/BulkSelectionsScroll.jsx
+++ b/frontend/app/Lightbox/BulkSelectionsScroll.jsx
@@ -60,7 +60,7 @@ class BulkSelectionsScroll extends React.Component {
                         <a onClick={()=>{
                             this.initiateDownloadInApp(entry.id);
                             return false;
-                        }} style={{zIndex: 999}}>Download in app</a>
+                        }} className="bulk-download-link">Download in app</a>
                         <FontAwesomeIcon icon="trash-alt" className="clickable" style={{color: "red", float: "right"}} onClick={evt=>{
                             evt.stopPropagation();
                             this.props.onDeleteClicked(entry.id);

--- a/frontend/app/Lightbox/BulkSelectionsScroll.jsx
+++ b/frontend/app/Lightbox/BulkSelectionsScroll.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TimestampFormatter from "../common/TimestampFormatter.jsx";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import axios from 'axios';
 
 class BulkSelectionsScroll extends React.Component {
     static propTypes = {
@@ -34,6 +35,16 @@ class BulkSelectionsScroll extends React.Component {
         }
     }
 
+    initiateDownloadInApp(entryId) {
+        axios.get("/api/lightbox/bulk/appDownload/" + entryId, )
+            .then(result=>{
+                window.location.href = result.data.objectId;
+            }).catch(err=>{
+                console.error(err);
+                this.setState({lastError: err});
+        })
+    }
+
     render(){
         return <div className="bulk-selections-scroll">
             {
@@ -46,6 +57,10 @@ class BulkSelectionsScroll extends React.Component {
                         <p className="entry-title dont-expand"><FontAwesomeIcon style={{marginRight: "0.5em"}} icon="hdd"/>{bulkInfo.name}</p>
                         <p className="black small dont-expand deal-with-long-names"><FontAwesomeIcon style={{marginRight: "0.5em"}} icon="folder"/>{bulkInfo.pathArray.length>0 ? bulkInfo.pathArray.slice(-1) : ""}</p>
                         <p className="black small dont-expand"><FontAwesomeIcon style={{marginRight: "0.5em"}} icon="list-ol"/>{entry.availCount} items</p>
+                        <a onClick={()=>{
+                            this.initiateDownloadInApp(entry.id);
+                            return false;
+                        }} style={{zIndex: 999}}>Download in app</a>
                         <FontAwesomeIcon icon="trash-alt" className="clickable" style={{color: "red", float: "right"}} onClick={evt=>{
                             evt.stopPropagation();
                             this.props.onDeleteClicked(entry.id);

--- a/frontend/app/browse/BulkLightboxAdd.jsx
+++ b/frontend/app/browse/BulkLightboxAdd.jsx
@@ -96,9 +96,6 @@ class BulkLightboxAdd extends React.Component {
     render(){
         return <div className="centered" style={{marginTop: "0.1em", paddingLeft: "0.5em", display: this.props.path ? "inline":"none"}}>
             {
-                this.state.lastError ? <ErrorViewComponent error={this.state.lastError}/> : ""
-            }
-            {
                 this.state.quotaExceeded ? <span><p><FontAwesomeIcon icon="lightbulb" className="button-icon"/>Can't add as this would exceed your quota. You would need <BytesFormatter value={this.state.quotaRequired*1048576}/> but only have <BytesFormatter value={this.state.quotaLevel*1048576}/>.</p></span> : ""
             }
             {
@@ -113,7 +110,9 @@ class BulkLightboxAdd extends React.Component {
                     <a>Saved to lightbox</a>
                 </span> : ""
             }
-
+            {
+                this.state.lastError ? <span className="error-text" style={{marginLeft: "0.6em"}}>Server error, not all items were added</span> : ""
+            }
         </div>
     }
 }

--- a/frontend/app/common/Handle419.jsx
+++ b/frontend/app/common/Handle419.jsx
@@ -13,8 +13,8 @@ const reAuthUrl = "/loginAuthStub";
  */
 function handle419(err){
     return new Promise((resolve,reject)=> {
-        console.log(err);
-        if (err.response.status === 419) {
+        //console.log(err);
+        if (err && err.response && err.response.status === 419) {
             console.log("Received 419 error indicating expired credentials");
             reEstablishSession(reAuthUrl,5000).then(result=>{   //need a timeout
                 console.log("Re-established session");

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -160,12 +160,16 @@ div.entry-view {
 }
 
 div.bulk-selection-view {
-    height: 75px;
+    height: 95px;
     width: 280px;
     overflow: hidden;
     white-space: nowrap;
 }
 
+.bulk-download-link {
+    font-size: 0.8em;
+    z-index: 999;
+}
 .black {
     color: black;
     background-color: inherit;

--- a/test/SaveLightboxEntryFlowSpec.scala
+++ b/test/SaveLightboxEntryFlowSpec.scala
@@ -1,0 +1,63 @@
+import java.time.ZonedDateTime
+
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Keep, Sink}
+import cats.data.NonEmptyList
+import com.gu.scanamo.error.{DynamoReadError, InvalidPropertiesError, PropertyReadError}
+import com.sksamuel.elastic4s.http.HttpClient
+import com.theguardian.multimedia.archivehunter.common.cmn_models.LightboxEntryDAO
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer, MimeType, StorageClass}
+import helpers.LightboxStreamComponents.SaveLightboxEntryFlow
+import models.UserProfile
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+class SaveLightboxEntryFlowSpec extends Specification with Mockito {
+  "SaveLightboxEntryFlow" should {
+    "call out to LightboxEntryDAO to save elements" in new AkkaTestkitSpecs2Support {
+      val testArchiveEntry = ArchiveEntry("test-id","fakebucket","fakepath",None,None,1234L,
+        ZonedDateTime.now(),"fakeetag",MimeType("application","octet-stream"),false, StorageClass.STANDARD,Seq(), false,None)
+      val testUserProfile = UserProfile("userEmail@company.org",false,Seq(),true,Some(12345678L))
+
+      implicit val mat = ActorMaterializer.create(system)
+      implicit val ec:ExecutionContext = system.dispatcher
+      implicit val lightboxEntryDAO = mock[LightboxEntryDAO]
+      implicit val esClient = mock[HttpClient]
+      implicit val indexer = mock[Indexer]
+
+      lightboxEntryDAO.put(any)(any) returns Future(None)
+      val testelem = new SaveLightboxEntryFlow("test-bulk-id",testUserProfile)
+
+      val testStream = Source(scala.collection.immutable.Iterable(testArchiveEntry)).viaMat(testelem)(Keep.right).to(Sink.ignore)
+
+      val result = Await.result(testStream.run(), 30 seconds)
+      there was one(lightboxEntryDAO).put(any)(any)
+      result mustEqual 1
+
+    }
+
+    "report an underlying error as a stream failure" in new AkkaTestkitSpecs2Support {
+      val testArchiveEntry = ArchiveEntry("test-id","fakebucket","fakepath",None,None,1234L,
+        ZonedDateTime.now(),"fakeetag",MimeType("application","octet-stream"),false, StorageClass.STANDARD,Seq(), false,None)
+      val testUserProfile = UserProfile("userEmail@company.org",false,Seq(),true,Some(12345678L))
+
+      implicit val mat = ActorMaterializer.create(system)
+      implicit val ec:ExecutionContext = system.dispatcher
+      implicit val lightboxEntryDAO = mock[LightboxEntryDAO]
+      implicit val esClient = mock[HttpClient]
+      implicit val indexer = mock[Indexer]
+
+      lightboxEntryDAO.put(any)(any) returns Future(Some(Left(new InvalidPropertiesError(NonEmptyList(PropertyReadError("test",null), List())))))
+      val testelem = new SaveLightboxEntryFlow("test-bulk-id",testUserProfile)
+
+      val testStream = Source(scala.collection.immutable.Iterable(testArchiveEntry)).viaMat(testelem)(Keep.right).to(Sink.ignore)
+
+
+      Await.result(testStream.run(), 30 seconds) must throwA[RuntimeException]
+    }
+  }
+}

--- a/test/ServerTokenEntrySpec.scala
+++ b/test/ServerTokenEntrySpec.scala
@@ -1,0 +1,28 @@
+import java.time.ZonedDateTime
+
+import models.ServerTokenEntry
+import org.specs2.mutable.Specification
+
+class ServerTokenEntrySpec extends Specification {
+  "ServerTokenEntry.updateCheckExpired" should {
+    "return the original object if the token is not expired" in {
+      val tkn = ServerTokenEntry.create()
+      val result = tkn.updateCheckExpired()
+      result mustEqual tkn
+    }
+
+    "update the expiry flag if the expiry time is passed" in {
+      val tkn = ServerTokenEntry.create().copy(expiry = Some(ZonedDateTime.now().minusHours(1L)))
+      val result = tkn.updateCheckExpired()
+      result mustNotEqual tkn
+      result.expired must beTrue
+    }
+
+    "update the expiry flag if the token has been used too many times" in {
+      val tkn = ServerTokenEntry.create().copy(uses = 5)
+      val result = tkn.updateCheckExpired(maxUses = Some(5))
+      result mustNotEqual tkn
+      result.expired must beTrue
+    }
+  }
+}


### PR DESCRIPTION
This PR contains an implementation of the tokens flow outlined at https://www.lucidchart.com/documents/edit/f0441465-a3ca-4b72-b949-0b029b5e0536/0.

- A "download in app" button is added to the lightbox, which generates a token and passes it to the local downloder app using a custom URL. This relies on the app being registered as a URL handler on the local Mac
- The local app uses a new endpoint to exchange this token, which can only happen once and must be done within 10 seconds.  It gets a new, longer-lived token together with metadata about the given bulk and a list of items.
- The downloader app can then use the long-lived token on a third endpoint, which gets passed the ID of the item to download and responds with a pre-signed S3 URL telling the app where to get the data from
- The app then downloads the data directly from S3.

There are also error-handling improvements for akka streams errors when adding to lightbox
