### PR TITLE
Fix media becoming unavailable if it's dropped to Glacier but not been picked up

### DIFF
--- a/app/controllers/LightboxController.scala
+++ b/app/controllers/LightboxController.scala
@@ -287,7 +287,6 @@ class LightboxController @Inject() (override val config:Configuration,
 
 
         val actualSrc = builder.add(src)
-        //val actualSink = builder.add(sink)
 
         actualSrc ~> sink
         ClosedShape

--- a/app/helpers/LightboxHelper.scala
+++ b/app/helpers/LightboxHelper.scala
@@ -200,7 +200,7 @@ object LightboxHelper {
 
   def lightboxSearch(indexName:String, bulkId:Option[String], userEmail:String) =  {
     val queryTerms = Seq(
-      Some(matchQuery("owner", userEmail)),
+      Some(matchQuery("lightboxEntries.owner", userEmail)),
       bulkId.map(actualBulkId=>lightboxQuery(actualBulkId))
     ).collect({case Some(term)=>term})
 

--- a/app/helpers/LightboxHelper.scala
+++ b/app/helpers/LightboxHelper.scala
@@ -200,7 +200,7 @@ object LightboxHelper {
 
   def lightboxSearch(indexName:String, bulkId:Option[String], userEmail:String) =  {
     val queryTerms = Seq(
-      Some(matchQuery("lightboxEntries.owner", userEmail)),
+      Some(matchQuery("owner", userEmail)),
       bulkId.map(actualBulkId=>lightboxQuery(actualBulkId))
     ).collect({case Some(term)=>term})
 

--- a/app/helpers/LightboxStreamComponents/BulkRestoreStatsSink.scala
+++ b/app/helpers/LightboxStreamComponents/BulkRestoreStatsSink.scala
@@ -1,0 +1,72 @@
+package helpers.LightboxStreamComponents
+
+import akka.actor.ActorRef
+import akka.stream.{Attributes, Inlet, SinkShape}
+import akka.stream.stage.{AbstractInHandler, GraphStageLogic, GraphStageWithMaterializedValue}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.LightboxEntry
+import javax.inject.{Inject, Named}
+import models.BulkRestoreStats
+import akka.pattern.ask
+import play.api.Logger
+import services.GlacierRestoreActor._
+
+import scala.concurrent.{Await, Future, Promise}
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.duration._
+
+class BulkRestoreStatsSink @Inject() (@Named("glacierRestoreActor") glacierRestoreActor:ActorRef) extends GraphStageWithMaterializedValue[SinkShape[LightboxEntry], Future[BulkRestoreStats]]{
+  private final val in:Inlet[LightboxEntry] = Inlet("BulkRestoreStatsSink.in")
+  implicit val actorTimeout:akka.util.Timeout = 60 seconds
+
+  override def shape: SinkShape[LightboxEntry] = SinkShape.of(in)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[BulkRestoreStats]) = {
+    val logger = Logger(getClass)
+
+    val completionPromise = Promise[BulkRestoreStats]
+
+    var currentStats:BulkRestoreStats = BulkRestoreStats.empty
+    val logic = new GraphStageLogic(shape) {
+      setHandler(in, new AbstractInHandler {
+        override def onPush(): Unit = {
+          val elem = grab(in)
+
+          val result = Try { Await.result((glacierRestoreActor ? CheckRestoreStatus(elem)).mapTo[GRMsg], 60 seconds) }
+
+          result match {
+            case Failure(err)=>
+              logger.error(s"Could not check archive status on ${elem.fileId}", err)
+              failStage(err)
+            case Success(NotInArchive(entry))=>
+              logger.info(s"${elem.fileId} is not in Glacier")
+              currentStats = currentStats.copy(unneeded = currentStats.unneeded+1)
+            case Success(RestoreNotRequested(entry))=>
+              logger.info(s"${elem.fileId} was not requested")
+              currentStats = currentStats.copy(notRequested = currentStats.notRequested+1)
+            case Success(RestoreInProgress(entry))=>
+              logger.info(s"${elem.fileId} is currently restoring")
+              currentStats = currentStats.copy(inProgress = currentStats.inProgress+1)
+            case Success(RestoreCompleted(entry, expiry))=>
+              logger.info(s"${elem.fileId} is available")
+              currentStats = currentStats.copy(available = currentStats.available+1)
+            case Success(RestoreFailure(err))=>
+              logger.error(s"Could not check archive status on ${elem.fileId}", err)
+              failStage(err)
+          }
+
+          pull(in)
+        }
+      })
+
+      override def preStart(): Unit = {
+        pull(in)
+      }
+
+      override def postStop(): Unit = {
+        completionPromise.complete(Success(currentStats))
+      }
+    }
+
+    (logic, completionPromise.future)
+  }
+}

--- a/app/helpers/LightboxStreamComponents/BulkRestoreStatsSink.scala
+++ b/app/helpers/LightboxStreamComponents/BulkRestoreStatsSink.scala
@@ -14,6 +14,13 @@ import scala.concurrent.{Await, Future, Promise}
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration._
 
+/**
+  * an Akka streams sink that takes in a stream of LightboxEntries, checks the archive status on them and at the end
+  * materializes an object of [[BulkRestoreStats]] showing what state they are in.
+  * you should get hold of this using an injector, i.e. val sinkFactory = injector.getInstance(classOf[BulkRestoreStatsSink])
+  *
+  * @param glacierRestoreActor actorRef pointing to GlacierRestoreActor. Get this using an injector.
+  */
 class BulkRestoreStatsSink @Inject() (@Named("glacierRestoreActor") glacierRestoreActor:ActorRef) extends GraphStageWithMaterializedValue[SinkShape[LightboxEntry], Future[BulkRestoreStats]]{
   private final val in:Inlet[LightboxEntry] = Inlet("BulkRestoreStatsSink.in")
   implicit val actorTimeout:akka.util.Timeout = 60 seconds

--- a/app/helpers/LightboxStreamComponents/ExtractArchiveEntry.scala
+++ b/app/helpers/LightboxStreamComponents/ExtractArchiveEntry.scala
@@ -1,0 +1,26 @@
+package helpers.LightboxStreamComponents
+
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import com.theguardian.multimedia.archivehunter.common.ArchiveEntry
+import com.theguardian.multimedia.archivehunter.common.cmn_models.LightboxEntry
+
+class ExtractArchiveEntry extends GraphStage[FlowShape[(ArchiveEntry, LightboxEntry),ArchiveEntry]]{
+  private final val in:Inlet[(ArchiveEntry, LightboxEntry)] = Inlet("ExtractLightboxEntry.in")
+  private final val out:Outlet[ArchiveEntry] = Outlet("ExtractLightboxEntry.out")
+
+  override def shape: FlowShape[(ArchiveEntry, LightboxEntry), ArchiveEntry] = FlowShape.of(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elems = grab(in)
+        push(out, elems._1)
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+  }
+}

--- a/app/helpers/LightboxStreamComponents/ExtractArchiveEntry.scala
+++ b/app/helpers/LightboxStreamComponents/ExtractArchiveEntry.scala
@@ -5,6 +5,10 @@ import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, Gra
 import com.theguardian.multimedia.archivehunter.common.ArchiveEntry
 import com.theguardian.multimedia.archivehunter.common.cmn_models.LightboxEntry
 
+/**
+  * simple flow stage that takes in a tuple of (ArchiveEntry, LightboxEntry) as yielded by
+  * LookupLightboxEntryFlow/LookupArchiveEntryFromLBEntryFlow/ etc. and only returns the ArchiveEntry
+  */
 class ExtractArchiveEntry extends GraphStage[FlowShape[(ArchiveEntry, LightboxEntry),ArchiveEntry]]{
   private final val in:Inlet[(ArchiveEntry, LightboxEntry)] = Inlet("ExtractLightboxEntry.in")
   private final val out:Outlet[ArchiveEntry] = Outlet("ExtractLightboxEntry.out")

--- a/app/helpers/LightboxStreamComponents/LightboxDynamoSource.scala
+++ b/app/helpers/LightboxStreamComponents/LightboxDynamoSource.scala
@@ -1,0 +1,101 @@
+package helpers.LightboxStreamComponents
+
+import java.time.ZonedDateTime
+
+import akka.stream.{Attributes, Outlet, SourceShape}
+import akka.stream.stage.{AbstractOutHandler, GraphStage, GraphStageLogic}
+import com.amazonaws.services.dynamodbv2.model.{AttributeValue, QueryRequest, ScanRequest}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.DynamoClientManager
+import com.theguardian.multimedia.archivehunter.common.cmn_models.{LightboxEntry, RestoreStatus}
+import javax.inject.Inject
+import play.api.{Configuration, Logger}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
+class LightboxDynamoSource(memberOfBulk:String, config:Configuration, dynamoClientManager: DynamoClientManager) extends GraphStage[SourceShape[LightboxEntry]] {
+  private final val out:Outlet[LightboxEntry] = Outlet("LightboxDynamoSource.out")
+  val pageSize = 100
+
+  override def shape: SourceShape[LightboxEntry] = SourceShape.of(out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    protected val client = dynamoClientManager.getClient(config.getOptional[String]("externalData.awsProfile"))
+    val logger = Logger(getClass)
+    private var lastEvaluatedKey:Option[mutable.Map[String, AttributeValue]] = None
+
+    private var resultCache:Seq[mutable.Map[String,AttributeValue]] = Seq()
+    private var lastPage = false
+
+    def getNextPage(limit:Int,exclusiveStartKey:Option[mutable.Map[String, AttributeValue]]) = {
+      logger.info(s"getNextPage: memberOfBulk is $memberOfBulk")
+      val baseRq = new QueryRequest()
+        .withTableName(config.get[String]("lightbox.tableName"))
+        .withIndexName("memberOfBulkIndex")
+        .withLimit(limit)
+        .withKeyConditionExpression(s"memberOfBulk = :bulkId")
+        .withExpressionAttributeValues(Map(":bulkId"->new AttributeValue().withS(memberOfBulk)).asJava)
+
+      val rqWithStart = exclusiveStartKey match {
+        case Some(key)=>baseRq.withExclusiveStartKey(key.asJava)
+        case None=>baseRq
+      }
+
+      Try { client.query(rqWithStart) }
+    }
+
+    def optionalString(sourceData:mutable.Map[String, AttributeValue], key:String):Option[String] = {
+      sourceData.get(key).flatMap(attributeValue=>Option(attributeValue.getS))
+    }
+
+    def buildLightboxEntry(sourceData: mutable.Map[String,AttributeValue]):Try[LightboxEntry] = Try {
+      LightboxEntry(
+        sourceData("userEmail").getS,
+        sourceData("fileId").getS,
+        ZonedDateTime.parse(sourceData("addedAt").getS),
+        RestoreStatus.withName(sourceData("restoreStatus").getS),
+        optionalString(sourceData,"restoreStarted").map(timeStr=>ZonedDateTime.parse(timeStr)),
+        optionalString(sourceData,"restoreCompleted").map(timeStr=>ZonedDateTime.parse(timeStr)),
+        optionalString(sourceData,"availableUntil").map(timeStr=>ZonedDateTime.parse(timeStr)),
+        optionalString(sourceData,"lastError"),
+        optionalString(sourceData,"memberOfBulk")
+      )
+    }
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = {
+        if(resultCache.isEmpty && !lastPage){  //if we are empty, then grab the next page of results
+          logger.info("cache is empty, getting next page of 100 results")
+          getNextPage(pageSize, lastEvaluatedKey) match {
+            case Success(scanResult)=>
+              logger.info(s"Got scan result with ${scanResult.getCount} items")
+              lastEvaluatedKey = Option(scanResult.getLastEvaluatedKey.asScala)
+              resultCache = scanResult.getItems.asScala.map(_.asScala)
+              if(scanResult.getCount<pageSize) {
+                logger.info(s"${scanResult.getCount} items is less than page size of 100, assuming that all items have been returned")
+                lastPage = true
+              }
+            case Failure(err)=>
+              logger.error(s"Could not scan Dynamodb table: ", err)
+              throw err
+          }
+        }
+
+        if(resultCache.isEmpty ){  //if we are still empty here then no items were added.
+          logger.info(s"No more results were returned")
+          complete(out)
+        } else {
+          buildLightboxEntry(resultCache.head) match {
+            case Success(entry) =>
+              push(out, entry)
+              resultCache = resultCache.tail
+            case Failure(err) =>
+              logger.error(s"Could not marshal lightbox entry data into domain object", err)
+              throw err
+          } //match
+        } //if(resultCache.isEmpty)
+      } //onPull
+    }) //setHandler
+  } //new GraphStageLogic
+}

--- a/app/helpers/LightboxStreamComponents/LightboxDynamoSource.scala
+++ b/app/helpers/LightboxStreamComponents/LightboxDynamoSource.scala
@@ -36,7 +36,7 @@ class LightboxDynamoSource(memberOfBulk:String, config:Configuration, dynamoClie
 
     private var resultCache:Seq[mutable.Map[String,AttributeValue]] = Seq()
     private var lastPage = false
-
+    private var ctr = 0
     /**
       * retrieve next page of results from DynamoDB
       * @param limit maximum number of items to return
@@ -99,10 +99,13 @@ class LightboxDynamoSource(memberOfBulk:String, config:Configuration, dynamoClie
               logger.info(s"Got scan result with ${scanResult.getCount} items")
               lastEvaluatedKey = Option(scanResult.getLastEvaluatedKey.asScala)
               resultCache = scanResult.getItems.asScala.map(_.asScala)
+              ctr+=scanResult.getCount
+              logger.info(s"Scan returned ${scanResult.getCount} items, running total is now $ctr items total")
               if(scanResult.getCount<pageSize) {
                 logger.info(s"${scanResult.getCount} items is less than page size of 100, assuming that all items have been returned")
                 lastPage = true
               }
+
             case Failure(err)=>
               logger.error(s"Could not scan Dynamodb table: ", err)
               failStage(err)

--- a/app/helpers/LightboxStreamComponents/LookupArchiveEntryFromLBEntryFlow.scala
+++ b/app/helpers/LightboxStreamComponents/LookupArchiveEntryFromLBEntryFlow.scala
@@ -1,0 +1,37 @@
+package helpers.LightboxStreamComponents
+
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.ESClientManager
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.LightboxEntry
+import javax.inject.Inject
+import play.api.Configuration
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class LookupArchiveEntryFromLBEntryFlow @Inject()(config:Configuration, esClientManager: ESClientManager) extends GraphStage[FlowShape[LightboxEntry,(ArchiveEntry, LightboxEntry)]]{
+  private final val in:Inlet[LightboxEntry] = Inlet("LookupArchiveEntryFromLBEntryFlow.in")
+  private final val out:Outlet[(ArchiveEntry, LightboxEntry)] = Outlet("LookupArchiveEntryFromLBEntryFlow.out")
+
+  override def shape: FlowShape[LightboxEntry, (ArchiveEntry, LightboxEntry)] = FlowShape.of(in,out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    val indexer = new Indexer(config.get[String]("externalData.indexName"))
+    implicit val esClient = esClientManager.getClient()
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val lbEntry = grab(in)
+
+        val archiveEntry = Await.result(indexer.getById(lbEntry.fileId), 30 seconds)
+        push(out, (archiveEntry, lbEntry))
+      }
+    })
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+  }
+}

--- a/app/helpers/LightboxStreamComponents/LookupArchiveEntryFromLBEntryFlow.scala
+++ b/app/helpers/LightboxStreamComponents/LookupArchiveEntryFromLBEntryFlow.scala
@@ -5,12 +5,34 @@ import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, Gra
 import com.theguardian.multimedia.archivehunter.common.clientManagers.ESClientManager
 import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer}
 import com.theguardian.multimedia.archivehunter.common.cmn_models.LightboxEntry
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
+/**
+  * injectable filter stage that looks up the ArchiveEntry (from the index) associated with the given LightboxEntry and
+  * returns both as a tuple.
+  * You should obtain one like this:
+  *
+  * class MyControllerOrSomething @Inject() (...., injector:Injector) {
+  * .
+  * .
+  * .
+  *   def myFunction() = {
+  *   .
+  *   .
+  *   val lookupFlow = injector.getInstance(classOf[LookupArchiveEntryFromLBEntryFlow])
+  *   (now use lookupFlow)
+  *   /
+  *   /
+  *   }
+  * }
+  * @param config injected Configuration
+  * @param esClientManager injected elasticsearch client manager
+  */
+@Singleton
 class LookupArchiveEntryFromLBEntryFlow @Inject()(config:Configuration, esClientManager: ESClientManager) extends GraphStage[FlowShape[LightboxEntry,(ArchiveEntry, LightboxEntry)]]{
   private final val in:Inlet[LightboxEntry] = Inlet("LookupArchiveEntryFromLBEntryFlow.in")
   private final val out:Outlet[(ArchiveEntry, LightboxEntry)] = Outlet("LookupArchiveEntryFromLBEntryFlow.out")

--- a/app/helpers/LightboxStreamComponents/LookupLightboxEntryFlow.scala
+++ b/app/helpers/LightboxStreamComponents/LookupLightboxEntryFlow.scala
@@ -35,7 +35,7 @@ class LookupLightboxEntryFlow (username:String)(implicit val lightboxEntryDAO:Li
           None
         case Some(Left(err))=>
           logger.error(s"Could not look up lightbox entry for ${elem.id} on attempt $retryCount: $err")
-          if(retryCount>100) throw new RuntimeException(s"Could not look up lightbox entry: $err")
+          if(retryCount>100) failStage(new RuntimeException(s"Could not look up lightbox entry: $err"))
           retryGetEntry(elem, retryCount+1)
         case success @ Some(Right(_))=>success
       }

--- a/app/helpers/LightboxStreamComponents/RemoveLightboxEntrySink.scala
+++ b/app/helpers/LightboxStreamComponents/RemoveLightboxEntrySink.scala
@@ -37,7 +37,7 @@ class RemoveLightboxEntrySink (userEmail:String)(implicit lightboxEntryDAO:Light
             case Failure(err)=>
               logger.error(s"Could not delete lightbox entry $elem: ", err)
               promise.failure(err)
-              throw err
+              failStage(err)
           })
 
           Await.ready(deleteFuture, 30 seconds)

--- a/app/helpers/LightboxStreamComponents/RemoveLightboxIndexInfoSink.scala
+++ b/app/helpers/LightboxStreamComponents/RemoveLightboxIndexInfoSink.scala
@@ -38,7 +38,7 @@ class RemoveLightboxIndexInfoSink (userEmail:String)(implicit esClient:HttpClien
               MDC.put("error",err.toString)
               MDC.put("entry",elem.toString)
               logger.error(s"Could not remove lightbox entry data: ${err.toString}")
-              throw new RuntimeException(err.toString)
+              failStage(new RuntimeException(err.toString))
           }), 30 seconds)
           pull(in)
         }

--- a/app/helpers/LightboxStreamComponents/SaveLightboxEntryFlow.scala
+++ b/app/helpers/LightboxStreamComponents/SaveLightboxEntryFlow.scala
@@ -58,7 +58,7 @@ class SaveLightboxEntryFlow (bulkId:String,userProfile: UserProfile)
               logger.error("Could not save lightbox entry", err)
               //fail the output immediately, this should get seen by the stream's user
               promise.failure(err)
-              throw err
+              failStage(err)
           }
         }
       })

