### PR TITLE
Items Not in Glacier Now Not Shown as Errors and New Icon Added

### DIFF
--- a/app/controllers/LightboxController.scala
+++ b/app/controllers/LightboxController.scala
@@ -267,7 +267,7 @@ class LightboxController @Inject() (override val config:Configuration,
             case GlacierRestoreActor.RestoreInProgress(entry)=>
               Ok(RestoreStatusResponse("ok", entry.id, RestoreStatus.RS_UNDERWAY, None, None).asJson)
             case GlacierRestoreActor.RestoreNotRequested(entry)=>
-              Ok(RestoreStatusResponse("not_requested", entry.id, RestoreStatus.RS_ERROR, None, None).asJson)
+              Ok(RestoreStatusResponse("not_requested", entry.id, RestoreStatus.RS_UNNEEDED, None, None).asJson)
           })
       })
     }

--- a/frontend/app/Lightbox/LightboxInfoInsert.jsx
+++ b/frontend/app/Lightbox/LightboxInfoInsert.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TimestampFormatter from "../common/TimestampFormatter.jsx";
 import RestoreStatusComponent from "./RestoreStatusComponent.jsx";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 class LightboxInfoInsert extends React.Component {
     static propTypes = {
         entry: PropTypes.object.isRequired,
-        extraInfo: PropTypes.string
+        extraInfo: PropTypes.string,
+        iconName: PropTypes.string,
     };
 
     render(){
@@ -22,9 +24,9 @@ class LightboxInfoInsert extends React.Component {
                 startTime={this.props.entry.restoreStarted}
                 completed={this.props.entry.restoreCompleted}
                 expires={this.props.entry.availableUntil}
-            />
+                hidden={this.props.entry.restoreStatus==="RS_UNNEEDED"}/>
             {
-                this.props.extraInfo ? <p className="centered">{this.props.extraInfo}</p> : ""
+                this.props.extraInfo ? <p className="centered"><FontAwesomeIcon icon={this.props.iconName} size="1.5x" style={{color:"yellow"}}/> {this.props.extraInfo}</p> : ""
             }
         </div>
     }

--- a/frontend/app/Lightbox/LightboxInfoInsert.jsx
+++ b/frontend/app/Lightbox/LightboxInfoInsert.jsx
@@ -22,7 +22,7 @@ class LightboxInfoInsert extends React.Component {
                 startTime={this.props.entry.restoreStarted}
                 completed={this.props.entry.restoreCompleted}
                 expires={this.props.entry.availableUntil}
-                hidden={this.props.entry.restoreStatus==="RS_UNNEEDED"}/>
+            />
             {
                 this.props.extraInfo ? <p className="centered">{this.props.extraInfo}</p> : ""
             }

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -157,7 +157,7 @@ class MyLightbox extends CommonSearchView {
             window.setTimeout(this.checkArchiveStatus, 3000);
         }).catch(err=>{
             console.error(err);
-            this.setState({showingArchiveSpinner: false, selectedRestoreStatus: err.response.data && err.response.data.detail ? err.response.data.detail : ""});
+            this.setState({showingArchiveSpinner: false});
         }));
     }
 
