### PR TITLE
Bulk view only "loose" items in lightbox

### DIFF
--- a/app/controllers/LightboxController.scala
+++ b/app/controllers/LightboxController.scala
@@ -273,10 +273,10 @@ class LightboxController @Inject() (override val config:Configuration,
             LightboxHelper.getLooseCountForUser(indexName, request.user.email).map({
               case Left(err)=>
                 logger.error(s"Could not look up count for loose lightbox items: $err")
-                val successes = results.collect({ case Right(value)=>value }) ++ List(LightboxBulkEntry("loose","Loose items", profile.userEmail, ZonedDateTime.now(),0,0,0))
+                val successes = results.collect({ case Right(value)=>value }) ++ List(LightboxBulkEntry.forLoose(profile.userEmail, 0))
                 Ok(ObjectListResponse("ok","lightboxBulk",successes,successes.length).asJson)
               case Right(count)=>
-                val successes = results.collect({ case Right(value)=>value }) ++ List(LightboxBulkEntry("loose","Loose items", profile.userEmail, ZonedDateTime.now(),0,count,0))
+                val successes = results.collect({ case Right(value)=>value }) ++ List(LightboxBulkEntry.forLoose(profile.userEmail, count))
                 Ok(ObjectListResponse("ok","lightboxBulk",successes,successes.length).asJson)
             })
 
@@ -342,6 +342,19 @@ class LightboxController @Inject() (override val config:Configuration,
     )
   }
 
+  private def makeDownloadToken(entryId:String, userEmail:String) = {
+    val token = ServerTokenEntry.create(associatedId = Some(entryId),duration=tokenShortDuration, forUser = Some(userEmail))
+    serverTokenDAO.put(token).map({
+      case None =>
+        Ok(ObjectCreatedResponse("ok", "link", s"archivehunter:bulkdownload:${token.value}").asJson)
+      case Some(Right(_)) =>
+        Ok(ObjectCreatedResponse("ok", "link", s"archivehunter:bulkdownload:${token.value}").asJson)
+      case Some(Left(err)) =>
+        logger.error(s"Could not save token to database: $err")
+        InternalServerError(GenericErrorResponse("db_error", err.toString).asJson)
+    })
+  }
+
   def bulkDownloadInApp(entryId:String) = APIAuthAction.async { request=>
     implicit val lightboxEntryDAOImpl = lightboxEntryDAO
     userProfileFromSession(request.session) match {
@@ -350,25 +363,20 @@ class LightboxController @Inject() (override val config:Configuration,
         logger.error(s"Session is corrupted: ${err.toString}")
         Future(InternalServerError(GenericErrorResponse("session_error","session is corrupted, log out and log in again").asJson))
       case Some(Right(profile))=>
-        lightboxBulkEntryDAO.entryForId(UUID.fromString(entryId)).flatMap({
-          case None=>
-            Future(NotFound(GenericErrorResponse("not_found","No bulk with that ID is present").asJson))
-          case Some(Right(entry))=>
-            //create a token that is valid for 10 seconds
-            val token = ServerTokenEntry.create(associatedId = Some(entryId),duration=tokenShortDuration)
-            serverTokenDAO.put(token).map({
-              case None=>
-                Ok(ObjectCreatedResponse("ok","link",s"archivehunter:bulkdownload:${token.value}").asJson)
-              case Some(Right(_))=>
-                Ok(ObjectCreatedResponse("ok","link",s"archivehunter:bulkdownload:${token.value}").asJson)
-              case Some(Left(err))=>
-                logger.error(s"Could not save token to database: $err")
-                InternalServerError(GenericErrorResponse("db_error", err.toString).asJson)
-            })
-          case Some(Left(err))=>
-            logger.error(s"Could not look up bulk entry in dynamo: ${err.toString}")
-            Future(InternalServerError(GenericErrorResponse("db_error",err.toString).asJson))
-        })
+        if(entryId=="loose"){
+          makeDownloadToken(entryId, request.user.email)
+        } else {
+          lightboxBulkEntryDAO.entryForId(UUID.fromString(entryId)).flatMap({
+            case None =>
+              Future(NotFound(GenericErrorResponse("not_found", "No bulk with that ID is present").asJson))
+            case Some(Right(_)) =>
+              //create a token that is valid for 10 seconds
+              makeDownloadToken(entryId, request.user.email)
+            case Some(Left(err)) =>
+              logger.error(s"Could not look up bulk entry in dynamo: ${err.toString}")
+              Future(InternalServerError(GenericErrorResponse("db_error", err.toString).asJson))
+          })
+        }
     }
   }
 }