--- a/app/helpers/LightboxStreamComponents/UpdateLightboxIndexInfoSink.scala
+++ b/app/helpers/LightboxStreamComponents/UpdateLightboxIndexInfoSink.scala
@@ -56,7 +56,7 @@ class UpdateLightboxIndexInfoSink (bulkId:String,userProfile: UserProfile, userA
               logger.error(s"Could not update lightbox info: ${err.toString}")
               val excep = new RuntimeException(err.toString)
               promise.failure(excep)
-              throw excep
+              failStage(excep)
           }
         }
       })

--- a/app/helpers/S3ToArchiveEntryFlow.scala
+++ b/app/helpers/S3ToArchiveEntryFlow.scala
@@ -110,8 +110,7 @@ class S3ToArchiveEntryFlow @Inject() (s3ClientMgr: S3ClientManager, config:Confi
           } catch {
             case ex:Throwable=>
               logger.error(s"Could not create ArchiveEntry: ", ex)
-              failStage(ex) //temp for debugging
-              //pull(in)
+              failStage(ex)
           }
         }
       })

--- a/app/helpers/S3ToArchiveEntryFlow.scala
+++ b/app/helpers/S3ToArchiveEntryFlow.scala
@@ -52,24 +52,24 @@ class S3ToArchiveEntryFlow @Inject() (s3ClientMgr: S3ClientManager, config:Confi
         }
 
         val secondUpdate = if(existingEntry.etag!=newEntry.etag){
-          logger.info(s"etag updated on ${existingEntry.id}")
+          logger.info(s"etag updated on ${existingEntry.location}")
           firstUpdate.copy(etag = newEntry.etag)
         } else {
           firstUpdate
         }
 
         val thirdUpdate = if(existingEntry.storageClass!=newEntry.storageClass){
-          logger.info(s"storage class updated on ${existingEntry.id}")
+          logger.info(s"storage class updated on ${existingEntry.location}")
           secondUpdate.copy(storageClass = newEntry.storageClass)
         } else {
           secondUpdate
         }
 
         if(thirdUpdate==existingEntry){
-          logger.info(s"No differences on ${existingEntry.id}")
+          logger.info(s"No differences on ${existingEntry.location}")
           None
         } else {
-          logger.info(s"Updates detected on ${existingEntry.id}")
+          logger.info(s"Updates detected on ${existingEntry.location}")
           Some(thirdUpdate)
         }
       }