@@ -177,7 +177,7 @@ class MyLightbox extends CommonSearchView {
 
                 this.updateSearchResults(updatedEntry, itemIndex, this.state.showingPreview.id).then(()=>{
                     if(response.data.restoreStatus==="RS_UNNEEDED"){
-                        this.setState({showingArchiveSpinner: false, selectedRestoreStatus: response.data.restoreStatus, extraInfo: "Not in deep-freeze"})
+                        this.setState({showingArchiveSpinner: false, extraInfo: "Not in deep-freeze"})
                     } else if(this.state.extraInfo!==""){
                         this.setState({showingArchiveSpinner: false, selectedRestoreStatus: response.data.restoreStatus, extraInfo: ""})
                     }

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -28,7 +28,6 @@ class MyLightbox extends CommonSearchView {
             selectedUser: "my",
             showingArchiveSpinner: false,
             selectedRestoreStatus: null,
-            showRedoButton: true,
             pageSize: 500
         };
 
@@ -126,11 +125,11 @@ class MyLightbox extends CommonSearchView {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
-        if(prevState.showingPreview!==this.state.showingPreview) this.setState({selectedRestoreStatus: null, showRedoButton: true, extraInfo: ""});
+        if(prevState.showingPreview!==this.state.showingPreview) this.setState({selectedRestoreStatus: null, extraInfo: ""});
     }
 
     bulkSelectionChanged(newValue){
-        this.setState({bulkSelectionSelected: newValue, selectedRestoreStatus: null, showRedoButton: true, extraInfo: ""}, this.reloadSearch);
+        this.setState({bulkSelectionSelected: newValue, selectedRestoreStatus: null, extraInfo: ""}, this.reloadSearch);
     }
 
     shouldHideAvailability(entry){
@@ -179,7 +178,7 @@ class MyLightbox extends CommonSearchView {
 
                 this.updateSearchResults(updatedEntry, itemIndex, this.state.showingPreview.id).then(()=>{
                     if(response.data.restoreStatus==="RS_UNNEEDED"){
-                        this.setState({showingArchiveSpinner: false, showRedoButton: false, extraInfo: "Not in deep-freeze"})
+                        this.setState({showingArchiveSpinner: false, extraInfo: "Not in deep-freeze"})
                     } else if(this.state.extraInfo!==""){
                         this.setState({showingArchiveSpinner: false, selectedRestoreStatus: response.data.restoreStatus, extraInfo: ""})
                     }
@@ -197,11 +196,11 @@ class MyLightbox extends CommonSearchView {
         return ""
     }
 
-    displayRedo(){
-        if(this.state.showRedoButton) {
-            return "Redo restore";
-        } else {
+    displayRedo(status){
+        if(status==='RS_UNNEEDED') {
             return "";
+        } else {
+            return "Redo restore";
         }
     }
 
@@ -217,7 +216,7 @@ class MyLightbox extends CommonSearchView {
                 extraInfo={this.state.extraInfo}
             />
             <p className="centered small"><a style={{cursor: "pointer"}} onClick={this.checkArchiveStatus}>Re-check</a></p>
-            <p className="centered small"><a style={{cursor: "pointer"}} onClick={this.redoRestore}>{this.displayRedo()}</a><LoadingThrobber show={this.state.showingArchiveSpinner} small={true}/> </p>
+            <p className="centered small"><a style={{cursor: "pointer"}} onClick={this.redoRestore}>{this.displayRedo(this.state.showingPreview ? this.state.showingPreview.details.restoreStatus : "")}</a><LoadingThrobber show={this.state.showingArchiveSpinner} small={true}/> </p>
             <p className="centered small information" style={{display: this.state.selectedRestoreStatus ? "block": "none"}}>
                 {this.state.selectedRestoreStatus}
             </p>

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -28,6 +28,7 @@ class MyLightbox extends CommonSearchView {
             selectedUser: "my",
             showingArchiveSpinner: false,
             selectedRestoreStatus: null,
+            showRedoButton: true,
             pageSize: 500
         };
 
@@ -37,6 +38,7 @@ class MyLightbox extends CommonSearchView {
         this.bulkSearchDeleteRequested = this.bulkSearchDeleteRequested.bind(this);
         this.userChanged = this.userChanged.bind(this);
         this.redoRestore = this.redoRestore.bind(this);
+        this.displayRedo = this.displayRedo.bind(this);
     }
 
     performLoad(){
@@ -124,11 +126,11 @@ class MyLightbox extends CommonSearchView {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
-        if(prevState.showingPreview!==this.state.showingPreview) this.setState({selectedRestoreStatus: null});
+        if(prevState.showingPreview!==this.state.showingPreview) this.setState({selectedRestoreStatus: null, showRedoButton: true});
     }
 
     bulkSelectionChanged(newValue){
-        this.setState({bulkSelectionSelected: newValue, selectedRestoreStatus: null}, this.reloadSearch);
+        this.setState({bulkSelectionSelected: newValue, selectedRestoreStatus: null, showRedoButton: true}, this.reloadSearch);
     }
 
     shouldHideAvailability(entry){
@@ -177,7 +179,7 @@ class MyLightbox extends CommonSearchView {
 
                 this.updateSearchResults(updatedEntry, itemIndex, this.state.showingPreview.id).then(()=>{
                     if(response.data.restoreStatus==="RS_UNNEEDED"){
-                        this.setState({showingArchiveSpinner: false, extraInfo: "Not in deep-freeze"})
+                        this.setState({showingArchiveSpinner: false, showRedoButton: false, extraInfo: "Not in deep-freeze"})
                     } else if(this.state.extraInfo!==""){
                         this.setState({showingArchiveSpinner: false, selectedRestoreStatus: response.data.restoreStatus, extraInfo: ""})
                     }
@@ -195,6 +197,14 @@ class MyLightbox extends CommonSearchView {
         return ""
     }
 
+    displayRedo(){
+        if(this.state.showRedoButton) {
+            return "Redo restore";
+        } else {
+            return "";
+        }
+    }
+
     render(){
         /**
          * this describes an "insert" into the standard entry details view, to provide lightbox-specific data
@@ -207,7 +217,7 @@ class MyLightbox extends CommonSearchView {
                 extraInfo={this.state.extraInfo}
             />
             <p className="centered small"><a style={{cursor: "pointer"}} onClick={this.checkArchiveStatus}>Re-check</a></p>
-            <p className="centered small"><a style={{cursor: "pointer"}} onClick={this.redoRestore}>Redo restore</a><LoadingThrobber show={this.state.showingArchiveSpinner} small={true}/> </p>
+            <p className="centered small"><a style={{cursor: "pointer"}} onClick={this.redoRestore}>{this.displayRedo()}</a><LoadingThrobber show={this.state.showingArchiveSpinner} small={true}/> </p>
             <p className="centered small information" style={{display: this.state.selectedRestoreStatus ? "block": "none"}}>
                 {this.state.selectedRestoreStatus}
             </p>

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -126,11 +126,11 @@ class MyLightbox extends CommonSearchView {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
-        if(prevState.showingPreview!==this.state.showingPreview) this.setState({selectedRestoreStatus: null, showRedoButton: true});
+        if(prevState.showingPreview!==this.state.showingPreview) this.setState({selectedRestoreStatus: null, showRedoButton: true, extraInfo: ""});
     }
 
     bulkSelectionChanged(newValue){
-        this.setState({bulkSelectionSelected: newValue, selectedRestoreStatus: null, showRedoButton: true}, this.reloadSearch);
+        this.setState({bulkSelectionSelected: newValue, selectedRestoreStatus: null, showRedoButton: true, extraInfo: ""}, this.reloadSearch);
     }
 
     shouldHideAvailability(entry){

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -204,6 +204,14 @@ class MyLightbox extends CommonSearchView {
         }
     }
 
+    displayInfo(status){
+        if(status==='RS_UNNEEDED') {
+            return "Not in deep freeze";
+        } else {
+            return this.state.extraInfo;
+        }
+    }
+
     render(){
         /**
          * this describes an "insert" into the standard entry details view, to provide lightbox-specific data
@@ -213,7 +221,8 @@ class MyLightbox extends CommonSearchView {
                 entry={this.state.showingPreview && this.state.showingPreview.details ?
                             this.state.showingPreview.details : null
                 }
-                extraInfo={this.state.extraInfo}
+                extraInfo={this.displayInfo(this.state.showingPreview ? this.state.showingPreview.details.restoreStatus : "")}
+                iconName="file"
             />
             <p className="centered small"><a style={{cursor: "pointer"}} onClick={this.checkArchiveStatus}>Re-check</a></p>
             <p className="centered small"><a style={{cursor: "pointer"}} onClick={this.redoRestore}>{this.displayRedo(this.state.showingPreview ? this.state.showingPreview.details.restoreStatus : "")}</a><LoadingThrobber show={this.state.showingArchiveSpinner} small={true}/> </p>

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -37,7 +37,6 @@ class MyLightbox extends CommonSearchView {
         this.bulkSearchDeleteRequested = this.bulkSearchDeleteRequested.bind(this);
         this.userChanged = this.userChanged.bind(this);
         this.redoRestore = this.redoRestore.bind(this);
-        this.displayRedo = this.displayRedo.bind(this);
     }
 
     performLoad(){

--- a/frontend/app/Lightbox/RestoreStatusComponent.jsx
+++ b/frontend/app/Lightbox/RestoreStatusComponent.jsx
@@ -28,7 +28,7 @@ class RestoreStatusComponent extends React.Component {
             case "RS_ERROR":
                 return <span data-tip="Error" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="exclamation-triangle" style={{color:"red"}}/></span>;
             case "RS_UNNEEDED":
-                return <span data-tip="Unneeded" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="not-equal" style={{color:"yellow"}}/></span>;
+                return <span data-tip="Unneeded" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="file" style={{color:"yellow"}}/></span>;
             default:
                 return <span data-tip={this.props.status}>{this.props.status}</span>;
         }
@@ -45,7 +45,7 @@ class RestoreStatusComponent extends React.Component {
             case "RS_ERROR":
                 return <TimestampFormatter relative={true} value={this.props.completed ? this.props.completed : this.props.startTime}/>;
             case "RS_UNNEEDED":
-                return <TimestampFormatter relative={true} value={this.props.completed ? this.props.completed : this.props.startTime}/>;
+                return '(N/A because not in Glacier)';
         }
     }
 

--- a/frontend/app/Lightbox/RestoreStatusComponent.jsx
+++ b/frontend/app/Lightbox/RestoreStatusComponent.jsx
@@ -27,8 +27,6 @@ class RestoreStatusComponent extends React.Component {
                 return <span data-tip="Success" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="check-circle" style={{color:"green"}}/></span>;
             case "RS_ERROR":
                 return <span data-tip="Error" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="exclamation-triangle" style={{color:"red"}}/></span>;
-            case "RS_UNNEEDED":
-                return <span data-tip="Unneeded" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="file" style={{color:"yellow"}}/></span>;
             default:
                 return <span data-tip={this.props.status}>{this.props.status}</span>;
         }
@@ -44,8 +42,6 @@ class RestoreStatusComponent extends React.Component {
                 return <TimestampFormatter relative={true} value={this.props.completed}/>;
             case "RS_ERROR":
                 return <TimestampFormatter relative={true} value={this.props.completed ? this.props.completed : this.props.startTime}/>;
-            case "RS_UNNEEDED":
-                return '(N/A because not in Glacier)';
         }
     }
 

--- a/frontend/app/Lightbox/RestoreStatusComponent.jsx
+++ b/frontend/app/Lightbox/RestoreStatusComponent.jsx
@@ -27,6 +27,8 @@ class RestoreStatusComponent extends React.Component {
                 return <span data-tip="Success" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="check-circle" style={{color:"green"}}/></span>;
             case "RS_ERROR":
                 return <span data-tip="Error" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="exclamation-triangle" style={{color:"red"}}/></span>;
+            case "RS_UNNEEDED":
+                return <span data-tip="Unneeded" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="not-equal" style={{color:"yellow"}}/></span>;
             default:
                 return <span data-tip={this.props.status}>{this.props.status}</span>;
         }
@@ -41,6 +43,8 @@ class RestoreStatusComponent extends React.Component {
             case "RS_ALREADY":
                 return <TimestampFormatter relative={true} value={this.props.completed}/>;
             case "RS_ERROR":
+                return <TimestampFormatter relative={true} value={this.props.completed ? this.props.completed : this.props.startTime}/>;
+            case "RS_UNNEEDED":
                 return <TimestampFormatter relative={true} value={this.props.completed ? this.props.completed : this.props.startTime}/>;
         }
     }


### PR DESCRIPTION
Items that are not in Glacier are no longer flagged with the error status and the UI displays a new yellow file icon in the item info. panel with the message 'Not in deep freeze' next to it. The 'Redo restore' link is no longer displayed for items not in Glacier.

Also fixed a problem with the 'Not in deep freeze' message showing on items that it should not have done and stopped statuses and error messages being printed.

![image](https://user-images.githubusercontent.com/10620802/71092631-88fcb180-219f-11ea-9d8a-059b5cf7e08a.png)

Tested on a machine running macOS 10.12.6.

@fredex42 