### PR TITLE
Handle elasticsearch Version Conflict errors in ProxyFrameworkQueue actor

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,11 +2,12 @@ package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import helpers.InjectableRefresher
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
+@Singleton
 class Application @Inject() (override val controllerComponents:ControllerComponents,
                              override val wsClient: WSClient,
                              override val config: Configuration,

--- a/app/controllers/BrowseCollectionController.scala
+++ b/app/controllers/BrowseCollectionController.scala
@@ -6,7 +6,7 @@ import com.sksamuel.elastic4s.http.search.TermsAggResult
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{ESClientManager, S3ClientManager}
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{ScanTarget, ScanTargetDAO}
 import helpers.InjectableRefresher
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.libs.circe.Circe
 import play.api.{Configuration, Logger}
 import play.api.mvc.{AbstractController, ControllerComponents}
@@ -21,7 +21,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.Try
-
+@Singleton
 class BrowseCollectionController @Inject() (override val config:Configuration,
                                             s3ClientMgr:S3ClientManager,
                                             scanTargetDAO:ScanTargetDAO,

--- a/app/controllers/BulkDownloadsController.scala
+++ b/app/controllers/BulkDownloadsController.scala
@@ -8,7 +8,7 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import com.amazonaws.HttpMethod
 import com.amazonaws.services.s3.model.{GeneratePresignedUrlRequest, ResponseHeaderOverrides}
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{LightboxBulkEntry, LightboxBulkEntryDAO, LightboxEntryDAO}
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import models.{ArchiveEntryDownloadSynopsis, ServerTokenDAO, ServerTokenEntry}
 import play.api.{Configuration, Logger}
 import play.api.libs.circe.Circe
@@ -24,6 +24,7 @@ import helpers.{LightboxHelper, SearchHitToArchiveEntryFlow}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+@Singleton
 class BulkDownloadsController @Inject()(config:Configuration,serverTokenDAO: ServerTokenDAO,
                                         lightboxBulkEntryDAO: LightboxBulkEntryDAO,
                                         lightboxEntryDAO: LightboxEntryDAO,

--- a/app/controllers/ProxyFrameworkAdminController.scala
+++ b/app/controllers/ProxyFrameworkAdminController.scala
@@ -12,7 +12,7 @@ import com.amazonaws.services.cloudformation.model._
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{ProxyFrameworkInstance, ProxyFrameworkInstanceDAO}
 import com.typesafe.config.ConfigException.Generic
 import helpers.InjectableRefresher
-import javax.inject.{Inject, Named}
+import javax.inject.{Inject, Named, Singleton}
 import play.api.{Configuration, Logger}
 import play.api.libs.circe.Circe
 import play.api.libs.ws.WSClient
@@ -26,6 +26,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
+@Singleton
 class ProxyFrameworkAdminController @Inject() (override val config:Configuration,
                                                override val controllerComponents:ControllerComponents,
                                                override val refresher:InjectableRefresher,

--- a/app/controllers/ProxyHealthController.scala
+++ b/app/controllers/ProxyHealthController.scala
@@ -5,7 +5,7 @@ import com.theguardian.multimedia.archivehunter.common.{ProblemItemHitReader, Pr
 import com.theguardian.multimedia.archivehunter.common.clientManagers.ESClientManager
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{JobModel, JobModelDAO, ProblemItem, ProxyHealthEncoder}
 import helpers.InjectableRefresher
-import javax.inject.{Inject, Named}
+import javax.inject.{Inject, Named, Singleton}
 import org.slf4j.MDC
 import play.api.{Configuration, Logger}
 import play.api.libs.circe.Circe
@@ -28,6 +28,7 @@ import scala.concurrent.duration._
   * @param wsClient
   * @param refresher
   */
+@Singleton
 class ProxyHealthController @Inject()(override val config:Configuration,
                                      override val controllerComponents:ControllerComponents,
                                      esClientMgr:ESClientManager,

--- a/app/controllers/VersionController.scala
+++ b/app/controllers/VersionController.scala
@@ -6,7 +6,7 @@ import java.util.Properties
 
 import com.theguardian.multimedia.archivehunter.common.ZonedDateTimeEncoder
 import helpers.InjectableRefresher
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import play.api.libs.circe.Circe
 import play.api.libs.ws.WSClient
@@ -15,6 +15,7 @@ import io.circe.syntax._
 import io.circe.generic.auto._
 import responses.{GenericErrorResponse, VersionInfoResponse}
 
+@Singleton
 class VersionController @Inject() (override val controllerComponents:ControllerComponents,
                                    override val config:Configuration,
                                    override val wsClient:WSClient,

--- a/app/services/BucketScanner.scala
+++ b/app/services/BucketScanner.scala
@@ -15,7 +15,7 @@ import com.gu.scanamo.{ScanamoAlpakka, Table}
 import com.sksamuel.elastic4s.http.HttpClient
 import com.sksamuel.elastic4s.http.bulk.BulkResponseItem
 import helpers._
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import com.theguardian.multimedia.archivehunter.common.cmn_models._
 import play.api.{Configuration, Logger}
 import com.sksamuel.elastic4s.streams.ReactiveElastic._
@@ -38,7 +38,7 @@ object BucketScanner {
   case object RegularScanTrigger extends BSMsg
 }
 
-
+@Singleton
 class BucketScanner @Inject()(config:Configuration, ddbClientMgr:DynamoClientManager, s3ClientMgr:S3ClientManager,
                               esClientMgr:ESClientManager, scanTargetDAO: ScanTargetDAO, jobModelDAO:JobModelDAO,
                               injector:Injector)(implicit system:ActorSystem)

--- a/app/services/BulkThumbnailer.scala
+++ b/app/services/BulkThumbnailer.scala
@@ -8,7 +8,7 @@ import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ArchiveHun
 import com.theguardian.multimedia.archivehunter.common.clientManagers.ESClientManager
 import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTarget
 import helpers._
-import javax.inject.{Inject, Named}
+import javax.inject.{Inject, Named, Singleton}
 import play.api.Logger
 import services.BulkThumbnailer.{CapacityDidUpdate, CapacityOkDoThumbnails, DoThumbnails, JobDoneCapacityReset}
 
@@ -31,6 +31,7 @@ object BulkThumbnailer {
   * @param config
   * @param system
   */
+@Singleton
 class BulkThumbnailer @Inject() (@Named("dynamoCapacityActor") dynamoCapacityActor: ActorRef,
                                   ESClientManager: ESClientManager, hasThumbnailFilter: HasThumbnailFilter,
                                  createProxySink: CreateProxySink, config:ArchiveHunterConfiguration, system:ActorSystem)

--- a/app/services/ClockSingleton.scala
+++ b/app/services/ClockSingleton.scala
@@ -2,7 +2,7 @@ package services
 
 import akka.actor.{Actor, ActorRef, Timers}
 import com.theguardian.multimedia.archivehunter.common.{ArchiveHunterConfiguration, ExtValueConverters}
-import javax.inject.{Inject, Named}
+import javax.inject.{Inject, Named, Singleton}
 import play.api.Logger
 import services.BucketScanner.{RegularScanTrigger, TickKey}
 import services.ClockSingleton.RapidClockTick
@@ -24,6 +24,7 @@ object ClockSingleton {
   * the idea of isolating the timers in this way is to ensure that there is only one actor in the cluster sending timing pulses,
   * but the actors doing the work can fan-out and run in parallel.
   */
+@Singleton
 class ClockSingleton @Inject() (@Named("dynamoCapacityActor") dynamoCapacityActor:ActorRef,
                                 @Named("bucketScannerActor") bucketScanner:ActorRef,
                                 @Named("jobPurgerActor") jobPurgerActor: ActorRef,

--- a/app/services/DynamoCapacityActor.scala
+++ b/app/services/DynamoCapacityActor.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.dynamodbv2.document.Table
 import com.amazonaws.services.dynamodbv2.model._
 import com.theguardian.multimedia.archivehunter.common.ArchiveHunterConfiguration
 import com.theguardian.multimedia.archivehunter.common.clientManagers.DynamoClientManager
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.Logger
 
 import scala.collection.JavaConverters._
@@ -70,6 +70,7 @@ object DynamoCapacityActor {
   case class TestCheckListResponse(entries:Seq[DCAMsg])
 }
 
+@Singleton
 class DynamoCapacityActor @Inject() (ddbClientMgr:DynamoClientManager, config:ArchiveHunterConfiguration) extends Actor {
   import DynamoCapacityActor._
   private val logger = Logger(getClass)

--- a/app/services/GlacierRestoreActor.scala
+++ b/app/services/GlacierRestoreActor.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.s3.model.RestoreObjectRequest
 import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer}
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{ESClientManager, S3ClientManager}
 import com.theguardian.multimedia.archivehunter.common.cmn_models._
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.{Configuration, Logger}
 
 import scala.concurrent.ExecutionContext
@@ -38,7 +38,7 @@ object GlacierRestoreActor {
   case class RestoreCompleted(entry:ArchiveEntry, expiresAt:ZonedDateTime) extends GRMsg
 }
 
-
+@Singleton
 class GlacierRestoreActor @Inject() (config:Configuration, esClientMgr:ESClientManager, s3ClientMgr:S3ClientManager,
                                      jobModelDAO: JobModelDAO, lbEntryDAO:LightboxEntryDAO, system:ActorSystem) extends Actor {
   import GlacierRestoreActor._

--- a/app/services/IndexManagement.scala
+++ b/app/services/IndexManagement.scala
@@ -2,7 +2,7 @@ package services
 
 
 import com.theguardian.multimedia.archivehunter.common.clientManagers.ESClientManager
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.http.index.mappings.IndexMappings
@@ -11,6 +11,7 @@ import com.sksamuel.elastic4s.mappings.{BasicFieldDefinition, _}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
+@Singleton
 class IndexManagement @Inject() (config:Configuration, esClientMgr:ESClientManager) extends ElasticDsl {
 
   import com.sksamuel.elastic4s.mappings.FieldType._

--- a/app/services/IngestProxyQueue.scala
+++ b/app/services/IngestProxyQueue.scala
@@ -10,7 +10,7 @@ import com.theguardian.multimedia.archivehunter.common.{cmn_models, _}
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, S3ClientManager, SQSClientManager}
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{IngestMessage, ScanTargetDAO}
 import helpers.ProxyLocator
-import javax.inject.{Inject, Named}
+import javax.inject.{Inject, Named, Singleton}
 import models.AwsSqsMsg
 import play.api.{Configuration, Logger}
 
@@ -32,7 +32,7 @@ object IngestProxyQueue extends GenericSqsActorMessages {
 
 }
 
-
+@Singleton
 class IngestProxyQueue @Inject()(config: Configuration,
                                  system: ActorSystem,
                                  sqsClientManager: SQSClientManager,

--- a/app/services/JobPurgerActor.scala
+++ b/app/services/JobPurgerActor.scala
@@ -11,7 +11,7 @@ import com.gu.scanamo.DynamoFormat
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, ScanRequest}
 import com.theguardian.multimedia.archivehunter.common.clientManagers.DynamoClientManager
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{JobModel, JobModelDAO, JobStatus, SourceType}
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.{Configuration, Logger}
 
 import scala.collection.JavaConverters._
@@ -35,6 +35,7 @@ object JobPurgerActor {
   case class CheckMaybePurge(entry: Map[String,AttributeValue], maybePurgeTime:Option[ZonedDateTime]=None) extends JPMsg
 }
 
+@Singleton
 class JobPurgerActor @Inject() (config:Configuration, ddbClientMgr:DynamoClientManager, jobModelDAO: JobModelDAO)(implicit system:ActorSystem) extends Actor{
   import JobPurgerActor._
   import akka.stream.alpakka.dynamodb.scaladsl.DynamoImplicits._

--- a/app/services/LegacyProxiesScanner.scala
+++ b/app/services/LegacyProxiesScanner.scala
@@ -8,7 +8,7 @@ import com.amazonaws.services.dynamodbv2.model._
 import com.google.inject.Injector
 import com.theguardian.multimedia.archivehunter.common.ProxyLocation
 import helpers._
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{ScanTarget, ScanTargetDAO}
 import play.api.{Configuration, Logger}
 
@@ -27,6 +27,7 @@ object LegacyProxiesScanner {
   case class ProviderError(err:Throwable) extends LPSError
 }
 
+@Singleton
 class LegacyProxiesScanner @Inject()(config:Configuration, ddbClientMgr:DynamoClientManager, s3ClientMgr:S3ClientManager,
                                      esClientMgr:ESClientManager, scanTargetDAO: ScanTargetDAO, injector:Injector)(implicit system:ActorSystem)extends Actor {
   import LegacyProxiesScanner._

--- a/app/services/ProblemItemRetry.scala
+++ b/app/services/ProblemItemRetry.scala
@@ -10,7 +10,7 @@ import com.theguardian.multimedia.archivehunter.common.clientManagers.ESClientMa
 import com.theguardian.multimedia.archivehunter.common.cmn_models._
 import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ProblemItemHitReader, ProblemItemIndexer, ProxyLocationDAO}
 import helpers.{CreateProxySink, EOSDetect, ProblemItemReproxySink}
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.{Configuration, Logger}
 
 import scala.concurrent.Promise
@@ -29,6 +29,7 @@ object ProblemItemRetry {
   * @param actorSystem
   * @param proxyLocationDAO
   */
+@Singleton
 class ProblemItemRetry @Inject()(config:Configuration, proxyGenerators:ProxyGenerators,
                                  esClientManager:ESClientManager, jobModelDAO:JobModelDAO,
                                  problemItemReproxySink: ProblemItemReproxySink)

--- a/app/services/ProxiesRelinker.scala
+++ b/app/services/ProxiesRelinker.scala
@@ -8,7 +8,7 @@ import akka.stream.{ActorMaterializer, Materializer}
 import com.sksamuel.elastic4s.http.bulk.BulkResponseItem
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager}
 import com.theguardian.multimedia.archivehunter.common._
-import javax.inject.Inject
+import javax.inject.{Inject,Singleton}
 import play.api.{Configuration, Logger}
 import com.sksamuel.elastic4s.streams.ReactiveElastic._
 import com.sksamuel.elastic4s.streams.{RequestBuilder, ResponseListener, SubscriberConfig}
@@ -35,6 +35,7 @@ object ProxiesRelinker {
   case class RelinkError(err:Throwable) extends RelinkReply
 }
 
+@Singleton
 class ProxiesRelinker @Inject() (config:Configuration,
                                  esClientMgr:ESClientManager, ddbClientMgr:DynamoClientManager, system:ActorSystem,
                                  proxyVerifyFlow: ProxyVerifyFlow, jobModelDAO:JobModelDAO, scanTargetDAO:ScanTargetDAO)

--- a/app/services/ProxyFrameworkQueue.scala
+++ b/app/services/ProxyFrameworkQueue.scala
@@ -9,8 +9,9 @@ import com.theguardian.multimedia.archivehunter.common._
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager, SQSClientManager}
 import com.theguardian.multimedia.archivehunter.common.cmn_models._
 import io.circe.generic.auto._
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import models.{AwsSqsMsg, JobReportNew, JobReportStatus, JobReportStatusEncoder}
+import org.slf4j.MDC
 import play.api.{Configuration, Logger}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -57,6 +58,7 @@ trait ProxyFrameworkQueueFunctions extends ProxyTypeEncoder with JobReportStatus
   * @param esClientMgr client manager class instance for Elastic Search
   * @param proxyLocationDAO Data Access Object for proxy locations
   */
+@Singleton
 class ProxyFrameworkQueue @Inject() (config: Configuration,
                                      system: ActorSystem,
                                      sqsClientManager: SQSClientManager,
@@ -93,6 +95,29 @@ class ProxyFrameworkQueue @Inject() (config: Configuration,
 
   protected val problemItemIndexName = config.get[String]("externalData.problemItemsIndex")
   protected val problemItemIndexer = new ProblemItemIndexer(problemItemIndexName)
+
+  /**
+    * sets the "proxied" flag on the given item, retrying in case of a version conflict
+    * @param sourceId archive entry ID to update
+    * @return a Future with either a Left with an error string or a Right with the item ID string
+    */
+  def setProxiedWithRetry(sourceId:String):Future[Either[String,String]] = indexer.getById(sourceId).flatMap(entry=>{
+    val updatedEntry = entry.copy(proxied = true)
+    MDC.put("entry", updatedEntry.toString)
+    indexer.indexSingleItem(updatedEntry)
+  }).flatMap({
+    case Left(err)=>
+      if(err.error.`type`=="version_conflict_engine_exception"){
+        logger.warn(s"Elasticsearch version conflict detected for update of $sourceId, retrying...")
+        setProxiedWithRetry(sourceId)
+      } else {
+        MDC.put("error", err.toString)
+        logger.error(s"Could not set proxied flag for $sourceId: ${err.toString}")
+        Future(Left(err.toString))
+      }
+    case Right(value)=>
+      Future(Right(value.result.id))
+  })
 
   /**
     * looks up the ArchiveEntry for the original media associated with the given JobModel
@@ -286,16 +311,7 @@ class ProxyFrameworkQueue @Inject() (config: Configuration,
           case Right(archiveEntry) => updateProxyRef(msg.output.get, archiveEntry, proxyType)
         })
 
-        val indexUpdateFuture = indexer.getById(jobDesc.sourceId).flatMap(entry=>{
-          val updatedEntry = entry.copy(proxied = true)
-          indexer.indexSingleItem(updatedEntry)
-        }).map({
-          case Failure(err)=>
-            logger.error("Could not update index: ", err)
-            Left(err.toString)
-          case Success(value)=>
-            Right(value)
-        })
+        val indexUpdateFuture = setProxiedWithRetry(jobDesc.sourceId)
 
         //set up a future to complete when both of the update jobs have run. this marshals a single success/failure flag
         val overallCompletionFuture = Future.sequence(Seq(proxyUpdateFuture, indexUpdateFuture)).map(results=>{
@@ -379,8 +395,10 @@ class ProxyFrameworkQueue @Inject() (config: Configuration,
         logger.info(s"Received updated metadata ${msg.metadata} for ${entry.id}")
         val updatedEntry = entry.copy(mediaMetadata = msg.metadata)
         indexer.indexSingleItem(updatedEntry).map({
-          case Failure(err)=>
-            logger.error("Could not update index: ", err)
+          case Left(err)=>
+            MDC.put("entry",updatedEntry.toString)
+            MDC.put("error", err.toString)
+            logger.error(s"Could not update index: $err")
             val updatedLog = jobDesc.log match {
               case Some(existingLog) => existingLog + "\n" + s"Could not update index: ${err.toString}"
               case None => s"Could not update index: ${err.toString}"
@@ -388,8 +406,8 @@ class ProxyFrameworkQueue @Inject() (config: Configuration,
             val updatedJobDesc = jobDesc.copy(jobStatus = JobStatus.ST_ERROR, log = Some(updatedLog))
             jobModelDAO.putJob(updatedJobDesc)
             ownRef ! HandleFailure(msg, jobDesc, rq, receiptHandle, originalSender)
-            originalSender ! akka.actor.Status.Failure(err)
-          case Success(newId)=>
+            originalSender ! akka.actor.Status.Failure(new RuntimeException(err.toString))
+          case Right(newId)=>
             logger.info(s"Updated media metadata for $newId")
             ownRef ! HandleGenericSuccess(msg, jobDesc, rq, receiptHandle, originalSender)
         })

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/Indexer.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/Indexer.scala
@@ -35,7 +35,7 @@ class Indexer(indexName:String) extends ZonedDateTimeEncoder with StorageClassEn
 
     client.execute {
       update(idToUse).in(s"$indexName/entry").docAsUpsert(entry)
-    }
+    }.map(_.map(response=>response.result.id))
   }
 
   /**

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/clientManagers/DynamoClientManager.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/clientManagers/DynamoClientManager.scala
@@ -24,7 +24,7 @@ class DynamoClientManager @Inject() (config:ArchiveHunterConfiguration) extends 
         config.get[String]("externalData.awsRegion"),
         config.get[String]("externalData.ddbHost"),
         443,
-        8,
+        32,
         credentialsProvider(profileName)
       )
     )

--- a/common/src/test/scala/com/theguardian/multimedia/archivehunter/IndexerSpec.scala
+++ b/common/src/test/scala/com/theguardian/multimedia/archivehunter/IndexerSpec.scala
@@ -52,7 +52,7 @@ class IndexerSpec extends Specification with AfterAll {
 
       val i = new Indexer("testindex")
       val result = Await.result(i.indexSingleItem(entry), 5 seconds)
-      result must beSuccessfulTry("sfdfsdjfsdhjfsd")
+      result must beRight("sfdfsdjfsdhjfsd")
 
     }
   }

--- a/frontend/app/browse/BulkLightboxAdd.jsx
+++ b/frontend/app/browse/BulkLightboxAdd.jsx
@@ -42,7 +42,7 @@ class BulkLightboxAdd extends React.Component {
      */
     checkBulkRecord() {
         this.setState({loading: true},
-            ()=>axios.put("/api/lightbox/bulk/query", this.makeSearchJson(), {headers: {"Content-Type": "application/json"}})
+            ()=>axios.put("/api/lightbox/my/bulk/query", this.makeSearchJson(), {headers: {"Content-Type": "application/json"}})
                 .then(response=>{
                     this.setState({loading: false, bulkRecord: response.data.entry, lastERror: null});
                 }).catch(err=>{

--- a/lambda/input/src/test/scala/InputLambdaMainSpec.scala
+++ b/lambda/input/src/test/scala/InputLambdaMainSpec.scala
@@ -46,7 +46,7 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
       val mockIndexer = mock[Indexer]
       val mockSendIngestedMessage = mock[Function1[ArchiveEntry, Unit]]
 
-      mockIndexer.indexSingleItem(any,any,any)(any).returns(Future(Success("fake-entry-id")))
+      mockIndexer.indexSingleItem(any,any,any)(any).returns(Future(Right("fake-entry-id")))
       val test = new InputLambdaMain {
         override protected def getElasticClient(clusterEndpoint: String): HttpClient = {
           val m = mock[HttpClient]
@@ -100,7 +100,7 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
       val mockIndexer = mock[Indexer]
       val mockSendIngestedMessage = mock[Function1[ArchiveEntry, Unit]]
 
-      mockIndexer.indexSingleItem(any,any,any)(any).returns(Future(Success("fake-entry-id")))
+      mockIndexer.indexSingleItem(any,any,any)(any).returns(Future(Right("fake-entry-id")))
       val test = new InputLambdaMain {
         override protected def getElasticClient(clusterEndpoint: String): HttpClient = {
           val m = mock[HttpClient]


### PR DESCRIPTION
ProxyFrameworkQueue actor now reloads and retries elasticsearch updates. Also bump akka parallelism and mark all controllers and actors as singletons