@@ -102,7 +102,8 @@ class S3ToArchiveEntryFlow @Inject() (s3ClientMgr: S3ClientManager, config:Confi
               case Some(elemToUpdate)=>
                 push(out, elemToUpdate)
               case None=>
-                logger.info(s"Nothing to update on ${mappedElem.id}, grabbing next item")
+                logger.info(s"Nothing to update on ${mappedElem.location
+                }, grabbing next item")
                 pull(in)
             }
 

--- a/app/models/BulkRestoreStats.scala
+++ b/app/models/BulkRestoreStats.scala
@@ -1,0 +1,7 @@
+package models
+
+object BulkRestoreStats extends ((Int,Int,Int,Int)=>BulkRestoreStats) {
+  def empty:BulkRestoreStats = new BulkRestoreStats(0,0,0,0)
+}
+
+case class BulkRestoreStats(unneeded:Int, inProgress:Int, available:Int, notRequested:Int)

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -211,6 +211,8 @@ Resources:
           AttributeType: S
         - AttributeName: restoreStatus
           AttributeType: S
+        - AttributeName: memberOfBulk
+          AttributeType: S
       KeySchema:
         - AttributeName: userEmail
           KeyType: HASH
@@ -225,6 +227,17 @@ Resources:
             - AttributeName: restoreStatus
               KeyType: HASH
             - AttributeName: fileId
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            WriteCapacityUnits: 1
+            ReadCapacityUnits: 4
+        - IndexName: memberOfBulkIndex
+          KeySchema:
+            - AttributeName: memberOfBulk
+              KeyType: HASH
+            - AttributeName: userEmail
               KeyType: RANGE
           Projection:
             ProjectionType: ALL

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveEntry.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveEntry.scala
@@ -98,4 +98,6 @@ case class ArchiveEntry(id:String, bucket: String, path: String, region:Option[S
         case Some(Left(err))=>throw new RuntimeException(err.toString)
       })
   }