--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -138,7 +138,7 @@ with PanDomainAuthActions {
         logger.error(s"Could not perform lightbox query: $err")
         InternalServerError(GenericErrorResponse("search_error", err.toString).asJson)
       case Right(results)=>
-        results.result.to[ArchiveEntry].foreach(x=>println(x.toString))
+        results.result.to[ArchiveEntry].foreach(x=>logger.debug(x.toString))
         Ok(ObjectListResponse("ok","entry", results.result.to[ArchiveEntry], results.result.totalHits.toInt).asJson)
     }).recover({
       case err:Throwable=>

--- a/app/models/ServerTokenEntry.scala
+++ b/app/models/ServerTokenEntry.scala
@@ -2,7 +2,7 @@ package models
 
 import java.time.{Instant, ZonedDateTime}
 
-case class ServerTokenEntry (value:String, createdAt:ZonedDateTime, expiry:Option[ZonedDateTime], uses:Int, expired:Boolean, associatedId:Option[String]) {
+case class ServerTokenEntry (value:String, createdAt:ZonedDateTime, createdForUser:Option[String], expiry:Option[ZonedDateTime], uses:Int, expired:Boolean, associatedId:Option[String]) {
   /**
     * return an updated version of the token with the expired flag set if expiry time is passed. If expiry time is not passed same object
     * is returned
@@ -32,7 +32,7 @@ case class ServerTokenEntry (value:String, createdAt:ZonedDateTime, expiry:Optio
   }
 }
 
-object ServerTokenEntry extends ((String, ZonedDateTime, Option[ZonedDateTime], Int, Boolean,Option[String])=>ServerTokenEntry) {
+object ServerTokenEntry extends ((String, ZonedDateTime, Option[String], Option[ZonedDateTime], Int, Boolean,Option[String])=>ServerTokenEntry) {
   def randomStringFromCharList(length: Int, chars: Seq[Char]): String = {
     val sb = new StringBuilder
     for (i <- 1 to length) {
@@ -52,9 +52,9 @@ object ServerTokenEntry extends ((String, ZonedDateTime, Option[ZonedDateTime], 
     * @param duration how long this token should be valid for
     * @return a ServerTokenEntry (not saved to db)
     */
-  def create(associatedId:Option[String]=None, duration:Int=60):ServerTokenEntry = {
+  def create(associatedId:Option[String]=None, duration:Int=60, forUser:Option[String]):ServerTokenEntry = {
     val expiry:ZonedDateTime = ZonedDateTime.now().plusSeconds(duration.toLong)
 
-    ServerTokenEntry(randomAlphaNumericString(36),ZonedDateTime.now(),Some(expiry),0,false, associatedId)
+    ServerTokenEntry(randomAlphaNumericString(36),ZonedDateTime.now(),forUser, Some(expiry),0,false, associatedId)
   }
 }

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxBulkEntry.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxBulkEntry.scala
@@ -8,4 +8,6 @@ case class LightboxBulkEntry (id:String, description:String, userEmail:String, a
 object LightboxBulkEntry extends ((String,String,String,ZonedDateTime,Int,Int,Int)=>LightboxBulkEntry) {
   def create(userEmail:String, description:String, addTime:Option[ZonedDateTime]=None) =
     new LightboxBulkEntry(UUID.randomUUID().toString, description, userEmail, addTime.getOrElse(ZonedDateTime.now()),0,0,0)
+
+  def forLoose(userEmail:String, count:Int) = LightboxBulkEntry("loose","Loose items", userEmail, ZonedDateTime.now(),0,count,0)
 }

--- a/test/ServerTokenEntrySpec.scala
+++ b/test/ServerTokenEntrySpec.scala
@@ -6,20 +6,20 @@ import org.specs2.mutable.Specification
 class ServerTokenEntrySpec extends Specification {
   "ServerTokenEntry.updateCheckExpired" should {
     "return the original object if the token is not expired" in {
-      val tkn = ServerTokenEntry.create()
+      val tkn = ServerTokenEntry.create(forUser=Some("user@test.org"))
       val result = tkn.updateCheckExpired()
       result mustEqual tkn
     }
 
     "update the expiry flag if the expiry time is passed" in {
-      val tkn = ServerTokenEntry.create().copy(expiry = Some(ZonedDateTime.now().minusHours(1L)))
+      val tkn = ServerTokenEntry.create(forUser=Some("user@test.org")).copy(expiry = Some(ZonedDateTime.now().minusHours(1L)))
       val result = tkn.updateCheckExpired()
       result mustNotEqual tkn
       result.expired must beTrue
     }
 
     "update the expiry flag if the token has been used too many times" in {
-      val tkn = ServerTokenEntry.create().copy(uses = 5)
+      val tkn = ServerTokenEntry.create(forUser=Some("user@test.org")).copy(uses = 5)
       val result = tkn.updateCheckExpired(maxUses = Some(5))
       result mustNotEqual tkn
       result.expired must beTrue


### PR DESCRIPTION
Adds an option to the Lightbox view to see only "loose" items, i.e. those not associated with a bulk add.

Download In App works for these too.