### PR TITLE
Ignore outdated "scan in progress" flags

### DIFF
--- a/app/services/BucketScanner.scala
+++ b/app/services/BucketScanner.scala
@@ -1,8 +1,6 @@
 package services
 
 import java.time.ZonedDateTime
-import java.time.temporal.{ChronoUnit, IsoFields, TemporalUnit}
-
 import akka.NotUsed
 import akka.actor.{Actor, ActorSystem, Timers}
 import akka.stream.scaladsl.{GraphDSL, Keep, RunnableGraph, Sink, Source}

--- a/app/services/BucketScannerFunctions.scala
+++ b/app/services/BucketScannerFunctions.scala
@@ -1,0 +1,55 @@
+package services
+
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTarget
+import play.api.{Configuration, Logger}
+
+trait BucketScannerFunctions {
+  val config:Configuration
+  protected val logger:Logger
+
+  /**
+    * returns a boolean indicating whether the given target is due a scan, i.e. last_scan + scan_interval < now OR
+    * not scanned at all
+    * @param target [[ScanTarget]] instance to check
+    * @return boolean flag
+    */
+  def scanIsScheduled(target: ScanTarget) = {
+    target.lastScanned match {
+      case None=>true
+      case Some(lastScanned)=>
+        logger.info(s"${target.bucketName}: Next scan is due at ${lastScanned.plus(target.scanInterval,ChronoUnit.SECONDS)}")
+        lastScanned.plus(target.scanInterval,ChronoUnit.SECONDS).isBefore(ZonedDateTime.now())
+    }
+  }
+
+  /**
+    * returns a boolean indicating whether we should consider that a scan is in progress.
+    * if there is a scan in progress but it's onlder than "scanner.staleAge" in the config then we run anyway
+    * @param scanTarget
+    * @return boolean indicating if a scan is in progress. True if so (i.e. don't rescan) or False.
+    */
+  def scanIsInProgress(scanTarget:ScanTarget) =
+    if (scanTarget.scanInProgress) {
+      scanTarget.lastScanned match {
+        case Some(lastScanTime) =>
+          val oneDay = 86400  //1 day in seconds
+          val oldest = config.getOptional[Int]("scanner.staleAge").getOrElse(2) * oneDay
+
+          val interval = ZonedDateTime.now().toInstant.getEpochSecond - lastScanTime.toInstant.getEpochSecond
+
+          if (interval > oldest) {
+            logger.warn(s"Current scan is ${interval/oneDay} days old, assuming that it is stale. Rescanning anyway.")
+            false
+          } else {
+            true
+          }
+        case None=>
+          true
+      }
+    } else {
+      false
+    }
+
+}

--- a/test/BucketScannerFunctionsSpec.scala
+++ b/test/BucketScannerFunctionsSpec.scala
@@ -15,7 +15,7 @@ class BucketScannerFunctionsSpec extends Specification with Mockito {
         override val config: Configuration = Configuration.empty
       }
 
-      val testScanTarget = ScanTarget("testbucket",true,None,1234L, false, None,"proxybucket","region",None,None,None)
+      val testScanTarget = ScanTarget("testbucket",true,None,1234L, false, None,"proxybucket","region",None,None,None, proxyEnabled = Some(false))
       toTest.scanIsInProgress(testScanTarget) mustEqual false
     }
   }
@@ -29,7 +29,7 @@ class BucketScannerFunctionsSpec extends Specification with Mockito {
     }
 
     val lastScanTime = ZonedDateTime.now().minus(5, ChronoUnit.DAYS)
-    val testScanTarget = ScanTarget("testbucket",enabled=true,Some(lastScanTime),1234L, scanInProgress = true, None,"proxybucket","region",None,None,None)
+    val testScanTarget = ScanTarget("testbucket",enabled=true,Some(lastScanTime),1234L, scanInProgress = true, None,"proxybucket","region",None,None,None, proxyEnabled = Some(false))
     toTest.scanIsInProgress(testScanTarget) mustEqual false
 
   }
@@ -43,7 +43,7 @@ class BucketScannerFunctionsSpec extends Specification with Mockito {
     }
 
     val lastScanTime = ZonedDateTime.now().minus(1, ChronoUnit.DAYS)
-    val testScanTarget = ScanTarget("testbucket",enabled=true,Some(lastScanTime),1234L, scanInProgress = true, None,"proxybucket","region",None,None,None)
+    val testScanTarget = ScanTarget("testbucket",enabled=true,Some(lastScanTime),1234L, scanInProgress = true, None,"proxybucket","region",None,None,None, proxyEnabled = Some(false))
     toTest.scanIsInProgress(testScanTarget) mustEqual true
 
   }

--- a/test/BucketScannerFunctionsSpec.scala
+++ b/test/BucketScannerFunctionsSpec.scala
@@ -1,0 +1,50 @@
+import java.time.ZonedDateTime
+import java.time.temporal.{ChronoUnit, TemporalAdjuster, TemporalAdjusters, TemporalUnit}
+
+import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTarget
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import play.api.{Configuration, Logger}
+import services.BucketScannerFunctions
+
+class BucketScannerFunctionsSpec extends Specification with Mockito {
+  "BucketScannerFunctions.scanIsInProgress" should {
+    "return false if there is no scan in progress" in {
+      val toTest = new BucketScannerFunctions {
+        override protected val logger = mock[Logger]
+        override val config: Configuration = Configuration.empty
+      }
+
+      val testScanTarget = ScanTarget("testbucket",true,None,1234L, false, None,"proxybucket","region",None,None,None)
+      toTest.scanIsInProgress(testScanTarget) mustEqual false
+    }
+  }
+
+  "return false if there appears to be a scan in progress that is too old" in {
+    val toTest = new BucketScannerFunctions {
+      override protected val logger = mock[Logger]
+      override val config: Configuration = Configuration.from(Map(
+        "scanner.staleAge"->4
+      ))
+    }
+
+    val lastScanTime = ZonedDateTime.now().minus(5, ChronoUnit.DAYS)
+    val testScanTarget = ScanTarget("testbucket",enabled=true,Some(lastScanTime),1234L, scanInProgress = true, None,"proxybucket","region",None,None,None)
+    toTest.scanIsInProgress(testScanTarget) mustEqual false
+
+  }
+
+  "return true if there is a scan in progress and it is not too old" in {
+    val toTest = new BucketScannerFunctions {
+      override protected val logger = mock[Logger]
+      override val config: Configuration = Configuration.from(Map(
+        "scanner.staleAge"->4
+      ))
+    }
+
+    val lastScanTime = ZonedDateTime.now().minus(1, ChronoUnit.DAYS)
+    val testScanTarget = ScanTarget("testbucket",enabled=true,Some(lastScanTime),1234L, scanInProgress = true, None,"proxybucket","region",None,None,None)
+    toTest.scanIsInProgress(testScanTarget) mustEqual true
+
+  }
+}


### PR DESCRIPTION
If a scan has apparently been in progress for an unfeasibly long time then ignore it and rescan anyway