+
+  def location:String = s"s3://$bucket/$path"
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -49,6 +49,7 @@
     <logger name="helpers.SearchHitToArchiveEntryFlow" level="WARN"/>
     <logger name="helpers.ArchiveEntryVerifyFlow" level="WARN"/>
     <logger name="helpers.LightboxStreamComponents.SaveLightboxEntryFlow" level="DEBUG"/>
+
     <logger name="com.sksamuel.elastic4s.streams" level="WARN"/>
     <logger name="controllers.SearchController" level="WARN"/>
     <logger name="controllers.ProxyHealthController" level="INFO"/>
@@ -101,7 +102,6 @@
     <logger name="helpers.LightboxHelper$" level="INFO"/>
     <logger name="helpers.LightboxHelper" level="INFO"/>
 
-    <logger name="helpers.LightboxStreamComponents" level="INFO"/>
 
     <root level="WARN">
         <appender-ref ref="STDOUT" />

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -100,6 +100,9 @@
 
     <logger name="helpers.LightboxHelper$" level="INFO"/>
     <logger name="helpers.LightboxHelper" level="INFO"/>
+
+    <logger name="helpers.LightboxStreamComponents" level="INFO"/>
+
     <root level="WARN">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="ASYNCFILE"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -45,7 +45,7 @@
     <logger name="services.BucketScanner" level="INFO"/>
     <logger name="akka.cluster" level="ERROR"/>
     <logger name="helpers.LightboxStreamComponents" level="INFO"/>
