### PR TITLE
Fix for null pointer error in job purge actor

### DIFF
--- a/app/services/JobPurgerActor.scala
+++ b/app/services/JobPurgerActor.scala
@@ -78,7 +78,12 @@ class JobPurgerActor @Inject() (config:Configuration, ddbClientMgr:DynamoClientM
               case Success(result)=>
                 originalSender ! Status.Success
                  try {
-                  logger.info(s"Deleted job ${job.jobId}, consumed ${result.getConsumedCapacity.getCapacityUnits} capacity units")
+                   Option(result.getConsumedCapacity) match {
+                     case Some(capUnits)=>
+                      logger.info(s"Deleted job ${job.jobId}, consumed ${capUnits.getCapacityUnits} capacity units")
+                     case None=>
+                      logger.info(s"Deleted job ${job.jobId}")
+                   }
                  } catch {
                   case err:Throwable =>
                     logger.warn("Caught exception while logging job: ", err)


### PR DESCRIPTION
Fixes https://sentry.multimedia.gutools.co.uk/guardian-multimedia/archive-hunter-prod/issues/418520/events/e7b2f8d1d99b482f95a70234201d86a6/.  Appears that result.getConsumedCapacitty returns null.