### PR TITLE
bugfixes - boost scroll window and remove future-wait

### DIFF
--- a/app/controllers/BulkDownloadsController.scala
+++ b/app/controllers/BulkDownloadsController.scala
@@ -69,7 +69,7 @@ class BulkDownloadsController @Inject()(config:Configuration,serverTokenDAO: Ser
           nestedQuery("lightboxEntries", {
             matchQuery("lightboxEntries.memberOfBulk", bulkEntry.id)
           })
-        } sortBy fieldSort("path.keyword") scroll "1m"
+        } sortBy fieldSort("path.keyword") scroll "5m"
 
     val source = Source.fromPublisher(esClient.publisher(query))
     val hitConverter = new SearchHitToArchiveEntryFlow()

--- a/app/helpers/S3ToArchiveEntryFlow.scala
+++ b/app/helpers/S3ToArchiveEntryFlow.scala
@@ -41,7 +41,7 @@ class S3ToArchiveEntryFlow @Inject() (s3ClientMgr: S3ClientManager, config:Confi
           try {
             //we need to do a metadata lookup to get the MIME type anyway, so we may as well just call out here.
             //it appears that you can't push() to a port from in a Future thread, so doing it the crappy way and blocking here.
-            val mappedElem = Await.result(ArchiveEntry.fromS3(elem.bucketName, elem.key, region), 10.seconds)
+            val mappedElem = ArchiveEntry.fromS3Sync(elem.bucketName, elem.key, region)
             logger.debug(s"Mapped $elem to $mappedElem")
 
             while (!isAvailable(out)) {

--- a/app/services/BulkThumbnailer.scala
+++ b/app/services/BulkThumbnailer.scala
@@ -74,7 +74,7 @@ class BulkThumbnailer @Inject() (@Named("dynamoCapacityActor") dynamoCapacityAct
         matchQuery("bucket.keyword", tgt.bucketName),
         not(matchQuery("storageClass.keyword","GLACIER"))
       ))
-      val searchHitPublisher = esClient.publisher(search(indexName) bool queries scroll "1m")
+      val searchHitPublisher = esClient.publisher(search(indexName) bool queries scroll "5m")
       val searchHitSource = Source.fromPublisher(searchHitPublisher)
       val archiveEntryConverter = new SearchHitToArchiveEntryFlow
       val streamCompletionPromise = Promise[Unit]()

--- a/app/services/ProxiesRelinker.scala
+++ b/app/services/ProxiesRelinker.scala
@@ -54,7 +54,7 @@ class ProxiesRelinker @Inject() (config:Configuration,
       targetBucket.map(bucketName=>matchQuery("bucketName", bucketName))
     ).collect({case Some(term)=>term})
 
-    val pub = esClient.publisher(search(indexName) query boolQuery().must(queryTerms) scroll "1m")
+    val pub = esClient.publisher(search(indexName) query boolQuery().must(queryTerms) scroll "5m")
     Source.fromPublisher(pub)
   }
 

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveEntry.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveEntry.scala
@@ -33,7 +33,7 @@ object ArchiveEntry extends ((String, String, String, Option[String], Option[Str
     * @param client implicitly provided instance of AmazonS3Client to use
     * @return a (blocking) Future, containing an [[ArchiveEntry]] if successful
     */
-  def fromS3(bucket: String, key: String, region:String)(implicit client:AmazonS3):Future[ArchiveEntry] = Future {
+  def fromS3Sync(bucket: String, key: String, region:String)(implicit client:AmazonS3):ArchiveEntry = {
     val meta = client.getObjectMetadata(bucket,key)
     val mimeType = Option(meta.getContentType) match {
       case Some(mimeTypeString) =>
@@ -55,6 +55,10 @@ object ArchiveEntry extends ((String, String, String, Option[String], Option[Str
         "STANDARD"
     }
     ArchiveEntry(makeDocId(bucket, key), bucket, key, Some(region), getFileExtension(key), meta.getContentLength, ZonedDateTime.ofInstant(meta.getLastModified.toInstant, ZoneId.systemDefault()), meta.getETag, mimeType, proxied = false, StorageClass.withName(storageClass), Seq(), beenDeleted = false, None)
+  }
+
+  def fromS3(bucket: String, key: String, region:String)(implicit client:AmazonS3):Future[ArchiveEntry] = Future {
+    fromS3Sync(bucket, key,region)
   }
 
   def fromIndex(bucket:String, key:String)(implicit indexer:Indexer, httpClient: HttpClient):Future[ArchiveEntry] =


### PR DESCRIPTION
Two bugfixes:

- boost the scroll window size from 1 to 5 minutes, this should fix https://sentry.multimedia.gutools.co.uk/guardian-multimedia/archive-hunter-prod/issues/418516/
- remove pointless future-wait in S3ToArchiveEntryFlow by directly calling the synchronous code, this should fix https://sentry.multimedia.gutools.co.uk/guardian-multimedia/archive-hunter-prod/issues/418524/