-    <logger name="helpers.S3ToArchiveEntryFlow" level="WARN"/>
+    <logger name="helpers.S3ToArchiveEntryFlow" level="INFO"/>
     <logger name="helpers.SearchHitToArchiveEntryFlow" level="WARN"/>
     <logger name="helpers.ArchiveEntryVerifyFlow" level="WARN"/>
     <logger name="helpers.LightboxStreamComponents.SaveLightboxEntryFlow" level="DEBUG"/>

--- a/conf/routes
+++ b/conf/routes
@@ -83,6 +83,7 @@ GET     /api/lightbox/bulk/appDownload/:bulkId  @controllers.LightboxController.
 GET     /api/download/:fileId           @controllers.LightboxController.getDownloadLink(fileId)
 
 GET     /api/archive/status/:fileId     @controllers.LightboxController.checkRestoreStatus(user:String ?= "my", fileId)
+GET     /api/archive/bulkStatus/:user/:bulkId   @controllers.LightboxController.bulkCheckRestoreStatus(user:String, bulkId:String)
 
 GET     /api/version                    @controllers.VersionController.getInfo
 

--- a/conf/routes
+++ b/conf/routes
@@ -76,6 +76,7 @@ PUT     /api/lightbox/:user/:fileId             @controllers.LightboxController.
 DELETE  /api/lightbox/:user/:fileId             @controllers.LightboxController.removeFromLightbox(user, fileId)
 GET     /api/lightbox/:user/bulks               @controllers.LightboxController.myBulks(user)
 PUT     /api/lightbox/:user/redoRestore/:fileId @controllers.LightboxController.redoRestore(user, fileId)
+PUT     /api/lightbox/:user/bulk/verifiy/:bulkId     @controllers.LightboxController.verifyBulkLightbox(user, bulkId)
 PUT     /api/lightbox/:user/bulk/redoRestore/:bulkId @controllers.LightboxController.redoBulk(user:String, bulkId:String)
 GET     /api/lightbox/bulk/appDownload/:bulkId  @controllers.LightboxController.bulkDownloadInApp(bulkId)
 

--- a/frontend/app/Lightbox/BulkSelectionStats.jsx
+++ b/frontend/app/Lightbox/BulkSelectionStats.jsx
@@ -1,0 +1,58 @@
+import React from "react"
+import axios from "axios"
+import PropTypes from "prop-types"
+import ErrorViewComponent from "../common/ErrorViewComponent.jsx";
+import LoadingThrobber from "../common/LoadingThrobber.jsx";
+
+class BulkSelectionStats extends React.Component {
+    static propTypes = {
+        bulkId: PropTypes.string,
+        user: PropTypes.string.isRequired
+    };
+
+    constructor(props){
+        super(props);
+
+        this.state = {
+            loading: false,
+            currentStats: null,
+            lastError: null
+        }
+    }
+
+    loadData(){
+        if(this.props.bulkId){
+            this.setState({loading: true, lastError: null, currentStats: null}, ()=>axios.get("/api/archive/bulkStatus/" + this.props.user + "/" + this.props.bulkId).then(
+                response=>{
+                    this.setState({loading: false, lastError: null, currentStats: response.data.entry})
+                }).catch(err=>{
+                    this.setState({loading: false, lastError: err})
+            }))
+        } else {
+            this.setState({loading: false, currentStats: null, lastError: null})
+        }
+    }
+
+    componentWillMount() {
+        this.loadData();
+    }
+
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        if(prevProps.bulkId!==this.props.bulkId || prevProps.user!==this.props.user) this.loadData();
+    }
+
+    render() {
+        return <p className="information">
+            <LoadingThrobber show={this.state.loading} small={true} inline={true}/>
+            {
+                this.state.lastError ? <ErrorViewComponent error={this.state.lastError}/> : ""
+            }
+            {
+                this.state.currentStats ? "Un-needed: " + this.state.currentStats.unneeded + " In progress: " + this.state.currentStats.inProgress + " Available: " + this.state.currentStats.available + " Not requested: " + this.state.currentStats.notRequested :
+                    "Select a bulk to see restore stats"
+            }
+        </p>
+    }
+}
+
+export default BulkSelectionStats;

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -9,6 +9,7 @@ import AvailabilityInsert from "./AvailabilityInsert.jsx";
 import BulkSelectionsScroll from "./BulkSelectionsScroll.jsx";
 import UserSelector from "../common/UserSelector.jsx";
 import LoadingThrobber from "../common/LoadingThrobber.jsx";
+import BulkSelectionStats from "./BulkSelectionStats.jsx";
 
 class MyLightbox extends CommonSearchView {
     constructor(props){
@@ -238,6 +239,7 @@ class MyLightbox extends CommonSearchView {
                                   forUser={this.state.selectedUser}
                                   isAdmin={this.state.userDetails && this.state.userDetails.isAdmin}
             />
+            <BulkSelectionStats user={this.state.selectedUser} bulkId={this.state.bulkSelectionSelected}/>
 
             <EntryDetails entry={this.state.showingPreview}
                           autoPlay={this.state.autoPlay}

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -26,7 +26,8 @@ class MyLightbox extends CommonSearchView {
             bulkSelectionSelected: null,
             selectedUser: "my",
             showingArchiveSpinner: false,
-            selectedRestoreStatus: null
+            selectedRestoreStatus: null,
+            pageSize: 500
         };
 
         this.checkArchiveStatus = this.checkArchiveStatus.bind(this);
@@ -39,7 +40,7 @@ class MyLightbox extends CommonSearchView {
 
     performLoad(){
         const detailsRequest = axios.get("/api/lightbox/" + this.state.selectedUser+"/details");
-        const summaryRequest = axios.get("/api/search/myLightBox?user=" + this.state.selectedUser);
+        const summaryRequest = axios.get("/api/search/myLightBox?user=" + this.state.selectedUser + "&size=" + this.state.pageSize);
         const loginDetailsRequest = axios.get("/api/loginStatus");
         const bulkSelectionsRequest = axios.get("/api/lightbox/" + this.state.selectedUser+"/bulks");
         return Promise.all([detailsRequest, summaryRequest, loginDetailsRequest, bulkSelectionsRequest]);

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -77,8 +77,8 @@ class MyLightbox extends CommonSearchView {
     reloadSearch(){
         const detailsRequest = axios.get("/api/lightbox/" + this.state.selectedUser + "/details");
         const searchUrl = this.state.bulkSelectionSelected ?
-            "/api/search/myLightBox?bulkId=" + this.state.bulkSelectionSelected + "&user=" + this.state.selectedUser :
-            "/api/search/myLightBox?user="+ this.state.selectedUser;
+            "/api/search/myLightBox?bulkId=" + this.state.bulkSelectionSelected + "&user=" + this.state.selectedUser + "&size=" + this.state.pageSize :
+            "/api/search/myLightBox?user="+ this.state.selectedUser + "&size=" + this.state.pageSize ;
 
         const searchRequest = axios.get(searchUrl);
 

--- a/test/GlacierRestoreActorSpec.scala
+++ b/test/GlacierRestoreActorSpec.scala
@@ -8,7 +8,7 @@ import play.api.Configuration
 import services.GlacierRestoreActor
 import akka.pattern.ask
 import akka.util.Timeout
-import com.amazonaws.services.s3.model.RestoreObjectRequest
+import com.amazonaws.services.s3.model.{RestoreObjectRequest, RestoreObjectResult}
 import com.theguardian.multimedia.archivehunter.common.ArchiveEntry
 
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -25,6 +25,10 @@ class GlacierRestoreActorSpec extends Specification with Mockito {
       mockedConfig.getOptional[Int]("archive.restoresExpireAfter") returns Some(3)
       val mockedS3ClientManager = mock[S3ClientManager]
       val mockedS3Client = mock[AmazonS3]
+      val mockedRestoreResult = new RestoreObjectResult()
+      mockedRestoreResult.setRequesterCharged(true)
+      mockedRestoreResult.setRestoreOutputPath("/some/test/path")
+      mockedS3Client.restoreObjectV2(any) returns mockedRestoreResult
       mockedS3ClientManager.getClient(any) returns mockedS3Client
       val mockedJobModelDAO = mock[JobModelDAO]
       mockedJobModelDAO.putJob(any[JobModel]) returns Future(None)


### PR DESCRIPTION
- update bucket scanner to modify existing records rather than over-writing. No modification if there is no update.
- endpoint to ensure that index data for lightbox membership is in-sync with dynamodb. Not wired to UI as it's not obvious that it's needed.
- update "redo bulk restore" to source its data from Dynamo rather than Elastic
