### PR TITLE
API endpoint to move files from one collection to another

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -20,6 +20,7 @@ class Module extends AbstractModule with AkkaGuiceSupport {
     bindActor[IngestProxyQueue]("ingestProxyQueue")
     bindActor[ProxyFrameworkQueue]("proxyFrameworkQueue")
     bindActor[ProblemItemRetry]("problemItemRetry")
+    bindActor[FileMoveActor]("fileMoveActor")
     bind(classOf[AppStartup]).asEagerSingleton() //do app startup
   }
 }

--- a/app/controllers/FileMoveController.scala
+++ b/app/controllers/FileMoveController.scala
@@ -1,9 +1,6 @@
 package controllers
 
 import akka.actor.{ActorRef, ActorSystem}
-import com.theguardian.multimedia.archivehunter.common.ProxyLocationDAO
-import com.theguardian.multimedia.archivehunter.common.ProxyTranscodeFramework.ProxyGenerators
-import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager}
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{JobModelDAO, ScanTargetDAO}
 import helpers.InjectableRefresher
 import javax.inject.{Inject, Named}
@@ -25,7 +22,6 @@ import io.circe.syntax._
 
 class FileMoveController @Inject()(override val config:Configuration,
                                    override val controllerComponents:ControllerComponents,
-                                   jobModelDAO: JobModelDAO,
                                    override val refresher:InjectableRefresher,
                                    override val wsClient:WSClient,
                                    scanTargetDAO:ScanTargetDAO,

--- a/app/controllers/FileMoveController.scala
+++ b/app/controllers/FileMoveController.scala
@@ -1,0 +1,46 @@
+package controllers
+
+import akka.actor.ActorSystem
+import com.theguardian.multimedia.archivehunter.common.ProxyLocationDAO
+import com.theguardian.multimedia.archivehunter.common.ProxyTranscodeFramework.ProxyGenerators
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.JobModelDAO
+import helpers.InjectableRefresher
+import javax.inject.Inject
+import play.api.Configuration
+import play.api.libs.circe.Circe
+import play.api.libs.ws.WSClient
+import play.api.mvc.{AbstractController, ControllerComponents}
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class FileMoveController @Inject()(override val config:Configuration,
+                                   override val controllerComponents:ControllerComponents,
+                                   jobModelDAO: JobModelDAO,
+                                   esClientManager: ESClientManager,
+                                   s3ClientManager: S3ClientManager,
+                                   ddbClientManager:DynamoClientManager,
+                                   override val refresher:InjectableRefresher,
+                                   override val wsClient:WSClient,
+                                   proxyLocationDAO:ProxyLocationDAO,
+                                   proxyGenerators:ProxyGenerators)
+                                  (implicit actorSystem:ActorSystem)
+  extends AbstractController(controllerComponents) with PanDomainAuthActions with Circe {
+
+  def moveFile(fileId:String, destCollection:String) = APIAuthAction.async {
+    //step one: verify file exists
+
+    //step two: verify dest collection exists
+
+    //step three: gather proxies
+
+    //step four: copy file to new location
+
+    //step five: copy proxies to new location
+
+    //step six: if all copies succeed,
+
+    Future(Ok(""))
+  }
+}

--- a/app/controllers/FileMoveController.scala
+++ b/app/controllers/FileMoveController.scala
@@ -39,7 +39,9 @@ class FileMoveController @Inject()(override val config:Configuration,
 
     //step five: copy proxies to new location
 
-    //step six: if all copies succeed,
+    //step six: if all copies succeed, remove the old ones
+
+    //step seven: remove tombstones
 
     Future(Ok(""))
   }

--- a/app/helpers/DDBSink.scala
+++ b/app/helpers/DDBSink.scala
@@ -31,6 +31,11 @@ final class DDBSink @Inject()(clientMgr: DynamoClientManager,config:Configuratio
 
       val table = Table[ProxyLocation](tableName)
 
+      /**
+        * if the provided Set of items contains duplicate database primary keys (from the perspective of Dynamo) then it fails.
+        * this function removes any duplicates of these keys so that we know that the update will succeed
+        * @return Iterable of unique ProxyLocation objects
+        */
       def dedupeRecordBuffer:Iterable[ProxyLocation] = {
         val recordBufferMap = recordBuffer.map(loc=>(loc.fileId,loc.proxyType)->loc).toMap
         recordBufferMap.values

--- a/app/helpers/ProxyLocator.scala
+++ b/app/helpers/ProxyLocator.scala
@@ -45,6 +45,7 @@ object ProxyLocator {
     }
   }
 
+  //FIXME: should cache the scan target for bucket in scanTargetDAO if possible to avoid hammering DDB
   /**
     * see if there is a proxy for the given [[ArchiveEntry]], assuming none exists in the dynamo table
     * @param entry [[ArchiveEntry]] instance

--- a/app/helpers/ProxyLocator.scala
+++ b/app/helpers/ProxyLocator.scala
@@ -45,7 +45,6 @@ object ProxyLocator {
     }
   }
 
-  //FIXME: should cache the scan target for bucket in scanTargetDAO if possible to avoid hammering DDB
   /**
     * see if there is a proxy for the given [[ArchiveEntry]], assuming none exists in the dynamo table
     * @param entry [[ArchiveEntry]] instance

--- a/app/services/FileMove/CopyMainFile.scala
+++ b/app/services/FileMove/CopyMainFile.scala
@@ -1,0 +1,53 @@
+package services.FileMove
+
+import com.amazonaws.services.s3.AmazonS3
+import com.theguardian.multimedia.archivehunter.common.DocId
+import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
+
+/**
+  * this actor copies a file to the requested destination bucket and updates the internal state with the new file ID.
+  * when rolling back, it checks that the source file still exists and if so deletes the one it copied earlier.
+  */
+class CopyMainFile (s3ClientManager: S3ClientManager) extends GenericMoveActor with DocId {
+  import GenericMoveActor._
+
+  override def receive: Receive = {
+    case PerformStep(currentState)=>
+      val s3Client = s3ClientManager.getS3Client(region=currentState.entry.flatMap(_.region))
+      currentState.entry match {
+        case None=>
+          sender() ! StepFailed(currentState, "No archive entry source")
+        case Some(entry)=>
+          try {
+            logger.info(s"Copying ${entry.bucket}:${entry.path} to  ${currentState.destBucket}:${entry.path}")
+            val updatedState = currentState.copy(destFileId = Some(makeDocId(currentState.destBucket, entry.path)))
+            s3Client.copyObject(entry.bucket, entry.path, currentState.destBucket, entry.path)
+            logger.info("Copy succeded")
+            sender() ! StepSucceeded(updatedState)
+          } catch {
+            case err:Throwable=>
+              logger.error(s"Could not copy $entry", err)
+              sender() ! StepFailed(currentState, err.toString)
+          }
+      }
+
+    case RollbackStep(currentState)=>
+      val s3Client = s3ClientManager.getS3Client(region=currentState.entry.flatMap(_.region))
+      currentState.entry match {
+        case None=>
+          sender() ! StepFailed(currentState, "No archive entry source")
+        case Some(entry)=>
+          try {
+            logger.info(s"Rolling back failed file move, going to delete ${currentState.destBucket}:${entry.path} if ${entry.bucket}:${entry.path} exists")
+            val meta = s3Client.getObjectMetadata(entry.bucket,entry.path) //this will raise if the file does not exist
+            s3Client.deleteObject(currentState.destBucket,entry.path)
+            logger.info(s"Rollback succeeded")
+            sender() ! StepSucceeded(currentState.copy(destFileId = None))
+          } catch {
+            case err:Throwable=>
+              logger.error(s"Could not rollback copy for $entry", err)
+              sender() ! StepFailed(currentState, err.toString)
+          }
+      }
+  }
+}

--- a/app/services/FileMove/CopyMainFile.scala
+++ b/app/services/FileMove/CopyMainFile.scala
@@ -3,17 +3,18 @@ package services.FileMove
 import com.amazonaws.services.s3.AmazonS3
 import com.theguardian.multimedia.archivehunter.common.DocId
 import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
+import play.api.Configuration
 
 /**
   * this actor copies a file to the requested destination bucket and updates the internal state with the new file ID.
   * when rolling back, it checks that the source file still exists and if so deletes the one it copied earlier.
   */
-class CopyMainFile (s3ClientManager: S3ClientManager) extends GenericMoveActor with DocId {
+class CopyMainFile (s3ClientManager: S3ClientManager, config:Configuration) extends GenericMoveActor with DocId {
   import GenericMoveActor._
 
   override def receive: Receive = {
     case PerformStep(currentState)=>
-      val s3Client = s3ClientManager.getS3Client(region=currentState.entry.flatMap(_.region))
+      val s3Client = s3ClientManager.getS3Client(region=Some(currentState.destRegion),profileName=config.getOptional[String]("externalData.awsProfile"))
       currentState.entry match {
         case None=>
           sender() ! StepFailed(currentState, "No archive entry source")
@@ -32,15 +33,18 @@ class CopyMainFile (s3ClientManager: S3ClientManager) extends GenericMoveActor w
       }
 
     case RollbackStep(currentState)=>
-      val s3Client = s3ClientManager.getS3Client(region=currentState.entry.flatMap(_.region))
+      val destClient = s3ClientManager.getS3Client(region=Some(currentState.destRegion),profileName=config.getOptional[String]("externalData.awsProfile"))
+      val sourceClient = s3ClientManager.getS3Client(region=currentState.entry.flatMap(_.region),profileName=config.getOptional[String]("externalData.awsProfile"))
       currentState.entry match {
         case None=>
           sender() ! StepFailed(currentState, "No archive entry source")
         case Some(entry)=>
           try {
             logger.info(s"Rolling back failed file move, going to delete ${currentState.destBucket}:${entry.path} if ${entry.bucket}:${entry.path} exists")
-            val meta = s3Client.getObjectMetadata(entry.bucket,entry.path) //this will raise if the file does not exist
-            s3Client.deleteObject(currentState.destBucket,entry.path)
+            if(!sourceClient.doesObjectExist(entry.bucket, entry.path)){
+              sourceClient.copyObject(currentState.destBucket, entry.path, entry.bucket, entry.path)  //raises if the copy-back fails
+            }
+            destClient.deleteObject(currentState.destBucket,entry.path)
             logger.info(s"Rollback succeeded")
             sender() ! StepSucceeded(currentState.copy(destFileId = None))
           } catch {

--- a/app/services/FileMove/CopyProxyFiles.scala
+++ b/app/services/FileMove/CopyProxyFiles.scala
@@ -36,7 +36,9 @@ class CopyProxyFiles (s3ClientManager:S3ClientManager, config:Configuration) ext
             val updatedProxyList = proxyList.map(loc=>
               loc.copy(fileId=currentState.destFileId.get,
                 proxyId=makeDocId(currentState.destProxyBucket, loc.bucketPath),
-                bucketName = currentState.destProxyBucket)
+                bucketName = currentState.destProxyBucket,
+                region = Some(currentState.destRegion)
+              )
             )
 
             proxyList.map(proxy => {

--- a/app/services/FileMove/CopyProxyFiles.scala
+++ b/app/services/FileMove/CopyProxyFiles.scala
@@ -1,0 +1,70 @@
+package services.FileMove
+
+import com.amazonaws.services.s3.AmazonS3
+import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
+import com.theguardian.multimedia.archivehunter.common.{DocId, ProxyLocation}
+
+import scala.util.Try
+
+/**
+  * this actor copies a file to the requested destination bucket and updates the internal state with the new file ID.
+  * when rolling back, it checks that the source file still exists and if so deletes the one it copied earlier.
+  */
+class CopyProxyFiles (s3ClientManager:S3ClientManager) extends GenericMoveActor with DocId {
+  import GenericMoveActor._
+
+  def deleteCopiedProxies(currentState:FileMoveTransientData, proxyList:Seq[ProxyLocation])(implicit s3Client:AmazonS3) =
+    proxyList.foreach(loc=>
+      if(s3Client.doesObjectExist(currentState.destProxyBucket, loc.bucketPath)){
+        logger.info(s"Deleting copied proxy at ${currentState.destProxyBucket}:${loc.bucketPath}")
+        try {
+          s3Client.deleteObject(currentState.destProxyBucket, loc.bucketPath)
+        } catch {
+          case deleteErr:Throwable=>
+            logger.error("Could not delete copied proxy: ", deleteErr)
+        }
+      }
+    )
+
+  override def receive: Receive = {
+    case PerformStep(currentState)=>
+      implicit val s3Client = s3ClientManager.getS3Client(region=currentState.entry.flatMap(_.region))
+      currentState.sourceFileProxies match {
+        case Some(proxyList) =>
+          try {
+            val updatedProxyList = proxyList.map(loc=>
+              loc.copy(fileId=currentState.destFileId.get,
+                proxyId=makeDocId(currentState.destProxyBucket, loc.bucketPath),
+                bucketName = currentState.destProxyBucket)
+            )
+
+            proxyList.map(proxy =>
+              s3Client.copyObject(proxy.bucketName, proxy.bucketPath, currentState.destProxyBucket, proxy.bucketPath)
+            )
+
+            sender() ! StepSucceeded(currentState.copy(destFileProxy = Some(updatedProxyList)))
+          } catch {
+            case err:Throwable=>
+              logger.error("Can't copy proxies", err)
+              currentState.sourceFileProxies match {
+                case Some(proxyList)=>deleteCopiedProxies(currentState, proxyList)
+                case None=> //don't need to do anything
+              }
+              sender() ! StepFailed(currentState, err.toString)
+          }
+        case None=>
+          sender() ! StepFailed(currentState, "No source proxy list available")
+      }
+
+    case RollbackStep(currentState)=>
+      implicit val s3Client = s3ClientManager.getS3Client(region=currentState.entry.flatMap(_.region))
+      currentState.sourceFileProxies match {
+        case Some(proxyList) =>
+          logger.info(s"Rolling back proxy copy for $proxyList")
+          deleteCopiedProxies(currentState, proxyList)
+          sender() ! StepSucceeded(currentState)
+        case None=>
+          sender() ! StepFailed(currentState, "Can't rollback proxy copy as there were no proxies copied")
+      }
+  }
+}

--- a/app/services/FileMove/CopyProxyFiles.scala
+++ b/app/services/FileMove/CopyProxyFiles.scala
@@ -3,6 +3,7 @@ package services.FileMove
 import com.amazonaws.services.s3.AmazonS3
 import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
 import com.theguardian.multimedia.archivehunter.common.{DocId, ProxyLocation}
+import play.api.Configuration
 
 import scala.util.Try
 
@@ -10,7 +11,7 @@ import scala.util.Try
   * this actor copies a file to the requested destination bucket and updates the internal state with the new file ID.
   * when rolling back, it checks that the source file still exists and if so deletes the one it copied earlier.
   */
-class CopyProxyFiles (s3ClientManager:S3ClientManager) extends GenericMoveActor with DocId {
+class CopyProxyFiles (s3ClientManager:S3ClientManager, config:Configuration) extends GenericMoveActor with DocId {
   import GenericMoveActor._
 
   def deleteCopiedProxies(currentState:FileMoveTransientData, proxyList:Seq[ProxyLocation])(implicit s3Client:AmazonS3) =
@@ -28,7 +29,7 @@ class CopyProxyFiles (s3ClientManager:S3ClientManager) extends GenericMoveActor 
 
   override def receive: Receive = {
     case PerformStep(currentState)=>
-      implicit val s3Client = s3ClientManager.getS3Client(region=currentState.entry.flatMap(_.region))
+      implicit val s3Client = s3ClientManager.getS3Client(region=Some(currentState.destRegion),profileName=config.getOptional[String]("externalData.awsProfile"))
       currentState.sourceFileProxies match {
         case Some(proxyList) =>
           try {
@@ -38,14 +39,15 @@ class CopyProxyFiles (s3ClientManager:S3ClientManager) extends GenericMoveActor 
                 bucketName = currentState.destProxyBucket)
             )
 
-            proxyList.map(proxy =>
+            proxyList.map(proxy => {
+              logger.debug(s"Copying from ${proxy.bucketName}:${proxy.bucketPath} to ${currentState.destProxyBucket}:${proxy.bucketPath}")
               s3Client.copyObject(proxy.bucketName, proxy.bucketPath, currentState.destProxyBucket, proxy.bucketPath)
-            )
+            })
 
             sender() ! StepSucceeded(currentState.copy(destFileProxy = Some(updatedProxyList)))
           } catch {
             case err:Throwable=>
-              logger.error("Can't copy proxies", err)
+              logger.error(s"Can't copy proxies ", err)
               currentState.sourceFileProxies match {
                 case Some(proxyList)=>deleteCopiedProxies(currentState, proxyList)
                 case None=> //don't need to do anything
@@ -57,7 +59,7 @@ class CopyProxyFiles (s3ClientManager:S3ClientManager) extends GenericMoveActor 
       }
 
     case RollbackStep(currentState)=>
-      implicit val s3Client = s3ClientManager.getS3Client(region=currentState.entry.flatMap(_.region))
+      implicit val s3Client = s3ClientManager.getS3Client(region=Some(currentState.destRegion),profileName=config.getOptional[String]("externalData.awsProfile"))
       currentState.sourceFileProxies match {
         case Some(proxyList) =>
           logger.info(s"Rolling back proxy copy for $proxyList")

--- a/app/services/FileMove/DeleteOriginalFiles.scala
+++ b/app/services/FileMove/DeleteOriginalFiles.scala
@@ -1,0 +1,154 @@
+package services.FileMove
+
+import com.amazonaws.services.s3.AmazonS3
+import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
+import com.theguardian.multimedia.archivehunter.common.{DocId, Indexer, ProxyLocation}
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+  * final step, delete the original files from the disk(s)
+  * @param indexer
+  */
+class DeleteOriginalFiles(s3ClientMgr:S3ClientManager, indexer:Indexer) extends GenericMoveActor with DocId {
+  import GenericMoveActor._
+
+  /**
+    * verify that the object pointed to by (destBucket, destPath) is indeed an accurate copy of (srcBucket, srcPath)
+    * @param srcBucket
+    * @param srcPath
+    * @param destBucket
+    * @param destPath
+    * @return
+    */
+  protected def verifyFile(srcBucket:String, srcPath:String, destBucket:String, destPath:String)(implicit s3Client:AmazonS3):Either[String, Unit] = {
+    if(!s3Client.doesObjectExist(destBucket, destPath)){
+      return Left(s"Destination file s3://$destBucket/$destPath does not exist")
+    }
+    if(!s3Client.doesObjectExist(srcBucket, srcPath)){
+      return Left(s"Source file s3://$srcBucket/$srcPath does not exist")
+    }
+
+    val destFileMeta = s3Client.getObjectMetadata(destBucket, destPath)
+    val srcFileMeta = s3Client.getObjectMetadata(srcBucket, srcPath)
+
+    if(destFileMeta.getContentLength!=srcFileMeta.getContentLength){
+      return Left(s"Destination size was ${destFileMeta.getContentLength} vs ${srcFileMeta.getContentLength}")
+    }
+
+    val maybeDestCS = Option(destFileMeta.getContentMD5)
+    val maybeSrcCS  = Option(srcFileMeta.getContentMD5)
+    if((maybeDestCS.isDefined && maybeSrcCS.isDefined) && maybeDestCS.get!=maybeSrcCS.get){
+      return Left(s"Destination checksum ${maybeDestCS.get} is different to source ${maybeSrcCS.get}")
+    } else if(maybeDestCS.isEmpty || maybeSrcCS.isEmpty){
+      logger.warn("Either source or destination checksum could not be obtained from S3")
+    }
+
+    Right( () )
+  }
+
+  /**
+    * verify that the new file is in place and that its size and checksum match the source
+    * @param state [[FileMoveTransientData]] giving the state of the move
+    * @return either a string indicating why the file is not good or the Unit value
+    */
+  def verifyNewMedia(state:FileMoveTransientData)(implicit s3Client:AmazonS3):Either[String,Unit] = {
+    val archiveEntry = state.entry.get
+
+    verifyFile(archiveEntry.bucket, archiveEntry.path, state.destBucket, archiveEntry.path)
+  }
+
+  def verifyProxyFiles(state:FileMoveTransientData)(implicit s3Client:AmazonS3):Either[String,Unit] = {
+    if (state.sourceFileProxies.isEmpty) {
+      logger.warn(s"No source file proxies to verify")
+      return Right(())
+    }
+
+    if (state.destFileProxy.isEmpty) {
+      logger.error(s"Have ${state.sourceFileProxies.get.length} source proxies but no destination proxies defined")
+      return Left(s"Have ${state.sourceFileProxies.get.length} source proxies but no destination proxies defined")
+    }
+
+    val srcProxies = state.sourceFileProxies.get
+    val dstProxies = state.destFileProxy.get
+
+    if (srcProxies.length != dstProxies.length) {
+      return Left(s"Source had ${srcProxies.length} proxies but destination has ${dstProxies.length}")
+    }
+
+    /**
+      * tail-recursively iterate the proxy lists and verify that all are present and correct
+      * this assumes that srcProxyList and dstProxyList are in-sync
+      * @param srcProxyList list of ProxyLocation for the source item
+      * @param dstProxyList list of ProxyLocation for the destination
+      * @return Right if both srcProxyList and dstProxyList match, otherwise Left with a description
+      */
+    def recursiveVerify(srcProxyList: Seq[ProxyLocation], dstProxyList: Seq[ProxyLocation]): Either[String, Unit] = {
+      if (srcProxyList.isEmpty) return Right(())
+
+      verifyFile(srcProxyList.head.bucketName, srcProxyList.head.bucketPath, dstProxyList.head.bucketName, dstProxyList.head.bucketPath) match {
+        case Right(_) =>
+          recursiveVerify(srcProxyList.tail, dstProxyList.tail)
+        case problem@Left(_) => problem
+      }
+    }
+
+    recursiveVerify(srcProxies, dstProxies)
+  }
+
+  //Delete the files in parallel. Contained in a Try to make it easier to catch _every_ failure not
+  //just one
+  def tryToDelete(bucket:String, path:String)(implicit s3Client:AmazonS3) = Future {
+    Try { s3Client.deleteObject(bucket, path) }
+  }
+
+  def deleteAllFor(state:FileMoveTransientData)(implicit s3Client:AmazonS3) = {
+    val archiveEntry = state.entry.get
+
+    val proxiesList = state.sourceFileProxies.getOrElse(Seq()).map(prx=>(prx.bucketName, prx.bucketPath))
+    val allFilesList = proxiesList :+ (archiveEntry.bucket, archiveEntry.path)
+
+    val completionFuture = Future.sequence(allFilesList.map(bucketpath=>tryToDelete(bucketpath._1, bucketpath._2)))
+
+    completionFuture.map(results=>{
+      val failures = results.collect({case Failure(err)=>err})
+      if(failures.nonEmpty){
+        logger.error(s"${failures.length} files failed to delete: ")
+        failures.foreach(err=>logger.error(s"\tFailed to delete: ", err))
+        Left(failures.head.getMessage)
+      } else {
+        logger.info(s"Deleted ${results.length} files")
+        Right( () )
+      }
+    })
+  }
+
+  override def receive: Receive = {
+    case PerformStep(state)=>
+      //verify new media and proxy files. only if both match do the deletion
+      implicit val s3Client = s3ClientMgr.getS3Client(region=state.entry.flatMap(_.region))
+      verifyNewMedia(state).map(_=>verifyProxyFiles(state)) match {
+        case Left(problem)=>
+          sender() ! StepFailed(state, problem)
+        case Right(_)=> //media and proxies both verified, can proceed to deletion.
+          val originalSender = sender()
+          deleteAllFor(state).onComplete({
+            case Success(Right(_))=>
+              logger.info(s"Deletion completed")
+              val updatedState = state.copy(sourceFileProxies = None)
+              originalSender ! StepSucceeded(updatedState)
+            case Success(Left(err))=>
+              logger.error(s"Some or all deletions failed")
+              originalSender ! StepFailed(state, err)
+            case Failure(err)=>
+              logger.error(s"Deletion thread(s) failed: ", err)
+              originalSender ! StepFailed(state, err.getMessage)
+          })
+      }
+    case RollbackStep(state)=>
+      logger.error(s"Can't roll back file deletion!")
+      sender() ! StepFailed(state, "Can't roll back file deletion!")
+  }
+}

--- a/app/services/FileMove/GenericMoveActor.scala
+++ b/app/services/FileMove/GenericMoveActor.scala
@@ -7,8 +7,19 @@ import play.api.Logger
 object GenericMoveActor {
   trait MoveActorMessage
 
-  case class FileMoveTransientData(sourceFileId:String, entry:Option[ArchiveEntry], destFileId:Option[String], sourceFileProxies:Option[Seq[ProxyLocation]],
-                                   destFileProxy:Option[Seq[ProxyLocation]], destBucket:String, destProxyBucket:String)
+  case class FileMoveTransientData(sourceFileId:String,
+                                   entry:Option[ArchiveEntry],
+                                   destFileId:Option[String],
+                                   sourceFileProxies:Option[Seq[ProxyLocation]],
+                                   destFileProxy:Option[Seq[ProxyLocation]],
+                                   destBucket:String,
+                                   destProxyBucket:String)
+
+  object FileMoveTransientData {
+    def initialise(sourceFileId:String, destBucket:String, destProxyBucket:String) = {
+      new FileMoveTransientData(sourceFileId,None,None,None,None,destBucket,destProxyBucket)
+    }
+  }
 
   case class PerformStep(state:FileMoveTransientData) extends MoveActorMessage
   case class RollbackStep(state:FileMoveTransientData) extends MoveActorMessage

--- a/app/services/FileMove/GenericMoveActor.scala
+++ b/app/services/FileMove/GenericMoveActor.scala
@@ -13,11 +13,12 @@ object GenericMoveActor {
                                    sourceFileProxies:Option[Seq[ProxyLocation]],
                                    destFileProxy:Option[Seq[ProxyLocation]],
                                    destBucket:String,
-                                   destProxyBucket:String)
+                                   destProxyBucket:String,
+                                   destRegion:String)
 
   object FileMoveTransientData {
-    def initialise(sourceFileId:String, destBucket:String, destProxyBucket:String) = {
-      new FileMoveTransientData(sourceFileId,None,None,None,None,destBucket,destProxyBucket)
+    def initialise(sourceFileId:String, destBucket:String, destProxyBucket:String,destRegion:String) = {
+      new FileMoveTransientData(sourceFileId,None,None,None,None,destBucket,destProxyBucket,destRegion)
     }
   }
 

--- a/app/services/FileMove/GenericMoveActor.scala
+++ b/app/services/FileMove/GenericMoveActor.scala
@@ -1,0 +1,24 @@
+package services.FileMove
+
+import akka.actor.Actor
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ProxyLocation}
+import play.api.Logger
+
+object GenericMoveActor {
+  trait MoveActorMessage
+
+  case class FileMoveTransientData(sourceFileId:String, entry:Option[ArchiveEntry], destFileId:Option[String], sourceFileProxies:Option[Seq[ProxyLocation]],
+                                   destFileProxy:Option[Seq[ProxyLocation]], destBucket:String, destProxyBucket:String)
+
+  case class PerformStep(state:FileMoveTransientData) extends MoveActorMessage
+  case class RollbackStep(state:FileMoveTransientData) extends MoveActorMessage
+
+  case class StepSucceeded(updatedData:FileMoveTransientData) extends MoveActorMessage
+  case class StepFailed(updatedData:FileMoveTransientData, err:String) extends MoveActorMessage
+}
+
+trait GenericMoveActor extends Actor {
+  protected val logger = Logger(getClass)
+
+
+}

--- a/app/services/FileMove/UpdateIndexRecords.scala
+++ b/app/services/FileMove/UpdateIndexRecords.scala
@@ -1,0 +1,94 @@
+package services.FileMove
+
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
+import com.sksamuel.elastic4s.http.HttpClient
+import com.theguardian.multimedia.archivehunter.common.{Indexer, ProxyLocation, ProxyLocationDAO}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+/**
+  * this step copies the ArchiveEntry record for the given file to a new ID, copies the Proxy records to the new ID and deletes the
+  * old ones.
+  * rollback makes it copy them back again the other way
+  */
+class UpdateIndexRecords(indexer:Indexer, proxyLocationDAO: ProxyLocationDAO)(implicit esClient:HttpClient, dynamoClient:DynamoClient) extends GenericMoveActor {
+  import GenericMoveActor._
+
+  def deleteCopiedProxies(proxyList:Seq[ProxyLocation]) = {
+    val proxyDeleteFutureList = proxyList.map(loc=>proxyLocationDAO.deleteProxyRecord(loc.proxyId))
+
+    Future.sequence(proxyDeleteFutureList)
+  }
+
+  override def receive: Receive = {
+    case PerformStep(state)=>
+      val originalSender = sender()
+      if(state.sourceFileProxies.isEmpty || state.destFileProxy.isEmpty || state.destFileId.isEmpty){
+        sender() ! StepFailed(state, "Not enough state elements were defined")
+      } else {
+        indexer.getById(state.sourceFileId).map(entry => {
+          logger.debug(s"Looked up entry: $entry")
+          val updatedEntry = entry.copy(id = state.destFileId.get)
+          indexer.indexSingleItem(updatedEntry).map({
+            case Success(_) =>
+              logger.debug(s"Saved updated etnry")
+              val proxyUpdateFutureList = state.destFileProxy.get.map(loc => proxyLocationDAO.saveProxy(loc))
+
+              Future.sequence(proxyUpdateFutureList).map(proxyUpdateResults => {
+                val failures = proxyUpdateResults.collect({ case Some(Left(err)) => err })
+                if (failures.nonEmpty) {
+                  logger.error(s"Could not copy all proxies:")
+                  failures.foreach(err => logger.error(err.toString))
+
+                  indexer.deleteById(state.destFileId.get)
+                  deleteCopiedProxies(state.destFileProxy.get)
+                  originalSender ! StepFailed(state, failures.map(_.toString).mkString(","))
+                }
+
+                logger.info("Updated entry and proxies")
+                indexer.deleteById(state.sourceFileId)
+                state.sourceFileProxies.get.map(loc => proxyLocationDAO.deleteProxyRecord(loc.proxyId))
+                originalSender ! StepSucceeded(state)
+              })
+          })
+        }).recover({
+          case err: Throwable =>
+            logger.error("Could not update index records:", err)
+            indexer.deleteById(state.destFileId.get)
+            deleteCopiedProxies(state.destFileProxy.get)
+            originalSender ! StepFailed(state, err.toString)
+        })
+      }
+
+    case RollbackStep(state)=>
+      val originalSender = sender()
+
+      val indexDeleteFuture= indexer.deleteById(state.destFileId.get)
+      indexDeleteFuture.onComplete({
+        case Success(Left(err))=>
+          logger.warn(s"Could not rollback updated index record: $err")
+        case Failure(err)=>
+          logger.warn(s"Could not rollback updated index record: ", err)
+        case Success(Right(_))=>
+      })
+
+      val proxyDeleteFuture=deleteCopiedProxies(state.destFileProxy.get)
+      proxyDeleteFuture.onComplete({
+        case Success(results)=>
+          val failures = results.collect({case Left(err)=>err})
+          if(failures.nonEmpty){
+            failures.foreach(err=>logger.warn(s"Could not rollback specific proxy copy: $err"))
+          }
+        case Failure(err)=>
+          logger.error("Rollback proxy delete future crashed: ", err)
+      })
+
+      Future.sequence(Seq(indexDeleteFuture, proxyDeleteFuture)).onComplete({
+        case Success(_)=>originalSender ! StepSucceeded(state)
+        case Failure(err)=>originalSender ! StepFailed(state, err.toString)
+      })
+
+  }
+}

--- a/app/services/FileMove/VerifySource.scala
+++ b/app/services/FileMove/VerifySource.scala
@@ -1,0 +1,45 @@
+package services.FileMove
+
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
+import com.sksamuel.elastic4s.http.HttpClient
+import com.theguardian.multimedia.archivehunter.common.{DocId, Indexer, ProxyLocationDAO}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.ItemNotFound
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+  * verify that the source file is registered with us, and collect the IDs of all proxies for it.
+  * @param indexer
+  * @param proxyLocationDAO
+  * @param esClient
+  * @param dynamoClient
+  */
+class VerifySource(indexer:Indexer, proxyLocationDAO:ProxyLocationDAO)(implicit esClient:HttpClient, dynamoClient:DynamoClient) extends GenericMoveActor with DocId {
+  import GenericMoveActor._
+
+  override def receive: Receive = {
+    case PerformStep(currentState)=>
+      val originalSender = sender()
+
+      indexer.getByIdFull(currentState.sourceFileId).map({
+        case Left(ItemNotFound(_))=>
+          logger.warn(s"Requested file id ${currentState.sourceFileId} does not exist")
+          originalSender ! StepFailed(currentState, s"Requested file id ${currentState.sourceFileId} does not exist")
+        case Left(err)=>
+          originalSender ! StepFailed(currentState, err.toString)
+        case Right(entry)=>
+          proxyLocationDAO.getAllProxiesFor(currentState.sourceFileId).map(results=>{
+            val failures = results.collect({case Left(err)=>err})
+            if(failures.nonEmpty){
+              originalSender ! StepFailed(currentState, failures.map(_.toString).mkString(","))
+            }
+            val proxyList = results.collect({case Right(proxyLoc)=>proxyLoc})
+            originalSender ! StepSucceeded(currentState.copy(entry=Some(entry), sourceFileProxies = Some(proxyList)))
+          })
+      })
+
+    case RollbackStep(currentState)=>
+      //nothing to roll back here
+
+  }
+}

--- a/app/services/FileMove/VerifySource.scala
+++ b/app/services/FileMove/VerifySource.scala
@@ -6,13 +6,14 @@ import com.theguardian.multimedia.archivehunter.common.{DocId, Indexer, ProxyLoc
 import com.theguardian.multimedia.archivehunter.common.cmn_models.ItemNotFound
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 /**
   * verify that the source file is registered with us, and collect the IDs of all proxies for it.
-  * @param indexer
-  * @param proxyLocationDAO
-  * @param esClient
-  * @param dynamoClient
+  * @param indexer [[Indexer]] DAO providing access to the index data
+  * @param proxyLocationDAO [[ProxyLocationDAO]] providing access to the proxy location data
+  * @param esClient implicitly provided Elastic4s HttpClient
+  * @param dynamoClient implicitly provided Alpakka DynamoClient
   */
 class VerifySource(indexer:Indexer, proxyLocationDAO:ProxyLocationDAO)(implicit esClient:HttpClient, dynamoClient:DynamoClient) extends GenericMoveActor with DocId {
   import GenericMoveActor._
@@ -21,25 +22,33 @@ class VerifySource(indexer:Indexer, proxyLocationDAO:ProxyLocationDAO)(implicit 
     case PerformStep(currentState)=>
       val originalSender = sender()
 
-      indexer.getByIdFull(currentState.sourceFileId).map({
+      indexer.getByIdFull(currentState.sourceFileId).flatMap({
         case Left(ItemNotFound(_))=>
           logger.warn(s"Requested file id ${currentState.sourceFileId} does not exist")
           originalSender ! StepFailed(currentState, s"Requested file id ${currentState.sourceFileId} does not exist")
+          Future( () )
         case Left(err)=>
           originalSender ! StepFailed(currentState, err.toString)
+          Future( () )
         case Right(entry)=>
           proxyLocationDAO.getAllProxiesFor(currentState.sourceFileId).map(results=>{
             val failures = results.collect({case Left(err)=>err})
             if(failures.nonEmpty){
               originalSender ! StepFailed(currentState, failures.map(_.toString).mkString(","))
+            } else {
+              val proxyList = results.collect({ case Right(proxyLoc) => proxyLoc })
+              originalSender ! StepSucceeded(currentState.copy(entry = Some(entry), sourceFileProxies = Some(proxyList)))
             }
-            val proxyList = results.collect({case Right(proxyLoc)=>proxyLoc})
-            originalSender ! StepSucceeded(currentState.copy(entry=Some(entry), sourceFileProxies = Some(proxyList)))
           })
+      }).recover({
+        case err:Throwable=>
+          logger.error(s"Could not look up media source from id '${currentState.sourceFileId}': ", err)
+          originalSender ! StepFailed(currentState, err.getMessage)
       })
 
     case RollbackStep(currentState)=>
       //nothing to roll back here
-
+      logger.info("VerifySource has nothing to roll back")
+      sender() ! StepSucceeded(currentState)
   }
 }

--- a/app/services/FileMove/VerifySource.scala
+++ b/app/services/FileMove/VerifySource.scala
@@ -8,6 +8,7 @@ import com.theguardian.multimedia.archivehunter.common.cmn_models.ItemNotFound
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+//FIXME: should check the "deleted" flag and error if it is set
 /**
   * verify that the source file is registered with us, and collect the IDs of all proxies for it.
   * @param indexer [[Indexer]] DAO providing access to the index data

--- a/app/services/FileMoveActor.scala
+++ b/app/services/FileMoveActor.scala
@@ -8,7 +8,14 @@ import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTarget
 import javax.inject.Inject
 import play.api.Configuration
 import services.FileMove.GenericMoveActor.MoveActorMessage
-import services.FileMove.{CopyMainFile, CopyProxyFiles, VerifySource}
+import services.FileMove.{CopyMainFile, CopyProxyFiles, DeleteOriginalFiles, GenericMoveActor, UpdateIndexRecords, VerifySource}
+import akka.pattern.ask
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
 
 //step one: verify file exists [VerifySource[
 
@@ -16,11 +23,11 @@ import services.FileMove.{CopyMainFile, CopyProxyFiles, VerifySource}
 
 //step three: gather proxies [VerifySource]
 
-//step four: copy file to new location
+//step four: copy file to new location [CopyMainFile]
 
-//step five: copy proxies to new location
+//step five: copy proxies to new location [CopyProxyFile]
 
-//step six: if all copies succeed, update index records
+//step six: if all copies succeed, update index records [UpdateIndexRecords]
 
 //step seven: remove original files
 
@@ -28,7 +35,12 @@ object FileMoveActor {
 
   case class MoveFile(sourceFileId:String, destination:ScanTarget) extends MoveActorMessage
 
+  //replies
+  case object MoveSuccess extends MoveActorMessage
+  case class MoveFailed(reason:String) extends MoveActorMessage
 }
+
+
 /**
   * this actor uses the same technique as Project Locker to run a step-function and roll back all successful stages if a
   * stage fails
@@ -40,25 +52,68 @@ class FileMoveActor @Inject() (config:Configuration,
                                s3ClientManager: S3ClientManager)(implicit system:ActorSystem)
   extends Actor {
   import FileMoveActor._
+  import GenericMoveActor._
   import services.FileMove.GenericMoveActor._
 
+  private val logger = LoggerFactory.getLogger(getClass)
   private implicit val mat:Materializer = ActorMaterializer.create(system)
-
   private implicit val esClient = esClientManager.getClient()
   private implicit val dynamoClient = dynamoClientManager.getNewAlpakkaDynamoClient()
-
-  val indexName = config.getOptional[String]("externalData.indexName").getOrElse("archivehunter")
   private val indexer = new Indexer(indexName)
 
-  val fileMoveChain:Seq[ActorRef] = Seq(
+  private implicit val timeout:akka.util.Timeout = 30 seconds
+
+  val indexName = config.getOptional[String]("externalData.indexName").getOrElse("archivehunter")
+
+  protected val fileMoveChain:Seq[ActorRef] = Seq(
     system.actorOf(Props(new VerifySource(indexer, proxyLocationDAO))),
     system.actorOf(Props(new CopyMainFile(s3ClientManager))),
     system.actorOf(Props(new CopyProxyFiles(s3ClientManager))),
-
+    system.actorOf(Props(new UpdateIndexRecords(indexer, proxyLocationDAO))),
+    system.actorOf(Props(new DeleteOriginalFiles(s3ClientManager, indexer)))
   )
+
+  def runNextActorInChain(initialData:FileMoveTransientData, otherSteps:Seq[ActorRef]):Future[Either[StepFailed,StepSucceeded]] = {
+    println(s"runNextActorInChain: remaining chain is $otherSteps")
+    if(otherSteps.isEmpty) return Future(Right(StepSucceeded(initialData)))
+
+    val nextActor = otherSteps.head
+    println(s"Sending PerformStep to $nextActor")
+    (nextActor ? GenericMoveActor.PerformStep(initialData) ).mapTo[MoveActorMessage].flatMap({
+      case successMsg:StepSucceeded=>
+        println(s"Step succeeded, moving to next")
+        runNextActorInChain(successMsg.updatedData,otherSteps.tail) flatMap {
+          case Left(failedMessage)=>  //if the _next_ step fails, tell _this_ step to roll back
+            (nextActor ? GenericMoveActor.RollbackStep(successMsg.updatedData)).map(_=>Left(failedMessage)) //overwrite return value with the original failure
+          case Right(nextActorSuccess)=>
+            Future(Right(nextActorSuccess))
+        }
+      case failedMessage:StepFailed=>  //if the step fails, tell it to roll back
+        println(s"StepFailed, sending rollback to $nextActor")
+        (nextActor ? RollbackStep(initialData)).map(_=>Left(failedMessage))
+      case other:Any =>
+        println(s"got unexpected message: ${other.getClass}")
+        Future(Left(StepFailed(initialData,"got unexpected message")))
+    })
+  }
 
   override def receive:Receive = {
     case MoveFile(sourceFileId, destination)=>
+      val originalSender = sender()
+      val setupData = FileMoveTransientData.initialise(sourceFileId, destination.bucketName,destination.proxyBucket)
 
+      println(s"Setting up file move with initial data $setupData")
+      runNextActorInChain(setupData, fileMoveChain).map({
+        case Right(_) =>
+          logger.info(s"File move for $sourceFileId -> ${destination.bucketName} completed successfully")
+          originalSender ! MoveSuccess
+        case Left(errMsg) =>
+          logger.error(s"File move for $sourceFileId -> ${destination.bucketName} failed: ${errMsg.err}")
+          originalSender ! MoveFailed(errMsg.err)
+      }).recover({
+        case err:Throwable=>
+          logger.error(s"File move processor crashed: ", err)
+          originalSender ! akka.actor.Status.Failure(err)
+      })
   }
 }

--- a/app/services/FileMoveActor.scala
+++ b/app/services/FileMoveActor.scala
@@ -8,7 +8,7 @@ import akka.stream.{ActorMaterializer, Materializer}
 import com.theguardian.multimedia.archivehunter.common.{Indexer, ProxyLocationDAO}
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager}
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{JobModel, JobModelDAO, JobStatus, ScanTarget, SourceType}
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import services.FileMove.GenericMoveActor.MoveActorMessage
 import services.FileMove.{CopyMainFile, CopyProxyFiles, DeleteOriginalFiles, GenericMoveActor, UpdateIndexRecords, VerifySource}
@@ -49,6 +49,7 @@ object FileMoveActor {
   * this actor uses the same technique as Project Locker to run a step-function and roll back all successful stages if a
   * stage fails
   */
+@Singleton
 class FileMoveActor @Inject() (config:Configuration,
                                proxyLocationDAO: ProxyLocationDAO,
                                esClientManager:ESClientManager,

--- a/app/services/FileMoveActor.scala
+++ b/app/services/FileMoveActor.scala
@@ -1,0 +1,63 @@
+package services
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.stream.{ActorMaterializer, Materializer}
+import com.theguardian.multimedia.archivehunter.common.{Indexer, ProxyLocationDAO}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTarget
+import javax.inject.Inject
+import play.api.Configuration
+import services.FileMove.GenericMoveActor.MoveActorMessage
+import services.FileMove.{CopyMainFile, CopyProxyFiles, VerifySource}
+
+//step one: verify file exists [VerifySource[
+
+//step two: verify dest collection exists [Inline]
+
+//step three: gather proxies [VerifySource]
+
+//step four: copy file to new location
+
+//step five: copy proxies to new location
+
+//step six: if all copies succeed, update index records
+
+//step seven: remove original files
+
+object FileMoveActor {
+
+  case class MoveFile(sourceFileId:String, destination:ScanTarget) extends MoveActorMessage
+
+}
+/**
+  * this actor uses the same technique as Project Locker to run a step-function and roll back all successful stages if a
+  * stage fails
+  */
+class FileMoveActor @Inject() (config:Configuration,
+                               proxyLocationDAO: ProxyLocationDAO,
+                               esClientManager:ESClientManager,
+                               dynamoClientManager: DynamoClientManager,
+                               s3ClientManager: S3ClientManager)(implicit system:ActorSystem)
+  extends Actor {
+  import FileMoveActor._
+  import services.FileMove.GenericMoveActor._
+
+  private implicit val mat:Materializer = ActorMaterializer.create(system)
+
+  private implicit val esClient = esClientManager.getClient()
+  private implicit val dynamoClient = dynamoClientManager.getNewAlpakkaDynamoClient()
+
+  val indexName = config.getOptional[String]("externalData.indexName").getOrElse("archivehunter")
+  private val indexer = new Indexer(indexName)
+
+  val fileMoveChain:Seq[ActorRef] = Seq(
+    system.actorOf(Props(new VerifySource(indexer, proxyLocationDAO))),
+    system.actorOf(Props(new CopyMainFile(s3ClientManager))),
+    system.actorOf(Props(new CopyProxyFiles(s3ClientManager)))
+  )
+
+  override def receive:Receive = {
+    case MoveFile(sourceFileId, destination)=>
+
+  }
+}

--- a/app/services/FileMoveActor.scala
+++ b/app/services/FileMoveActor.scala
@@ -53,7 +53,8 @@ class FileMoveActor @Inject() (config:Configuration,
   val fileMoveChain:Seq[ActorRef] = Seq(
     system.actorOf(Props(new VerifySource(indexer, proxyLocationDAO))),
     system.actorOf(Props(new CopyMainFile(s3ClientManager))),
-    system.actorOf(Props(new CopyProxyFiles(s3ClientManager)))
+    system.actorOf(Props(new CopyProxyFiles(s3ClientManager))),
+
   )
 
   override def receive:Receive = {

--- a/app/services/LegacyProxiesScanner.scala
+++ b/app/services/LegacyProxiesScanner.scala
@@ -63,6 +63,9 @@ class LegacyProxiesScanner @Inject()(config:Configuration, ddbClientMgr:DynamoCl
       Left(WrongTableState)
     } else {
       val tableThroughput = result.getTable.getProvisionedThroughput
+      if(tableThroughput.getReadCapacityUnits==0){  //we are not in provisioned mode
+        return Right(true)
+      }
       val indexName = result.getTable.getGlobalSecondaryIndexes.get(0).getIndexName
 
       val indexThroughput = result.getTable.getGlobalSecondaryIndexes.get(0).getProvisionedThroughput

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ lazy val `archivehunter` = (project in file("."))
       "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
       "com.lightbend.akka.management" %% "akka-management-cluster-http" % akkaClusterVersion,
       "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaClusterVersion,
+      "com.lightbend.akka.discovery" %% "akka-discovery-config" % akkaClusterVersion,
       "com.lightbend.akka.discovery" %% "akka-discovery-dns" % akkaClusterVersion,
       "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % akkaClusterVersion,
       "com.lightbend.akka.discovery" %% "akka-discovery-aws-api" % akkaClusterVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,7 @@ lazy val `archivehunter` = (project in file("."))
       "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
       "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion,
+      "org.apache.logging.log4j" % "log4j-api" % "2.8.2",
       // Only if you are using Akka Testkit
       "com.typesafe.akka" %% "akka-testkit" % akkaVersion,
       "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.1",

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val `archivehunter` = (project in file("."))
       "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
       "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
       "com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion,
+      "com.gu" % "kinesis-logback-appender" % "1.4.4",
       "org.apache.logging.log4j" % "log4j-api" % "2.8.2",
       // Only if you are using Akka Testkit
       "com.typesafe.akka" %% "akka-testkit" % akkaVersion,

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -25,6 +25,9 @@ Parameters:
   ElkStack:
     Description: Name of a deployed ELK6 stack (https://github.com/guardian/elk6) to send logs to
     Type: String
+  LoggingStreamName:
+    Description: Name of a Kinesis stream to send logs to
+    Type: String
   AmiId:
     Type: String
     Description: ID of the base image to build instances from.  Build this with Amigo.
@@ -1106,34 +1109,37 @@ Resources:
           release=${!BUILD_NUMBER}
           EOF
 
+          cat /usr/share/archivehunter/conf/logback-deployment.xml | sed s/{region}/${AWS::Region}/ > /tmp/logback.xml
+          cat /tmp/logback.xml | sed s/{logging-stream}/${LoggingStreamName}/ > /usr/share/archivehunter/conf/logback.xml
+
           systemctl restart archivehunter
           systemctl enable archivehunter
 
-          aws s3 cp s3://gnm-multimedia-archivedtech/ELK/filebeat-6.1.2-amd64.deb /tmp/install
-          dpkg --install /tmp/install/filebeat-6.1.2-amd64.deb
-
-          cat > /etc/filebeat/filebeat.yml << EOF
-          filebeat.prospectors:
-          - type: log
-            enabled: true
-            paths:
-            - /var/log/archivehunter/*.log
-            fields:
-              App: ${App}
-              Stack: ${Stack}
-              Stage: ${Stage}
-
-            multiline:
-              pattern: '^\s+'
-              negate: false
-              match: after
-
-          output.logstash:
-            hosts: ["${LogstashEndpoint}"]
-          EOF
-
-          systemctl enable filebeat
-          systemctl start filebeat
+#          aws s3 cp s3://gnm-multimedia-archivedtech/ELK/filebeat-6.1.2-amd64.deb /tmp/install
+#          dpkg --install /tmp/install/filebeat-6.1.2-amd64.deb
+#
+#          cat > /etc/filebeat/filebeat.yml << EOF
+#          filebeat.prospectors:
+#          - type: log
+#            enabled: true
+#            paths:
+#            - /var/log/archivehunter/*.log
+#            fields:
+#              App: ${App}
+#              Stack: ${Stack}
+#              Stage: ${Stage}
+#
+#            multiline:
+#              pattern: '^\s+'
+#              negate: false
+#              match: after
+#
+#          output.logstash:
+#            hosts: ["${LogstashEndpoint}"]
+#          EOF
+#
+#          systemctl enable filebeat
+#          systemctl start filebeat
 
         - DeploySubnetsString: !Join [",",!Ref DeploySubnets]
           LogstashEndpoint:

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -382,7 +382,7 @@ Resources:
           - AttributeName: proxyId
             KeyType: HASH
           Projection:
-            ProjectionType: ALL
+            ProjectionType: KEYS_ONLY
           ProvisionedThroughput:
             WriteCapacityUnits: 1
             ReadCapacityUnits: 1

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -379,7 +379,7 @@ Resources:
           - AttributeName: proxyId
             KeyType: HASH
           Projection:
-            ProjectionType: KEYS_ONLY
+            ProjectionType: ALL
           ProvisionedThroughput:
             WriteCapacityUnits: 1
             ReadCapacityUnits: 1

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -822,6 +822,15 @@ Resources:
               - arn:aws:s3:::*proxies*/*
               - arn:aws:s3:::*proxy*
               - arn:aws:s3:::*proxy*/*
+      - PolicyName: HoldingPenDeletion
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Effect: Allow
+            Action:
+              - s3:DeleteObject
+            Resource:
+              - arn:aws:s3:::*holding-pen*
       - PolicyName: DeployablesAccess
         PolicyDocument:
           Version: 2012-10-17

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -695,6 +695,18 @@ Resources:
           Action: sts:AssumeRole
       Path: "/"
       Policies:
+      - PolicyName: KinesisLogging
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Effect: Allow
+            Action:
+              - kinesis:Describe*
+              - kinesis:List*
+              - kinesis:PutRecord
+              - kinesis:PutRecords
+            Resource:
+              - !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${LoggingStreamName}
       - PolicyName: DataAccess
         PolicyDocument:
           Version: 2012-10-17
@@ -1110,7 +1122,12 @@ Resources:
           EOF
 
           cat /usr/share/archivehunter/conf/logback-deployment.xml | sed s/{region}/${AWS::Region}/ > /tmp/logback.xml
-          cat /tmp/logback.xml | sed s/{logging-stream}/${LoggingStreamName}/ > /usr/share/archivehunter/conf/logback.xml
+          cat /tmp/logback.xml | sed s/{app}/${App}/ > /tmp/logback.xml.2
+          cat /tmp/logback.xml.2 | sed s/{stack}/${Stack}/ > /tmp/logback.xml.3
+          cat /tmp/logback.xml.3 | sed s/{stage}/${Stage}/ > /tmp/logback.xml.4
+          cat /tmp/logback.xml.4 | sed s/{logging-stream}/${LoggingStreamName}/ > /usr/share/archivehunter/conf/logback.xml
+
+          rm -f /tmp/logback.xml*
 
           systemctl restart archivehunter
           systemctl enable archivehunter

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/Indexer.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/Indexer.scala
@@ -104,6 +104,6 @@ class Indexer(indexName:String) extends ZonedDateTimeEncoder with StorageClassEn
   })
 
   def deleteById(docId:String)(implicit client:HttpClient) = client.execute {
-    delete(docId) from indexName
+    delete(docId) from indexName / "entry"
   }
 }

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/Indexer.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/Indexer.scala
@@ -25,7 +25,7 @@ class Indexer(indexName:String) extends ZonedDateTimeEncoder with StorageClassEn
     * @param entryId ID of the archive entry for upsert
     * @param entry [[ArchiveEntry]] object to index
     * @param client implicitly provided elastic4s HttpClient object
-    * @return a Future containing a Try with either the ID of the new item or a RuntimeException containing the failure
+    * @return a Future containing either the ID of the new item or a RuntimeException containing the failure
     */
   def indexSingleItem(entry:ArchiveEntry, entryId: Option[String]=None, refreshPolicy: RefreshPolicy=RefreshPolicy.WAIT_UNTIL)(implicit client:HttpClient) = {
     val idToUse = entryId match {

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/Indexer.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/Indexer.scala
@@ -102,4 +102,8 @@ class Indexer(indexName:String) extends ZonedDateTimeEncoder with StorageClassEn
           Left(UnexpectedReturnCode(docId, other))
       }
   })
+
+  def deleteById(docId:String)(implicit client:HttpClient) = client.execute {
+    delete(docId) from indexName
+  }
 }

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocation.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocation.scala
@@ -67,7 +67,7 @@ object ProxyLocation extends DocId {
 
   /**
     * Looks up the metadata of a given item in S3 and returns a ProxyLocation
-    * @param bucket bucket that the item resides in
+    * @param proxyBucket bucket that the item resides in
     * @param key path to the item within `bucket`
     * @param client implicitly provided instance of AmazonS3Client to use
     * @return a (blocking) Future, containing a [[ProxyLocation]] if successful

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocationDAO.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocationDAO.scala
@@ -33,9 +33,18 @@ class ProxyLocationDAO @Inject() (config:ArchiveHunterConfiguration) extends Pro
       case None=>None
     })
 
+  /**
+    * Synchronous (non-Akka) version of getProxy, used in streams.
+    * @param fileId
+    * @param proxyType
+    * @param client
+    * @return
+    */
   def getProxySync(fileId:String, proxyType:ProxyType.Value)(implicit client:AmazonDynamoDB) =
     Scanamo.exec(client)(table.get('fileId->fileId and ('proxyType->proxyType.toString)))
 
+  def getAllProxiesFor(fileId:String)(implicit client:DynamoClient) =
+    ScanamoAlpakka.exec(client)(table.query('fileId->fileId))
   /**
     * Look up proxy by proxy ID
     * @param proxyId proxyID to look up

--- a/conf/logback-deployment.xml
+++ b/conf/logback-deployment.xml
@@ -29,7 +29,7 @@
         <streamName>{logging-stream}</streamName>
         <encoding>UTF-8</encoding>
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX"} [%level] from %logger in %thread - %message%n%xException</pattern>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX"} |{app}|{stage}| [%level] from %logger in %thread - %message%n%xException</pattern>
         </layout>
     </appender>
 

--- a/conf/logback-deployment.xml
+++ b/conf/logback-deployment.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+  -->
+<!-- The default logback configuration that Play uses in dev mode if no other configuration is provided -->
+<configuration>
+
+    <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%coloredLevel %logger{15} - %message%n%xException{20}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <appender name="KINESIS" class="com.gu.logback.appender.kinesis.KinesisAppender">
+        <bufferSize>1000</bufferSize>
+        <threadCount>20</threadCount>
+        <region>{region}</region>
+        <maxRetries>3</maxRetries>
+        <shutdownTimeout>30</shutdownTimeout>
+        <streamName>{logging-stream}</streamName>
+        <encoding>UTF-8</encoding>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX"} [%level] from %logger in %thread - %message%n%xException</pattern>
+        </layout>
+    </appender>
+
+    <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
+    <!--<appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>-->
+
+    <logger name="play" level="INFO" />
+    <logger name="application" level="ERROR" />
+
+    <logger name="services.AppStartup" level="INFO"/>
+    <logger name="services.BucketScanner" level="INFO"/>
+    <logger name="akka.cluster" level="ERROR"/>
+    <logger name="helpers.LightboxStreamComponents" level="INFO"/>
+    <logger name="helpers.S3ToArchiveEntryFlow" level="INFO"/>
+    <logger name="helpers.SearchHitToArchiveEntryFlow" level="WARN"/>
+    <logger name="helpers.ArchiveEntryVerifyFlow" level="WARN"/>
+    <logger name="helpers.LightboxStreamComponents.SaveLightboxEntryFlow" level="DEBUG"/>
+
+    <logger name="com.sksamuel.elastic4s.streams" level="WARN"/>
+    <logger name="controllers.SearchController" level="WARN"/>
+    <logger name="controllers.ProxyHealthController" level="INFO"/>
+    <logger name="controllers.ScanTargetController" level="INFO"/>
+    <logger name="controllers.JobController" level="INFO"/>
+    <logger name="controllers.BrowseCollectionController" level="INFO"/>
+
+    <logger name="controllers.UserController" level="INFO"/>
+    <logger name="controllers.LightboxController" level="INFO"/>
+
+    <logger name="controllers.ProxyFrameworkAdminController" level="INFO"/>
+
+    <logger name="controllers.Auth" level="DEBUG"/>
+    <logger name="controllers.BulkDownloadsController" level="DEBUG"/>
+
+    <logger name="com.gu.pandomainauth.action.AuthActions" level="INFO"/>
+
+    <logger name="helpers.DDBSink" level="INFO"/>
+    <logger name="helpers.S3ToProxyLocationFlow" level="INFO"/>
+    <logger name="services.LegacyProxiesScanner" level="INFO"/>
+
+    <logger name="S3LocationSpec" level="INFO"/>
+    <logger name="helpers.ParanoidS3Source" level="INFO"/>
+    <logger name="helpers.S3XMLProcessor" level="INFO"/>
+    <logger name="helpers.HasThumbnailFilter" level="INFO"/>
+    <logger name="helpers.CreateProxySink" level="INFO"/>
+    <logger name="services.BulkThumbnailer" level="INFO"/>
+    <logger name="services.DynamoCapacityActor" level="INFO"/>
+    <logger name="services.ClockSingleton" level="INFO"/>
+    <logger name="services.ETSProxyActor" level="INFO"/>
+    <logger name="services.ProxiesRelinker" level="INFO"/>
+    <logger name="helpers.ProxyVerifyFlow" level="INFO"/>
+    <logger name="services.JobPurgerActor" level="INFO"/>
+    <logger name="services.IngestProxyQueue" level="INFO"/>
+    <logger name="services.ProblemItemRetry" level="INFO"/>
+    <logger name="requests.JobSearchRequest" level="INFO"/>
+
+    <logger name="ProblemItemRetry" level="INFO"/>
+    <logger name="helpers.ProblemItemReproxySink" level="INFO"/>
+
+    <logger name="helpers.ProxyFramework" level="INFO"/>
+    <logger name="services.ProxyFrameworkQueue" level="INFO"/>
+
+    <logger name="models.ChartFacet" level="INFO"/>
+    <logger name="com.theguardian.multimedia.archivehunter.cmn_services.ProxyGenerators" level="INFO"/>
+    <logger name="com.theguardian.multimedia.archivehunter.common.ProxyLocation$" level="INFO"/>
+
+    <logger name="services.GlacierRestoreActor" level="DEBUG"/>
+
+    <logger name="helpers.LightboxHelper$" level="INFO"/>
+    <logger name="helpers.LightboxHelper" level="INFO"/>
+
+
+    <logger name="services.FileMoveActor" level="DEBUG"/>
+    <logger name="services.FileMove" level="DEBUG"/>
+    <logger name-="FileMoveActorSpec" level="DEBUG"/>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="KINESIS"/>
+        <appender-ref ref="Sentry" />
+    </root>
+
+</configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -103,6 +103,10 @@
     <logger name="helpers.LightboxHelper" level="INFO"/>
 
 
+    <logger name="services.FileMoveActor" level="DEBUG"/>
+    <logger name="services.FileMove" level="DEBUG"/>
+    <logger name-="FileMoveActorSpec" level="DEBUG"/>
+
     <root level="WARN">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="ASYNCFILE"/>

--- a/conf/routes
+++ b/conf/routes
@@ -53,7 +53,6 @@ GET     /api/proxyhealth/problemitems                       @controllers.ProxyHe
 GET     /api/proxyhealth/problemitems/collectionlist        @controllers.ProxyHealthController.collectionsWithProblems
 POST    /api/proxyhealth/triggerproblems/:collectionName    @controllers.ProxyHealthController.triggerProblemItemsFor(collectionName)
 
-
 GET     /api/job/all                            @controllers.JobController.getAllJobs(limit:Int ?=100, scanFrom:Option[String])
 GET     /api/job/:jobId                         @controllers.JobController.getJob(jobId)
 GET     /api/job/forFile/:fileId                @controllers.JobController.jobsFor(fileId)
@@ -85,6 +84,7 @@ GET     /api/config @controllers.ConfigController.getConfig
 
 GET     /api/download/:fileId           @controllers.LightboxController.getDownloadLink(fileId)
 
+PUT     /api/move/:fileId                       @controllers.FileMoveController.moveFile(fileId, to:String)
 GET     /api/archive/status/:fileId     @controllers.LightboxController.checkRestoreStatus(user:String ?= "my", fileId)
 GET     /api/archive/bulkStatus/:user/:bulkId   @controllers.LightboxController.bulkCheckRestoreStatus(user:String, bulkId:String)
 

--- a/frontend/app/JobsList/JobsFilterComponent.jsx
+++ b/frontend/app/JobsList/JobsFilterComponent.jsx
@@ -71,6 +71,7 @@ class JobsFilterComponent extends React.Component {
                     <option value="Analyse">Analyse</option>
                     <option value="CheckSetup">Check setup</option>
                     <option value="SetupTranscoding">Set up transcoding</option>
+                    <option value="FileMove">File move</option>
                 </select>
             </span>
             <span className="filter-entry">

--- a/test/FileMoveActorSpec.scala
+++ b/test/FileMoveActorSpec.scala
@@ -1,0 +1,154 @@
+import java.sql.Timestamp
+import java.time.{LocalDateTime, ZonedDateTime}
+
+import akka.actor.{ActorRef, ActorSystem, Props}
+import org.specs2.mutable._
+import akka.testkit._
+import play.api.{Configuration, Logger}
+import akka.pattern.ask
+import com.theguardian.multimedia.archivehunter.common.ProxyLocationDAO
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTarget
+import org.specs2.mock.Mockito
+import services.FileMove.GenericMoveActor
+import services.FileMove.GenericMoveActor.{FileMoveTransientData, PerformStep}
+import services.FileMoveActor
+import services.FileMoveActor.{MoveFailed, MoveFile, MoveSuccess}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.util.{Failure, Try}
+import scala.concurrent.ExecutionContext.Implicits.global
+import services.FileMove.GenericMoveActor._
+
+class FileMoveActorSpec extends Specification with Mockito {
+  sequential
+  private val logger=Logger(getClass)
+  implicit val timeout:akka.util.Timeout = 30.seconds
+
+  "runNextActorInSequence" should {
+    "run a list of actors providing that they all return successfully" in new AkkaTestkitSpecs2Support {
+      val config = Configuration.empty
+      val mockedProxyLocationDAO = mock[ProxyLocationDAO]
+      val mockedESClientMgr = mock[ESClientManager]
+      val mockedDynamoClientMgr = mock[DynamoClientManager]
+      val mockedS3ClientMgr = mock[S3ClientManager]
+      val probe1 = TestProbe()
+      val probe2 = TestProbe()
+      val probe3 = TestProbe()
+
+      val actorSeq = Seq(probe1.ref, probe2.ref, probe3.ref)
+      val ac = system.actorOf(Props(new FileMoveActor(
+        config,
+        mockedProxyLocationDAO,
+        mockedESClientMgr,
+        mockedDynamoClientMgr,
+        mockedS3ClientMgr
+      ) {
+        override protected val fileMoveChain: Seq[ActorRef] = Seq(probe1.ref, probe2.ref, probe3.ref)
+      }))
+
+      val target = ScanTarget("some-bucket", true, None, 1234L, false, None, "some-proxy-bucket", "eu-west-1", None, None, None, None)
+
+      val resultFuture = ac ? MoveFile("somesourcefileId", target)
+      val initialData = FileMoveTransientData.initialise("somesourcefileId", "some-bucket", "some-proxy-bucket")
+
+      probe1.expectMsg(5.seconds, PerformStep(initialData))
+      logger.info(probe1.lastSender.toString)
+
+      val updatedData = initialData.copy(destFileId = Some("destination-file"))
+      probe1.reply(GenericMoveActor.StepSucceeded(updatedData))
+      probe2.expectMsg(5.seconds, PerformStep(updatedData))
+      probe2.reply(GenericMoveActor.StepSucceeded(updatedData))
+      probe3.expectMsg(5.seconds, PerformStep(updatedData))
+      probe3.reply(GenericMoveActor.StepSucceeded(updatedData))
+
+      val result = Await.result(resultFuture, 90.seconds)
+      result mustEqual MoveSuccess
+    }
+
+        "stop when an actor reports a failure and roll back the ones that had run before" in new AkkaTestkitSpecs2Support{
+          val config = Configuration.empty
+          val mockedProxyLocationDAO = mock[ProxyLocationDAO]
+          val mockedESClientMgr = mock[ESClientManager]
+          val mockedDynamoClientMgr = mock[DynamoClientManager]
+          val mockedS3ClientMgr = mock[S3ClientManager]
+          val probe1 = TestProbe()
+          val probe2 = TestProbe()
+          val probe3 = TestProbe()
+
+          val actorSeq = Seq(probe1.ref, probe2.ref, probe3.ref)
+          val ac = system.actorOf(Props(new FileMoveActor(
+            config,
+            mockedProxyLocationDAO,
+            mockedESClientMgr,
+            mockedDynamoClientMgr,
+            mockedS3ClientMgr
+          ) {
+            override protected val fileMoveChain: Seq[ActorRef] = Seq(probe1.ref, probe2.ref, probe3.ref)
+          }))
+
+          val target = ScanTarget("some-bucket", true, None, 1234L, false, None, "some-proxy-bucket", "eu-west-1", None, None, None, None)
+
+          val resultFuture = ac ? MoveFile("somesourcefileId", target)
+          val initialData = FileMoveTransientData.initialise("somesourcefileId", "some-bucket", "some-proxy-bucket")
+
+          probe1.expectMsg(5.seconds, PerformStep(initialData))
+          val updatedStage1 = initialData.copy(destFileId=Some("dest-file-id"))
+          probe1.reply(GenericMoveActor.StepSucceeded(updatedStage1))
+          probe2.expectMsg(5.seconds, PerformStep(updatedStage1))
+          probe2.reply(GenericMoveActor.StepFailed(updatedStage1, "Something went splat!"))
+          probe2.expectMsg(5.seconds, RollbackStep(updatedStage1))
+          probe2.reply(GenericMoveActor.StepSucceeded(updatedStage1))
+          probe1.expectMsg(5.seconds, RollbackStep(updatedStage1))
+          probe1.reply(StepSucceeded(updatedStage1))
+
+          probe3.expectNoMessage(5.seconds)
+
+          val result = Await.result(resultFuture, 15.seconds)
+          result mustEqual MoveFailed("Something went splat!")
+
+        }
+
+        "continue rollback even if a rollback fails" in new AkkaTestkitSpecs2Support{
+          val config = Configuration.empty
+          val mockedProxyLocationDAO = mock[ProxyLocationDAO]
+          val mockedESClientMgr = mock[ESClientManager]
+          val mockedDynamoClientMgr = mock[DynamoClientManager]
+          val mockedS3ClientMgr = mock[S3ClientManager]
+          val probe1 = TestProbe()
+          val probe2 = TestProbe()
+          val probe3 = TestProbe()
+
+          val actorSeq = Seq(probe1.ref, probe2.ref, probe3.ref)
+          val ac = system.actorOf(Props(new FileMoveActor(
+            config,
+            mockedProxyLocationDAO,
+            mockedESClientMgr,
+            mockedDynamoClientMgr,
+            mockedS3ClientMgr
+          ) {
+            override protected val fileMoveChain: Seq[ActorRef] = Seq(probe1.ref, probe2.ref, probe3.ref)
+          }))
+
+          val target = ScanTarget("some-bucket", true, None, 1234L, false, None, "some-proxy-bucket", "eu-west-1", None, None, None, None)
+
+          val resultFuture = ac ? MoveFile("somesourcefileId", target)
+          val initialData = FileMoveTransientData.initialise("somesourcefileId", "some-bucket", "some-proxy-bucket")
+
+          probe1.expectMsg(5.seconds, PerformStep(initialData))
+          probe1.reply(StepSucceeded(initialData))
+          probe2.expectMsg(5.seconds, PerformStep(initialData))
+          probe2.reply(StepFailed(initialData, "Fire the blobfish!"))
+          probe2.expectMsg(5.seconds, RollbackStep(initialData))
+          probe2.reply(StepFailed(initialData, "Fire the octopus!"))
+          probe1.expectMsg(5.seconds,  RollbackStep(initialData))
+          probe1.reply(StepSucceeded(initialData))
+
+          probe3.expectNoMessage(5.seconds)
+
+          val result = Await.result(resultFuture,15.seconds)
+          result mustEqual MoveFailed("Fire the blobfish!")
+        }
+      }
+}

--- a/test/FileMoveActorSpec.scala
+++ b/test/FileMoveActorSpec.scala
@@ -33,6 +33,8 @@ class FileMoveActorSpec extends Specification with Mockito {
       val mockedESClientMgr = mock[ESClientManager]
       val mockedDynamoClientMgr = mock[DynamoClientManager]
       val mockedS3ClientMgr = mock[S3ClientManager]
+      val mockedJobModelDAO = mock[JobModelDAO]
+      mockedJobModelDAO.putJob(any) returns Future(None)
       val probe1 = TestProbe()
       val probe2 = TestProbe()
       val probe3 = TestProbe()
@@ -43,6 +45,7 @@ class FileMoveActorSpec extends Specification with Mockito {
         mockedProxyLocationDAO,
         mockedESClientMgr,
         mockedDynamoClientMgr,
+        mockedJobModelDAO,
         mockedS3ClientMgr
       ) {
         override protected val fileMoveChain: Seq[ActorRef] = Seq(probe1.ref, probe2.ref, probe3.ref)
@@ -50,8 +53,8 @@ class FileMoveActorSpec extends Specification with Mockito {
 
       val target = ScanTarget("some-bucket", true, None, 1234L, false, None, "some-proxy-bucket", "eu-west-1", None, None, None, None)
 
-      val resultFuture = ac ? MoveFile("somesourcefileId", target)
-      val initialData = FileMoveTransientData.initialise("somesourcefileId", "some-bucket", "some-proxy-bucket","dest-region")
+      val resultFuture = ac ? MoveFile("somesourcefileId", target, async=false)
+      val initialData = FileMoveTransientData.initialise("somesourcefileId", "some-bucket", "some-proxy-bucket", "eu-west-1")
 
       probe1.expectMsg(5.seconds, PerformStep(initialData))
       logger.info(probe1.lastSender.toString)
@@ -73,6 +76,8 @@ class FileMoveActorSpec extends Specification with Mockito {
           val mockedESClientMgr = mock[ESClientManager]
           val mockedDynamoClientMgr = mock[DynamoClientManager]
           val mockedS3ClientMgr = mock[S3ClientManager]
+          val mockedJobModelDAO = mock[JobModelDAO]
+          mockedJobModelDAO.putJob(any) returns Future(None)
           val probe1 = TestProbe()
           val probe2 = TestProbe()
           val probe3 = TestProbe()
@@ -83,6 +88,7 @@ class FileMoveActorSpec extends Specification with Mockito {
             mockedProxyLocationDAO,
             mockedESClientMgr,
             mockedDynamoClientMgr,
+            mockedJobModelDAO,
             mockedS3ClientMgr
           ) {
             override protected val fileMoveChain: Seq[ActorRef] = Seq(probe1.ref, probe2.ref, probe3.ref)
@@ -90,8 +96,8 @@ class FileMoveActorSpec extends Specification with Mockito {
 
           val target = ScanTarget("some-bucket", true, None, 1234L, false, None, "some-proxy-bucket", "eu-west-1", None, None, None, None)
 
-          val resultFuture = ac ? MoveFile("somesourcefileId", target)
-          val initialData = FileMoveTransientData.initialise("somesourcefileId", "some-bucket", "some-proxy-bucket","dest-region")
+          val resultFuture = ac ? MoveFile("somesourcefileId", target, async=false)
+          val initialData = FileMoveTransientData.initialise("somesourcefileId", "some-bucket", "some-proxy-bucket","eu-west-1")
 
           probe1.expectMsg(5.seconds, PerformStep(initialData))
           val updatedStage1 = initialData.copy(destFileId=Some("dest-file-id"))
@@ -117,6 +123,7 @@ class FileMoveActorSpec extends Specification with Mockito {
           val mockedDynamoClientMgr = mock[DynamoClientManager]
           val mockedS3ClientMgr = mock[S3ClientManager]
           val mockedJobModelDAO = mock[JobModelDAO]
+          mockedJobModelDAO.putJob(any) returns Future(None)
           val probe1 = TestProbe()
           val probe2 = TestProbe()
           val probe3 = TestProbe()
@@ -135,8 +142,8 @@ class FileMoveActorSpec extends Specification with Mockito {
 
           val target = ScanTarget("some-bucket", true, None, 1234L, false, None, "some-proxy-bucket", "eu-west-1", None, None, None, None)
 
-          val resultFuture = ac ? MoveFile("somesourcefileId", target)
-          val initialData = FileMoveTransientData.initialise("somesourcefileId", "some-bucket", "some-proxy-bucket","dest-region")
+          val resultFuture = ac ? MoveFile("somesourcefileId", target,async=false)
+          val initialData = FileMoveTransientData.initialise("somesourcefileId", "some-bucket", "some-proxy-bucket","eu-west-1")
 
           probe1.expectMsg(5.seconds, PerformStep(initialData))
           probe1.reply(StepSucceeded(initialData))

--- a/test/TestFileMove/AkkaTestkitSpecs2Support.scala
+++ b/test/TestFileMove/AkkaTestkitSpecs2Support.scala
@@ -1,0 +1,16 @@
+package TestFileMove
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit}
+import org.specs2.mutable.After
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/* A tiny class that can be used as a Specs2 ‘context’. */
+abstract class AkkaTestkitSpecs2Support extends TestKit(ActorSystem())
+  with After
+  with ImplicitSender {
+  // make sure we shut down the actor system after all tests have run
+  def after = Await.result(system.terminate(), 30 seconds)
+}

--- a/test/TestFileMove/CopyMainFileSpec.scala
+++ b/test/TestFileMove/CopyMainFileSpec.scala
@@ -11,6 +11,7 @@ import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientMa
 import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, DocId, MimeType, StorageClass}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
+import play.api.Configuration
 import services.FileMove.CopyMainFile
 import services.FileMove.GenericMoveActor._
 
@@ -33,7 +34,7 @@ class CopyMainFileSpec extends Specification with Mockito with DocId {
       val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
         MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
 
-      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies")
+      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies","dest-region")
 
       val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr)))
 
@@ -54,7 +55,7 @@ class CopyMainFileSpec extends Specification with Mockito with DocId {
       val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
         MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
 
-      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies")
+      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies", "dest-region")
 
       val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr)))
 
@@ -80,9 +81,9 @@ class CopyMainFileSpec extends Specification with Mockito with DocId {
       val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
         MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
 
-      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies")
+      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies","dest-region")
 
-      val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr)))
+      val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr, Configuration.empty)))
 
       val result = Await.result(actor ? RollbackStep(request), 30 seconds).asInstanceOf[MoveActorMessage]
 
@@ -103,9 +104,9 @@ class CopyMainFileSpec extends Specification with Mockito with DocId {
       val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
         MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
 
-      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies")
+      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies","dest-region")
 
-      val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr)))
+      val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr, Configuration.empty)))
 
       val result = Await.result(actor ? RollbackStep(request), 30 seconds).asInstanceOf[MoveActorMessage]
 

--- a/test/TestFileMove/CopyMainFileSpec.scala
+++ b/test/TestFileMove/CopyMainFileSpec.scala
@@ -1,0 +1,118 @@
+package TestFileMove
+
+import java.time.ZonedDateTime
+
+import akka.actor.Props
+import com.amazonaws.AmazonClientException
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.internal.DeleteObjectsResponse
+import com.amazonaws.services.s3.model.{CopyObjectResult, ObjectMetadata}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, DocId, MimeType, StorageClass}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import services.FileMove.CopyMainFile
+import services.FileMove.GenericMoveActor._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class CopyMainFileSpec extends Specification with Mockito with DocId {
+  import akka.pattern.ask
+  implicit val timeout:akka.util.Timeout = 30 seconds
+
+  "CopyMainFile!PerformStep" should {
+    "tell S3 to copy the file with same path to given destination bucket" in new AkkaTestkitSpecs2Support {
+      val mockedClientMgr = mock[S3ClientManager]
+      val mockedS3Client = mock[AmazonS3]
+      val mockedCopyResult = mock[CopyObjectResult]
+
+      mockedClientMgr.getS3Client(any,any) returns mockedS3Client
+      mockedS3Client.copyObject(any, any, any, any) returns mockedCopyResult
+
+      val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
+        MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
+
+      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies")
+
+      val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr)))
+
+      val result = Await.result(actor ? PerformStep(request), 30 seconds).asInstanceOf[MoveActorMessage]
+
+      result must beAnInstanceOf[StepSucceeded]
+      result.asInstanceOf[StepSucceeded].updatedData.destFileId must beSome(makeDocId("destBucket","/path/to/file"))
+      there was one(mockedS3Client).copyObject("sourcebucket","/path/to/file","destBucket","/path/to/file")
+    }
+
+    "reply with step failed if the S3 copy raises an exception" in new AkkaTestkitSpecs2Support {
+      val mockedClientMgr = mock[S3ClientManager]
+      val mockedS3Client = mock[AmazonS3]
+      mockedClientMgr.getS3Client(any,any) returns mockedS3Client
+
+      mockedS3Client.copyObject(any, any, any, any) throws new RuntimeException("test")
+
+      val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
+        MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
+
+      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies")
+
+      val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr)))
+
+      val result = Await.result(actor ? PerformStep(request), 30 seconds).asInstanceOf[MoveActorMessage]
+
+      result must beAnInstanceOf[StepFailed]
+      result.asInstanceOf[StepFailed].updatedData.destFileId must beNone
+      there was one(mockedS3Client).copyObject("sourcebucket","/path/to/file","destBucket","/path/to/file")
+    }
+  }
+
+  "CopyMainFile!RollbackStep" should {
+    "delete the target file if the original exists" in new AkkaTestkitSpecs2Support {
+      val mockedClientMgr = mock[S3ClientManager]
+      val mockedS3Client = mock[AmazonS3]
+      mockedClientMgr.getS3Client(any,any) returns mockedS3Client
+      val mockedGetResponse = mock[ObjectMetadata]
+      val mockedDeleteResponse = mock[DeleteObjectsResponse]
+
+      mockedS3Client.deleteObject(any, any)
+      mockedS3Client.getObjectMetadata(any, any) returns mockedGetResponse
+
+      val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
+        MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
+
+      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies")
+
+      val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr)))
+
+      val result = Await.result(actor ? RollbackStep(request), 30 seconds).asInstanceOf[MoveActorMessage]
+
+      result must beAnInstanceOf[StepSucceeded]
+      there was one(mockedS3Client).getObjectMetadata("sourcebucket","/path/to/file")
+      there was one(mockedS3Client).deleteObject("destBucket","/path/to/file")
+    }
+
+    "NOT delete the target file if the original file could not be verified" in new AkkaTestkitSpecs2Support {
+      val mockedClientMgr = mock[S3ClientManager]
+      val mockedS3Client = mock[AmazonS3]
+      mockedClientMgr.getS3Client(any,any) returns mockedS3Client
+      val mockedGetResponse = mock[ObjectMetadata]
+      val mockedDeleteResponse = mock[DeleteObjectsResponse]
+
+      mockedS3Client.getObjectMetadata(any, any) throws new RuntimeException("fake exception showing that file exists")
+
+      val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
+        MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
+
+      val request = FileMoveTransientData("fake-id",Some(testItem),None,None,None,"destBucket","destProxies")
+
+      val actor = system.actorOf(Props(new CopyMainFile(mockedClientMgr)))
+
+      val result = Await.result(actor ? RollbackStep(request), 30 seconds).asInstanceOf[MoveActorMessage]
+
+      result must beAnInstanceOf[StepFailed]
+      result.asInstanceOf[StepFailed].updatedData.destFileId must beNone
+      there was one(mockedS3Client).getObjectMetadata("sourcebucket","/path/to/file")
+      there was no(mockedS3Client).deleteObject(any, any)
+    }
+  }
+}

--- a/test/TestFileMove/CopyProxyFilesSpec.scala
+++ b/test/TestFileMove/CopyProxyFilesSpec.scala
@@ -7,6 +7,7 @@ import com.theguardian.multimedia.archivehunter.common.{DocId, ProxyLocation, Pr
 import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
+import play.api.Configuration
 import services.FileMove.CopyProxyFiles
 
 import scala.concurrent.Await
@@ -33,11 +34,11 @@ class CopyProxyFilesSpec extends Specification with Mockito with DocId {
         ProxyLocation("source-file-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
         ProxyLocation("source-file-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
       )
-      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),None,"dest-media-bucket","dest-proxy-bucket")
+      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),None,"dest-media-bucket","dest-proxy-bucket","dest-region")
 
       val testMsg = PerformStep(data)
 
-      val actor = system.actorOf(Props(new CopyProxyFiles(mockedClientMgr)))
+      val actor = system.actorOf(Props(new CopyProxyFiles(mockedClientMgr, Configuration.empty)))
 
       val result = Await.result(actor ? testMsg, 30 seconds).asInstanceOf[MoveActorMessage]
 
@@ -84,11 +85,11 @@ class CopyProxyFilesSpec extends Specification with Mockito with DocId {
         ProxyLocation("source-file-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
         ProxyLocation("source-file-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
       )
-      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),None,"dest-media-bucket","dest-proxy-bucket")
+      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),None,"dest-media-bucket","dest-proxy-bucket","dest-region")
 
       val testMsg = PerformStep(data)
 
-      val actor = system.actorOf(Props(new CopyProxyFiles(mockedClientMgr)))
+      val actor = system.actorOf(Props(new CopyProxyFiles(mockedClientMgr, Configuration.empty)))
 
       val result = Await.result(actor ? testMsg, 30 seconds).asInstanceOf[MoveActorMessage]
       result must beAnInstanceOf[StepFailed]
@@ -117,11 +118,11 @@ class CopyProxyFilesSpec extends Specification with Mockito with DocId {
         ProxyLocation("source-file-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
         ProxyLocation("source-file-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
       )
-      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),None,"dest-media-bucket","dest-proxy-bucket")
+      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),None,"dest-media-bucket","dest-proxy-bucket","dest-region")
 
       val testMsg = RollbackStep(data)
 
-      val actor = system.actorOf(Props(new CopyProxyFiles(mockedClientMgr)))
+      val actor = system.actorOf(Props(new CopyProxyFiles(mockedClientMgr,Configuration.empty)))
 
       val result = Await.result(actor ? testMsg, 30 seconds).asInstanceOf[MoveActorMessage]
 

--- a/test/TestFileMove/CopyProxyFilesSpec.scala
+++ b/test/TestFileMove/CopyProxyFilesSpec.scala
@@ -1,0 +1,8 @@
+package TestFileMove
+
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+class CopyProxyFilesSpec extends Specification with Mockito {
+
+}

--- a/test/TestFileMove/CopyProxyFilesSpec.scala
+++ b/test/TestFileMove/CopyProxyFilesSpec.scala
@@ -1,8 +1,133 @@
 package TestFileMove
 
+import akka.actor.Props
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.CopyObjectResult
+import com.theguardian.multimedia.archivehunter.common.{DocId, ProxyLocation, ProxyType, StorageClass}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
+import services.FileMove.CopyProxyFiles
 
-class CopyProxyFilesSpec extends Specification with Mockito {
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
+
+class CopyProxyFilesSpec extends Specification with Mockito with DocId {
+  import akka.pattern.ask
+  import services.FileMove.GenericMoveActor._
+
+  implicit val timeout:akka.util.Timeout = 30 seconds
+
+  "CopyProxyFiles!PerformStep" should {
+    "copy all referenced proxies and update the state with new locations" in new AkkaTestkitSpecs2Support {
+      val mockedClientMgr = mock[S3ClientManager]
+      val mockedS3Client = mock[AmazonS3]
+      val mockedCopyResult = mock[CopyObjectResult]
+
+      mockedClientMgr.getS3Client(any,any) returns mockedS3Client
+      mockedS3Client.copyObject(any, any, any, any) returns mockedCopyResult
+
+      val sourceProxyList = Seq(
+        ProxyLocation("source-file-id","proxyid1",ProxyType.VIDEO,"source-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("source-file-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("source-file-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),None,"dest-media-bucket","dest-proxy-bucket")
+
+      val testMsg = PerformStep(data)
+
+      val actor = system.actorOf(Props(new CopyProxyFiles(mockedClientMgr)))
+
+      val result = Await.result(actor ? testMsg, 30 seconds).asInstanceOf[MoveActorMessage]
+
+      result must beAnInstanceOf[StepSucceeded]
+
+      there was one(mockedS3Client).copyObject("source-proxy-bucket","path/to/proxy1","dest-proxy-bucket","path/to/proxy1")
+      there was one(mockedS3Client).copyObject("source-proxy-bucket","path/to/proxy2","dest-proxy-bucket","path/to/proxy2")
+      there was one(mockedS3Client).copyObject("source-proxy-bucket","path/to/proxy3","dest-proxy-bucket","path/to/proxy3")
+
+      val updatedData = result.asInstanceOf[StepSucceeded].updatedData
+
+      updatedData.destFileProxy must beSome
+      val updatedDestProxies = updatedData.destFileProxy.get
+      updatedDestProxies.length mustEqual 3
+      updatedDestProxies.head.bucketName mustEqual "dest-proxy-bucket"
+      updatedDestProxies.head.bucketPath mustEqual "path/to/proxy1"
+      updatedDestProxies.head.fileId mustEqual "dest-file-id"
+      updatedDestProxies.head.proxyId mustEqual makeDocId("dest-proxy-bucket","path/to/proxy1")
+      updatedDestProxies(1).bucketName mustEqual "dest-proxy-bucket"
+      updatedDestProxies(1).bucketPath mustEqual "path/to/proxy2"
+      updatedDestProxies(1).fileId mustEqual "dest-file-id"
+      updatedDestProxies(1).proxyId mustEqual makeDocId("dest-proxy-bucket","path/to/proxy2")
+      updatedDestProxies(2).bucketName mustEqual "dest-proxy-bucket"
+      updatedDestProxies(2).bucketPath mustEqual "path/to/proxy3"
+      updatedDestProxies(2).fileId mustEqual "dest-file-id"
+      updatedDestProxies(2).proxyId mustEqual makeDocId("dest-proxy-bucket","path/to/proxy3")
+
+      there were no(mockedS3Client).deleteObject(any,any)
+    }
+
+    "delete all potentially existing copies (continuing if anything errors) and signal error if one copy fails" in new AkkaTestkitSpecs2Support {
+      val mockedClientMgr = mock[S3ClientManager]
+      val mockedS3Client = mock[AmazonS3]
+      val mockedCopyResult = mock[CopyObjectResult]
+
+      mockedClientMgr.getS3Client(any,any) returns mockedS3Client
+      mockedS3Client.deleteObject("dest-proxy-bucket","path/to/proxy2") throws new RuntimeException("bleagh")
+      mockedS3Client.doesObjectExist(any, any) returns true
+      mockedS3Client.copyObject(any, any, any, any) returns mockedCopyResult
+      mockedS3Client.copyObject("source-proxy-bucket","path/to/proxy3","dest-proxy-bucket","path/to/proxy3") throws new RuntimeException("something went ping")
+
+      val sourceProxyList = Seq(
+        ProxyLocation("source-file-id","proxyid1",ProxyType.VIDEO,"source-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("source-file-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("source-file-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),None,"dest-media-bucket","dest-proxy-bucket")
+
+      val testMsg = PerformStep(data)
+
+      val actor = system.actorOf(Props(new CopyProxyFiles(mockedClientMgr)))
+
+      val result = Await.result(actor ? testMsg, 30 seconds).asInstanceOf[MoveActorMessage]
+      result must beAnInstanceOf[StepFailed]
+
+      there was one(mockedS3Client).copyObject("source-proxy-bucket","path/to/proxy1","dest-proxy-bucket","path/to/proxy1")
+      there was one(mockedS3Client).copyObject("source-proxy-bucket","path/to/proxy2","dest-proxy-bucket","path/to/proxy2")
+      there was one(mockedS3Client).copyObject("source-proxy-bucket","path/to/proxy3","dest-proxy-bucket","path/to/proxy3")
+
+      there was one(mockedS3Client).deleteObject("dest-proxy-bucket","path/to/proxy1")
+      there was one(mockedS3Client).deleteObject("dest-proxy-bucket","path/to/proxy2")
+      there was one(mockedS3Client).deleteObject("dest-proxy-bucket","path/to/proxy3")
+    }
+  }
+
+  "CopyFiles!RollbackStep" should {
+    "delete the copied versions of any proxies available" in new AkkaTestkitSpecs2Support {
+      val mockedClientMgr = mock[S3ClientManager]
+      val mockedS3Client = mock[AmazonS3]
+      val mockedCopyResult = mock[CopyObjectResult]
+
+      mockedClientMgr.getS3Client(any,any) returns mockedS3Client
+      mockedS3Client.doesObjectExist(any, any) returns true
+
+      val sourceProxyList = Seq(
+        ProxyLocation("source-file-id","proxyid1",ProxyType.VIDEO,"source-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("source-file-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("source-file-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),None,"dest-media-bucket","dest-proxy-bucket")
+
+      val testMsg = RollbackStep(data)
+
+      val actor = system.actorOf(Props(new CopyProxyFiles(mockedClientMgr)))
+
+      val result = Await.result(actor ? testMsg, 30 seconds).asInstanceOf[MoveActorMessage]
+
+      there was one(mockedS3Client).deleteObject("dest-proxy-bucket","path/to/proxy1")
+      there was one(mockedS3Client).deleteObject("dest-proxy-bucket","path/to/proxy2")
+      there was one(mockedS3Client).deleteObject("dest-proxy-bucket","path/to/proxy3")
+    }
+  }
 }

--- a/test/TestFileMove/DeleteOriginalFileSpec.scala
+++ b/test/TestFileMove/DeleteOriginalFileSpec.scala
@@ -51,7 +51,8 @@ class DeleteOriginalFileSpec extends Specification with Mockito {
         Some(sourceProxyList),
         Some(destProxyList),
         "dest-bucket",
-        "dest-proxy-bucket"
+        "dest-proxy-bucket",
+        "dest-region"
       )
       val result = Await.result((actor ? PerformStep(jobState) ).mapTo[MoveActorMessage], 30 seconds)
 
@@ -103,7 +104,8 @@ class DeleteOriginalFileSpec extends Specification with Mockito {
         Some(sourceProxyList),
         Some(destProxyList),
         "dest-bucket",
-        "dest-proxy-bucket"
+        "dest-proxy-bucket",
+        "dest-region"
       )
       val result = Await.result((actor ? PerformStep(jobState) ).mapTo[MoveActorMessage], 30 seconds)
 
@@ -157,7 +159,8 @@ class DeleteOriginalFileSpec extends Specification with Mockito {
         Some(sourceProxyList),
         Some(destProxyList),
         "dest-bucket",
-        "dest-proxy-bucket"
+        "dest-proxy-bucket",
+        "dest-region"
       )
       val result = Await.result((actor ? PerformStep(jobState) ).mapTo[MoveActorMessage], 30 seconds)
 

--- a/test/TestFileMove/DeleteOriginalFileSpec.scala
+++ b/test/TestFileMove/DeleteOriginalFileSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable.Specification
 import services.FileMove.{DeleteOriginalFiles, GenericMoveActor}
 import akka.pattern.ask
 import com.amazonaws.services.s3.model.ObjectMetadata
-import services.FileMove.GenericMoveActor.{MoveActorMessage, PerformStep, StepSucceeded}
+import services.FileMove.GenericMoveActor.{MoveActorMessage, PerformStep, StepFailed, StepSucceeded}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -63,6 +63,114 @@ class DeleteOriginalFileSpec extends Specification with Mockito {
       there was one(mockedS3Client).deleteObject("source-media-bucket","path/to/source-media.mxf")
       there was one(mockedS3Client).deleteObject("source-proxy-bucket","path/to/thumbnail")
       there was one(mockedS3Client).deleteObject("source-proxy-bucket", "path/to/vidproxy")
+    }
+
+    "not delete anything if the main media size is different" in new AkkaTestkitSpecs2Support {
+      val mockedS3Client = mock[AmazonS3]
+      mockedS3Client.doesObjectExist(any,any) returns true
+
+      val fakeMetadata = mock[ObjectMetadata]
+      fakeMetadata.getContentLength returns 12345L
+      fakeMetadata.getContentMD5 returns "some-md5-here"
+      val fakeOtherMetadata = mock[ObjectMetadata]
+      fakeOtherMetadata.getContentLength returns 3L
+      fakeMetadata.getContentMD5 returns "some-md5-here"
+
+      mockedS3Client.getObjectMetadata(any,any) returns fakeOtherMetadata thenReturns fakeMetadata
+
+      val mockedS3ClientMgr = mock[S3ClientManager]
+      mockedS3ClientMgr.getS3Client(any,any) returns mockedS3Client
+      val mockedIndexer = mock[Indexer]
+
+      val actor = system.actorOf(Props(new DeleteOriginalFiles(mockedS3ClientMgr, mockedIndexer)))
+
+      val originalSourceEntry = mock[ArchiveEntry]
+      originalSourceEntry.bucket returns "source-media-bucket"
+      originalSourceEntry.path returns "path/to/source-media.mxf"
+
+      val sourceProxyList = Seq(
+        ProxyLocation("file-id-1","source-proxy-1",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/thumbnail",None,StorageClass.STANDARD),
+        ProxyLocation("file-id-2","source-proxy-2",ProxyType.VIDEO,"source-proxy-bucket","path/to/vidproxy",None,StorageClass.STANDARD)
+      )
+      val destProxyList = Seq(
+        ProxyLocation("file-id-3","dest-proxy-1",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/thumbnail",None,StorageClass.STANDARD),
+        ProxyLocation("file-id-4","dest-proxy-2",ProxyType.VIDEO,"dest-proxy-bucket","path/to/vidproxy",None,StorageClass.STANDARD)
+      )
+      val jobState = GenericMoveActor.FileMoveTransientData(
+        "source-file-id",
+        Some(originalSourceEntry),
+        Some("dest-file-id"),
+        Some(sourceProxyList),
+        Some(destProxyList),
+        "dest-bucket",
+        "dest-proxy-bucket"
+      )
+      val result = Await.result((actor ? PerformStep(jobState) ).mapTo[MoveActorMessage], 30 seconds)
+
+      val expectedFinalState = jobState.copy(sourceFileProxies = None)
+      result must beAnInstanceOf[StepFailed]
+      there was one(mockedS3Client).getObjectMetadata("source-media-bucket","path/to/source-media.mxf")
+      there was one(mockedS3Client).getObjectMetadata("dest-bucket","path/to/source-media.mxf")
+      there was one(mockedS3Client).doesObjectExist("dest-bucket","path/to/source-media.mxf")
+      there was no(mockedS3Client).doesObjectExist("dest-proxy-bucket","path/to/thumbnail")
+      there was no(mockedS3Client).doesObjectExist("dest-proxy-bucket","path/to/vidproxy")
+      there was no(mockedS3Client).deleteObject("source-media-bucket","path/to/source-media.mxf")
+      there was no(mockedS3Client).deleteObject("source-proxy-bucket","path/to/thumbnail")
+      there was no(mockedS3Client).deleteObject("source-proxy-bucket", "path/to/vidproxy")
+    }
+
+    "not delete anything if the main media checksum is different" in new AkkaTestkitSpecs2Support {
+      val mockedS3Client = mock[AmazonS3]
+      mockedS3Client.doesObjectExist(any,any) returns true
+
+      val fakeMetadata = mock[ObjectMetadata]
+      fakeMetadata.getContentLength returns 12345L
+      fakeMetadata.getContentMD5 returns "some-md5-here"
+      val fakeOtherMetadata = mock[ObjectMetadata]
+      fakeOtherMetadata.getContentLength returns 12345L
+      fakeOtherMetadata.getContentMD5 returns "some-other-md5-here"
+
+      mockedS3Client.getObjectMetadata(any,any) returns fakeOtherMetadata thenReturns fakeMetadata
+
+      val mockedS3ClientMgr = mock[S3ClientManager]
+      mockedS3ClientMgr.getS3Client(any,any) returns mockedS3Client
+      val mockedIndexer = mock[Indexer]
+
+      val actor = system.actorOf(Props(new DeleteOriginalFiles(mockedS3ClientMgr, mockedIndexer)))
+
+      val originalSourceEntry = mock[ArchiveEntry]
+      originalSourceEntry.bucket returns "source-media-bucket"
+      originalSourceEntry.path returns "path/to/source-media.mxf"
+
+      val sourceProxyList = Seq(
+        ProxyLocation("file-id-1","source-proxy-1",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/thumbnail",None,StorageClass.STANDARD),
+        ProxyLocation("file-id-2","source-proxy-2",ProxyType.VIDEO,"source-proxy-bucket","path/to/vidproxy",None,StorageClass.STANDARD)
+      )
+      val destProxyList = Seq(
+        ProxyLocation("file-id-3","dest-proxy-1",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/thumbnail",None,StorageClass.STANDARD),
+        ProxyLocation("file-id-4","dest-proxy-2",ProxyType.VIDEO,"dest-proxy-bucket","path/to/vidproxy",None,StorageClass.STANDARD)
+      )
+      val jobState = GenericMoveActor.FileMoveTransientData(
+        "source-file-id",
+        Some(originalSourceEntry),
+        Some("dest-file-id"),
+        Some(sourceProxyList),
+        Some(destProxyList),
+        "dest-bucket",
+        "dest-proxy-bucket"
+      )
+      val result = Await.result((actor ? PerformStep(jobState) ).mapTo[MoveActorMessage], 30 seconds)
+
+      val expectedFinalState = jobState.copy(sourceFileProxies = None)
+      result must beAnInstanceOf[StepFailed]
+      there was one(mockedS3Client).getObjectMetadata("source-media-bucket","path/to/source-media.mxf")
+      there was one(mockedS3Client).getObjectMetadata("dest-bucket","path/to/source-media.mxf")
+      there was one(mockedS3Client).doesObjectExist("dest-bucket","path/to/source-media.mxf")
+      there was no(mockedS3Client).doesObjectExist("dest-proxy-bucket","path/to/thumbnail")
+      there was no(mockedS3Client).doesObjectExist("dest-proxy-bucket","path/to/vidproxy")
+      there was no(mockedS3Client).deleteObject("source-media-bucket","path/to/source-media.mxf")
+      there was no(mockedS3Client).deleteObject("source-proxy-bucket","path/to/thumbnail")
+      there was no(mockedS3Client).deleteObject("source-proxy-bucket", "path/to/vidproxy")
     }
   }
 }

--- a/test/TestFileMove/DeleteOriginalFileSpec.scala
+++ b/test/TestFileMove/DeleteOriginalFileSpec.scala
@@ -9,6 +9,7 @@ import org.specs2.mutable.Specification
 import services.FileMove.{DeleteOriginalFiles, GenericMoveActor}
 import akka.pattern.ask
 import com.amazonaws.services.s3.model.ObjectMetadata
+import play.api.Configuration
 import services.FileMove.GenericMoveActor.{MoveActorMessage, PerformStep, StepFailed, StepSucceeded}
 
 import scala.concurrent.Await
@@ -30,7 +31,7 @@ class DeleteOriginalFileSpec extends Specification with Mockito {
       mockedS3ClientMgr.getS3Client(any,any) returns mockedS3Client
       val mockedIndexer = mock[Indexer]
 
-      val actor = system.actorOf(Props(new DeleteOriginalFiles(mockedS3ClientMgr, mockedIndexer)))
+      val actor = system.actorOf(Props(new DeleteOriginalFiles(mockedS3ClientMgr, mockedIndexer, Configuration.empty)))
 
       val originalSourceEntry = mock[ArchiveEntry]
       originalSourceEntry.bucket returns "source-media-bucket"
@@ -83,7 +84,7 @@ class DeleteOriginalFileSpec extends Specification with Mockito {
       mockedS3ClientMgr.getS3Client(any,any) returns mockedS3Client
       val mockedIndexer = mock[Indexer]
 
-      val actor = system.actorOf(Props(new DeleteOriginalFiles(mockedS3ClientMgr, mockedIndexer)))
+      val actor = system.actorOf(Props(new DeleteOriginalFiles(mockedS3ClientMgr, mockedIndexer, Configuration.empty)))
 
       val originalSourceEntry = mock[ArchiveEntry]
       originalSourceEntry.bucket returns "source-media-bucket"
@@ -138,7 +139,7 @@ class DeleteOriginalFileSpec extends Specification with Mockito {
       mockedS3ClientMgr.getS3Client(any,any) returns mockedS3Client
       val mockedIndexer = mock[Indexer]
 
-      val actor = system.actorOf(Props(new DeleteOriginalFiles(mockedS3ClientMgr, mockedIndexer)))
+      val actor = system.actorOf(Props(new DeleteOriginalFiles(mockedS3ClientMgr, mockedIndexer, Configuration.empty)))
 
       val originalSourceEntry = mock[ArchiveEntry]
       originalSourceEntry.bucket returns "source-media-bucket"

--- a/test/TestFileMove/DeleteOriginalFileSpec.scala
+++ b/test/TestFileMove/DeleteOriginalFileSpec.scala
@@ -1,0 +1,68 @@
+package TestFileMove
+
+import akka.actor.Props
+import com.amazonaws.services.s3.AmazonS3
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer, ProxyLocation, ProxyType, StorageClass}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import services.FileMove.{DeleteOriginalFiles, GenericMoveActor}
+import akka.pattern.ask
+import com.amazonaws.services.s3.model.ObjectMetadata
+import services.FileMove.GenericMoveActor.{MoveActorMessage, PerformStep, StepSucceeded}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class DeleteOriginalFileSpec extends Specification with Mockito {
+  sequential
+  implicit val timeout:akka.util.Timeout = 30.seconds
+
+  "DeleteOriginalFiles!PerformStep" should {
+    "validate that the destination files exist then tell S3 to delete the original source and proxy files" in new AkkaTestkitSpecs2Support {
+      val mockedS3Client = mock[AmazonS3]
+      mockedS3Client.doesObjectExist(any,any) returns true
+      val fakeMetadata = mock[ObjectMetadata]
+      fakeMetadata.getContentLength returns 12345L
+      fakeMetadata.getContentMD5 returns "some-md5-here"
+      mockedS3Client.getObjectMetadata(any,any) returns fakeMetadata
+      val mockedS3ClientMgr = mock[S3ClientManager]
+      mockedS3ClientMgr.getS3Client(any,any) returns mockedS3Client
+      val mockedIndexer = mock[Indexer]
+
+      val actor = system.actorOf(Props(new DeleteOriginalFiles(mockedS3ClientMgr, mockedIndexer)))
+
+      val originalSourceEntry = mock[ArchiveEntry]
+      originalSourceEntry.bucket returns "source-media-bucket"
+      originalSourceEntry.path returns "path/to/source-media.mxf"
+
+      val sourceProxyList = Seq(
+        ProxyLocation("file-id-1","source-proxy-1",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/thumbnail",None,StorageClass.STANDARD),
+        ProxyLocation("file-id-2","source-proxy-2",ProxyType.VIDEO,"source-proxy-bucket","path/to/vidproxy",None,StorageClass.STANDARD)
+      )
+      val destProxyList = Seq(
+        ProxyLocation("file-id-3","dest-proxy-1",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/thumbnail",None,StorageClass.STANDARD),
+        ProxyLocation("file-id-4","dest-proxy-2",ProxyType.VIDEO,"dest-proxy-bucket","path/to/vidproxy",None,StorageClass.STANDARD)
+      )
+      val jobState = GenericMoveActor.FileMoveTransientData(
+        "source-file-id",
+        Some(originalSourceEntry),
+        Some("dest-file-id"),
+        Some(sourceProxyList),
+        Some(destProxyList),
+        "dest-bucket",
+        "dest-proxy-bucket"
+      )
+      val result = Await.result((actor ? PerformStep(jobState) ).mapTo[MoveActorMessage], 30 seconds)
+
+      val expectedFinalState = jobState.copy(sourceFileProxies = None)
+      result mustEqual StepSucceeded(expectedFinalState)
+      there was one(mockedS3Client).doesObjectExist("dest-bucket","path/to/source-media.mxf")
+      there was one(mockedS3Client).doesObjectExist("dest-proxy-bucket","path/to/thumbnail")
+      there was one(mockedS3Client).doesObjectExist("dest-proxy-bucket","path/to/vidproxy")
+      there was one(mockedS3Client).deleteObject("source-media-bucket","path/to/source-media.mxf")
+      there was one(mockedS3Client).deleteObject("source-proxy-bucket","path/to/thumbnail")
+      there was one(mockedS3Client).deleteObject("source-proxy-bucket", "path/to/vidproxy")
+    }
+  }
+}

--- a/test/TestFileMove/UpdateIndexRecordsSpec.scala
+++ b/test/TestFileMove/UpdateIndexRecordsSpec.scala
@@ -146,7 +146,7 @@ class UpdateIndexRecordsSpec extends Specification with Mockito {
 
       there was one(mockedIndexer).getById("fake-id")
       there was one(mockedIndexer).indexSingleItem(any,any,any)(any)
-      there was one(mockedIndexer).deleteById("fake-id")    //even though this is deleted here it's reconstituted by the rollback
+      there was no(mockedIndexer).deleteById("fake-id")    //even though this is deleted here it's reconstituted by the rollback
 
       //these are done in parallel so will all get triggered even in failure
       there was one(mockedProxyLocationDAO).saveProxy(destProxyList.head)

--- a/test/TestFileMove/UpdateIndexRecordsSpec.scala
+++ b/test/TestFileMove/UpdateIndexRecordsSpec.scala
@@ -50,7 +50,7 @@ class UpdateIndexRecordsSpec extends Specification with Mockito {
         ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
         ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
       )
-      val data = FileMoveTransientData("fake-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
+      val data = FileMoveTransientData("fake-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket", "dest-region")
 
       val actor = system.actorOf(Props(new UpdateIndexRecords(mockedIndexer,mockedProxyLocationDAO)))
       val result = Await.result(actor ? PerformStep(data), 30 seconds).asInstanceOf[MoveActorMessage]
@@ -94,7 +94,7 @@ class UpdateIndexRecordsSpec extends Specification with Mockito {
         ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
         ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
       )
-      val data = FileMoveTransientData("fake-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
+      val data = FileMoveTransientData("fake-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket","dest-region")
 
       val actor = system.actorOf(Props(new UpdateIndexRecords(mockedIndexer,mockedProxyLocationDAO)))
       val result = Await.result(actor ? PerformStep(data), 30 seconds).asInstanceOf[MoveActorMessage]
@@ -137,7 +137,7 @@ class UpdateIndexRecordsSpec extends Specification with Mockito {
         ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
         ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
       )
-      val data = FileMoveTransientData("fake-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
+      val data = FileMoveTransientData("fake-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket","dest-region")
 
       val actor = system.actorOf(Props(new UpdateIndexRecords(mockedIndexer,mockedProxyLocationDAO)))
       val result = Await.result(actor ? PerformStep(data), 30 seconds).asInstanceOf[MoveActorMessage]
@@ -183,7 +183,7 @@ class UpdateIndexRecordsSpec extends Specification with Mockito {
         ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
         ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
       )
-      val data = FileMoveTransientData("fake-id",Some(testItem),Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
+      val data = FileMoveTransientData("fake-id",Some(testItem),Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket","dest-region")
 
       val actor = system.actorOf(Props(new UpdateIndexRecords(mockedIndexer,mockedProxyLocationDAO)))
       val result = Await.result(actor ? RollbackStep(data), 30 seconds).asInstanceOf[MoveActorMessage]

--- a/test/TestFileMove/UpdateIndexRecordsSpec.scala
+++ b/test/TestFileMove/UpdateIndexRecordsSpec.scala
@@ -1,0 +1,64 @@
+package TestFileMove
+
+import java.time.ZonedDateTime
+
+import akka.actor.Props
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
+import com.sksamuel.elastic4s.http.HttpClient
+import com.theguardian.multimedia.archivehunter.common._
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import services.FileMove.GenericMoveActor.{FileMoveTransientData, MoveActorMessage, PerformStep, StepSucceeded}
+import services.FileMove.UpdateIndexRecords
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.Success
+
+class UpdateIndexRecordsSpec extends Specification with Mockito {
+  import akka.pattern.ask
+  implicit val timeout:akka.util.Timeout = 30 seconds
+
+  "UpdateIndexRecords!PerformStep" should {
+    "create a new index record for the copied file and also register copied proxies" in new AkkaTestkitSpecs2Support {
+      implicit val esClient = mock[HttpClient]
+      implicit val ddbClient = mock[DynamoClient]
+
+      val mockedIndexer = mock[Indexer]
+
+      val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
+        MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
+
+      mockedIndexer.getById(any)(any) returns Future(testItem)
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Success("some-id"))
+
+      val mockedProxyLocationDAO = mock[ProxyLocationDAO]
+
+      val sourceProxyList = Seq(
+        ProxyLocation("source-file-id","proxyid1",ProxyType.VIDEO,"source-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("source-file-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("source-file-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+
+      val destProxyList = Seq(
+        ProxyLocation("dest-file-id","proxyid1",ProxyType.VIDEO,"dest-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("dest-file-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("dest-file-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
+
+      val actor = system.actorOf(Props(new UpdateIndexRecords(mockedIndexer,mockedProxyLocationDAO)))
+      val result = Await.result(actor ? PerformStep(data), 30 seconds).asInstanceOf[MoveActorMessage]
+
+      result must beAnInstanceOf[StepSucceeded]
+
+      there was one(mockedIndexer).getById("fake-id")
+      there was one(mockedIndexer).indexSingleItem(any)
+      there was one(mockedIndexer).deleteById("fake-id")
+      there was one(mockedProxyLocationDAO).saveProxy(destProxyList.head)
+      there was one(mockedProxyLocationDAO).saveProxy(destProxyList(1))
+      there was one(mockedProxyLocationDAO).saveProxy(destProxyList(2))
+    }
+  }
+}

--- a/test/TestFileMove/UpdateIndexRecordsSpec.scala
+++ b/test/TestFileMove/UpdateIndexRecordsSpec.scala
@@ -4,11 +4,14 @@ import java.time.ZonedDateTime
 
 import akka.actor.Props
 import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
-import com.sksamuel.elastic4s.http.HttpClient
+import com.amazonaws.services.dynamodbv2.model.DeleteItemResult
+import com.gu.scanamo.error.{DynamoReadError, InvalidPropertiesError, PropertyReadError}
+import com.sksamuel.elastic4s.http.{ElasticError, HttpClient, RequestFailure}
 import com.theguardian.multimedia.archivehunter.common._
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
-import services.FileMove.GenericMoveActor.{FileMoveTransientData, MoveActorMessage, PerformStep, StepSucceeded}
+import scalaz.NonEmptyList
+import services.FileMove.GenericMoveActor.{FileMoveTransientData, MoveActorMessage, PerformStep, RollbackStep, StepFailed, StepSucceeded}
 import services.FileMove.UpdateIndexRecords
 
 import scala.concurrent.{Await, Future}
@@ -21,7 +24,7 @@ class UpdateIndexRecordsSpec extends Specification with Mockito {
   implicit val timeout:akka.util.Timeout = 30 seconds
 
   "UpdateIndexRecords!PerformStep" should {
-    "create a new index record for the copied file and also register copied proxies" in new AkkaTestkitSpecs2Support {
+    "create a new index record for the copied file, register copied proxies and delete the original record and original proxies" in new AkkaTestkitSpecs2Support {
       implicit val esClient = mock[HttpClient]
       implicit val ddbClient = mock[DynamoClient]
 
@@ -31,22 +34,23 @@ class UpdateIndexRecordsSpec extends Specification with Mockito {
         MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
 
       mockedIndexer.getById(any)(any) returns Future(testItem)
-      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Success("some-id"))
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("some-id"))
 
       val mockedProxyLocationDAO = mock[ProxyLocationDAO]
-
+      mockedProxyLocationDAO.saveProxy(any)(any) returns Future(None)
+      mockedProxyLocationDAO.deleteProxyRecord(any)(any) returns Future(Right(mock[DeleteItemResult]))
       val sourceProxyList = Seq(
-        ProxyLocation("source-file-id","proxyid1",ProxyType.VIDEO,"source-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
-        ProxyLocation("source-file-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
-        ProxyLocation("source-file-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid1",ProxyType.VIDEO,"source-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
       )
 
       val destProxyList = Seq(
-        ProxyLocation("dest-file-id","proxyid1",ProxyType.VIDEO,"dest-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
-        ProxyLocation("dest-file-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
-        ProxyLocation("dest-file-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid1",ProxyType.VIDEO,"dest-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
       )
-      val data = FileMoveTransientData("source-file-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
+      val data = FileMoveTransientData("fake-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
 
       val actor = system.actorOf(Props(new UpdateIndexRecords(mockedIndexer,mockedProxyLocationDAO)))
       val result = Await.result(actor ? PerformStep(data), 30 seconds).asInstanceOf[MoveActorMessage]
@@ -54,11 +58,150 @@ class UpdateIndexRecordsSpec extends Specification with Mockito {
       result must beAnInstanceOf[StepSucceeded]
 
       there was one(mockedIndexer).getById("fake-id")
-      there was one(mockedIndexer).indexSingleItem(any)
+      there was one(mockedIndexer).indexSingleItem(any,any,any)(any)
       there was one(mockedIndexer).deleteById("fake-id")
+      there was one(mockedProxyLocationDAO).saveProxy(destProxyList.head)
+      there was one(mockedProxyLocationDAO).saveProxy(destProxyList(1))
+      there was one(mockedProxyLocationDAO).saveProxy(destProxyList(2))
+      there was one(mockedProxyLocationDAO).deleteProxyRecord(sourceProxyList.head.proxyId)
+      there was one(mockedProxyLocationDAO).deleteProxyRecord(sourceProxyList(1).proxyId)
+      there was one(mockedProxyLocationDAO).deleteProxyRecord(sourceProxyList(2).proxyId)
+
+    }
+
+    "not delete the original record if the copy fails" in new AkkaTestkitSpecs2Support {
+      implicit val esClient = mock[HttpClient]
+      implicit val ddbClient = mock[DynamoClient]
+
+      val mockedIndexer = mock[Indexer]
+
+      val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
+        MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
+
+      mockedIndexer.getById(any)(any) returns Future(testItem)
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Left(RequestFailure(500,Some("kersplat"),Map(),mock[ElasticError])))
+
+      val mockedProxyLocationDAO = mock[ProxyLocationDAO]
+      mockedProxyLocationDAO.saveProxy(any)(any) returns Future(None)
+      val sourceProxyList = Seq(
+        ProxyLocation("fake-id","proxyid1",ProxyType.VIDEO,"source-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+
+      val destProxyList = Seq(
+        ProxyLocation("fake-id","proxyid1",ProxyType.VIDEO,"dest-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+      val data = FileMoveTransientData("fake-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
+
+      val actor = system.actorOf(Props(new UpdateIndexRecords(mockedIndexer,mockedProxyLocationDAO)))
+      val result = Await.result(actor ? PerformStep(data), 30 seconds).asInstanceOf[MoveActorMessage]
+
+      result must beAnInstanceOf[StepFailed]
+      result.asInstanceOf[StepFailed].err must contain("kersplat")
+
+      there was one(mockedIndexer).getById("fake-id")
+      there was one(mockedIndexer).indexSingleItem(any,any,any)(any)
+      there was no(mockedIndexer).deleteById("fake-id")
+
+      there was no(mockedProxyLocationDAO).saveProxy(destProxyList.head)
+      there was no(mockedProxyLocationDAO).saveProxy(destProxyList(1))
+      there was no(mockedProxyLocationDAO).saveProxy(destProxyList(2))
+    }
+
+    "return a failure if at least one of the proxies fails to copy" in new AkkaTestkitSpecs2Support {
+      implicit val esClient = mock[HttpClient]
+      implicit val ddbClient = mock[DynamoClient]
+
+      val mockedIndexer = mock[Indexer]
+
+      val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
+        MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
+
+      mockedIndexer.getById(any)(any) returns Future(testItem)
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("new-docid"))
+
+      val mockedProxyLocationDAO = mock[ProxyLocationDAO]
+      val pretendError = mock[DynamoReadError]
+      mockedProxyLocationDAO.saveProxy(any)(any) returns Future(None) thenReturns Future(Some(Left(pretendError)))
+      val sourceProxyList = Seq(
+        ProxyLocation("fake-id","proxyid1",ProxyType.VIDEO,"source-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+
+      val destProxyList = Seq(
+        ProxyLocation("fake-id","proxyid1",ProxyType.VIDEO,"dest-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+      val data = FileMoveTransientData("fake-id",None,Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
+
+      val actor = system.actorOf(Props(new UpdateIndexRecords(mockedIndexer,mockedProxyLocationDAO)))
+      val result = Await.result(actor ? PerformStep(data), 30 seconds).asInstanceOf[MoveActorMessage]
+
+      result must beAnInstanceOf[StepFailed]
+
+      there was one(mockedIndexer).getById("fake-id")
+      there was one(mockedIndexer).indexSingleItem(any,any,any)(any)
+      there was one(mockedIndexer).deleteById("fake-id")    //even though this is deleted here it's reconstituted by the rollback
+
+      //these are done in parallel so will all get triggered even in failure
       there was one(mockedProxyLocationDAO).saveProxy(destProxyList.head)
       there was one(mockedProxyLocationDAO).saveProxy(destProxyList(1))
       there was one(mockedProxyLocationDAO).saveProxy(destProxyList(2))
     }
   }
+
+  "UpdateIndexRecords!RollbackStep" should {
+    "copy the destination ArchiveEntry record back to the original ID and then delete the former destination" in new AkkaTestkitSpecs2Support {
+      implicit val esClient = mock[HttpClient]
+      implicit val ddbClient = mock[DynamoClient]
+
+      val mockedIndexer = mock[Indexer]
+
+      val testItem = ArchiveEntry("fake-id","sourcebucket","/path/to/file",None,None,1234L,ZonedDateTime.now(),"fake-etag",
+        MimeType.fromString("video/quicktime").right.get,true,StorageClass.STANDARD_IA,Seq(), false,None)
+
+      mockedIndexer.getById(any)(any) returns Future(testItem)
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("some-id"))
+
+      val mockedProxyLocationDAO = mock[ProxyLocationDAO]
+      mockedProxyLocationDAO.saveProxy(any)(any) returns Future(None)
+      mockedProxyLocationDAO.deleteProxyRecord(any)(any) returns Future(Right(mock[DeleteItemResult]))
+
+      val sourceProxyList = Seq(
+        ProxyLocation("fake-id","proxyid1",ProxyType.VIDEO,"source-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"source-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"source-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+
+      val destProxyList = Seq(
+        ProxyLocation("fake-id","proxyid1",ProxyType.VIDEO,"dest-proxy-bucket","path/to/proxy1",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid2",ProxyType.AUDIO,"dest-proxy-bucket","path/to/proxy2",None,StorageClass.STANDARD),
+        ProxyLocation("fake-id","proxyid3",ProxyType.THUMBNAIL,"dest-proxy-bucket","path/to/proxy3",None,StorageClass.STANDARD),
+      )
+      val data = FileMoveTransientData("fake-id",Some(testItem),Some("dest-file-id"),Some(sourceProxyList),Some(destProxyList),"dest-media-bucket","dest-proxy-bucket")
+
+      val actor = system.actorOf(Props(new UpdateIndexRecords(mockedIndexer,mockedProxyLocationDAO)))
+      val result = Await.result(actor ? RollbackStep(data), 30 seconds).asInstanceOf[MoveActorMessage]
+
+      result must beAnInstanceOf[StepSucceeded]
+
+      there was one(mockedIndexer).getById("dest-file-id")
+      there was one(mockedIndexer).indexSingleItem(testItem)
+      there was one(mockedIndexer).deleteById("dest-file-id")
+      there was one(mockedProxyLocationDAO).saveProxy(sourceProxyList.head)
+      there was one(mockedProxyLocationDAO).saveProxy(sourceProxyList(1))
+      there was one(mockedProxyLocationDAO).saveProxy(sourceProxyList(2))
+      there was one(mockedProxyLocationDAO).deleteProxyRecord(sourceProxyList.head.proxyId)
+      there was one(mockedProxyLocationDAO).deleteProxyRecord(sourceProxyList(1).proxyId)
+      there was one(mockedProxyLocationDAO).deleteProxyRecord(sourceProxyList(2).proxyId)
+
+    }
+  }
+
+
 }

--- a/test/TestFileMove/VerifySourceSpec.scala
+++ b/test/TestFileMove/VerifySourceSpec.scala
@@ -1,0 +1,282 @@
+package TestFileMove
+
+import java.time.ZonedDateTime
+import akka.actor.Props
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
+import com.sksamuel.elastic4s.http.HttpClient
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer, MimeType, ProxyLocation, ProxyLocationDAO, ProxyType, StorageClass}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import services.FileMove.VerifySource
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import akka.pattern.ask
+import com.gu.scanamo.error.DynamoReadError
+import com.theguardian.multimedia.archivehunter.common.cmn_models.{ItemNotFound, SystemError}
+import services.FileMove.GenericMoveActor._
+
+class VerifySourceSpec extends Specification with Mockito {
+  sequential
+  implicit val timeout:akka.util.Timeout = 5 seconds
+
+  "VerifySource!PerformStep" should {
+    "look up the source file ID and its proxies and populate this into the transient data record" in new AkkaTestkitSpecs2Support {
+      implicit val mockedHttpClient = mock[HttpClient]
+      implicit val mockedDynamoClient = mock[DynamoClient]
+      val mockedEntry = ArchiveEntry(
+        "some-entry-id",
+        "source-bucket",
+        "path/to/source_media.mxf",
+        None,
+        Some("mxf"),
+        1234L,
+        ZonedDateTime.now(),
+        "some-etag",
+        MimeType("application","x-mxf"),
+        proxied=true,
+        StorageClass.STANDARD_IA,
+        Seq(),
+        mediaMetadata=None,
+        beenDeleted=false
+      )
+
+      val mockedProxyData = List(
+        ProxyLocation(
+          "file-id-thumbnail",
+          "proxy-id-thumbnail",
+          ProxyType.THUMBNAIL,
+          "some-proxy-bucket",
+          "path/to/source_media_thumb.jpg",
+          None,
+          StorageClass.STANDARD
+        ),
+        ProxyLocation(
+          "file-id-proxy",
+          "proxy-id-proxy",
+          ProxyType.VIDEO,
+          "some-proxy-bucket",
+          "path/to/source_media_proxy.mp4",
+          None,
+          StorageClass.STANDARD
+        )
+      )
+
+      val mockedIndexer = mock[Indexer]
+      mockedIndexer.getByIdFull(any)(any) returns Future(Right(mockedEntry))
+
+      val mockedProxyDAO = mock[ProxyLocationDAO]
+      mockedProxyDAO.getAllProxiesFor(any)(any) returns Future(mockedProxyData.map(entry=>Right(entry)))
+
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      initialData.sourceFileProxies must beNone
+      initialData.entry must beNone
+
+      val actor = system.actorOf(Props(new VerifySource(mockedIndexer, mockedProxyDAO)))
+      val result = Await.result((actor ? PerformStep(initialData)).mapTo[MoveActorMessage], 5 seconds)
+
+      result must beAnInstanceOf[StepSucceeded]
+      val s = result.asInstanceOf[StepSucceeded]
+      s.updatedData.sourceFileProxies mustEqual Some(mockedProxyData)
+      s.updatedData.entry must beSome(mockedEntry)
+      there was one(mockedIndexer).getByIdFull("source-entry-id")
+      there was one(mockedProxyDAO).getAllProxiesFor("source-entry-id")
+    }
+
+    "return StepFailed if the item could not be found" in new AkkaTestkitSpecs2Support {
+      implicit val mockedHttpClient = mock[HttpClient]
+      implicit val mockedDynamoClient = mock[DynamoClient]
+
+
+      val mockedIndexer = mock[Indexer]
+      mockedIndexer.getByIdFull(any)(any) returns Future(Left(ItemNotFound("some-entry-id")))
+
+      val mockedProxyDAO = mock[ProxyLocationDAO]
+      mockedProxyDAO.getAllProxiesFor(any)(any) returns Future.failed(new RuntimeException("should not get here"))
+
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      initialData.sourceFileProxies must beNone
+      initialData.entry must beNone
+
+      val actor = system.actorOf(Props(new VerifySource(mockedIndexer, mockedProxyDAO)))
+      val result = Await.result((actor ? PerformStep(initialData)).mapTo[MoveActorMessage], 5 seconds)
+
+      result must beAnInstanceOf[StepFailed]
+      val s = result.asInstanceOf[StepFailed]
+
+      s.updatedData mustEqual initialData
+      s.err mustEqual "Requested file id source-entry-id does not exist"
+      there was one(mockedIndexer).getByIdFull("source-entry-id")
+      there was no(mockedProxyDAO).getAllProxiesFor("source-entry-id")
+    }
+
+    "return StepFailed if any other error occurs" in new AkkaTestkitSpecs2Support {
+      implicit val mockedHttpClient = mock[HttpClient]
+      implicit val mockedDynamoClient = mock[DynamoClient]
+
+
+      val mockedIndexer = mock[Indexer]
+      mockedIndexer.getByIdFull(any)(any) returns Future(Left(SystemError("some-entry-id",new RuntimeException("kersplat!!"))))
+
+      val mockedProxyDAO = mock[ProxyLocationDAO]
+      mockedProxyDAO.getAllProxiesFor(any)(any) returns Future.failed(new RuntimeException("should not get here"))
+
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      initialData.sourceFileProxies must beNone
+      initialData.entry must beNone
+
+      val actor = system.actorOf(Props(new VerifySource(mockedIndexer, mockedProxyDAO)))
+      val result = Await.result((actor ? PerformStep(initialData)).mapTo[MoveActorMessage], 5 seconds)
+
+      result must beAnInstanceOf[StepFailed]
+      val s = result.asInstanceOf[StepFailed]
+
+      s.updatedData mustEqual initialData
+      s.err.contains("kersplat!!") must beTrue
+      there was one(mockedIndexer).getByIdFull("source-entry-id")
+      there was no(mockedProxyDAO).getAllProxiesFor("source-entry-id")
+    }
+
+    "return StepFailed if any of the proxy lookups fail" in new AkkaTestkitSpecs2Support {
+      implicit val mockedHttpClient = mock[HttpClient]
+      implicit val mockedDynamoClient = mock[DynamoClient]
+      val mockedEntry = ArchiveEntry(
+        "some-entry-id",
+        "source-bucket",
+        "path/to/source_media.mxf",
+        None,
+        Some("mxf"),
+        1234L,
+        ZonedDateTime.now(),
+        "some-etag",
+        MimeType("application","x-mxf"),
+        proxied=true,
+        StorageClass.STANDARD_IA,
+        Seq(),
+        mediaMetadata=None,
+        beenDeleted=false
+      )
+
+      val mockedProxyData = List(
+        ProxyLocation(
+          "file-id-thumbnail",
+          "proxy-id-thumbnail",
+          ProxyType.THUMBNAIL,
+          "some-proxy-bucket",
+          "path/to/source_media_thumb.jpg",
+          None,
+          StorageClass.STANDARD
+        )
+      )
+      val mockedError = mock[DynamoReadError]
+      mockedError.toString returns "My hovercraft is full of eels"
+      val mockedIndexer = mock[Indexer]
+      mockedIndexer.getByIdFull(any)(any) returns Future(Right(mockedEntry))
+
+      val mockedProxyDAO = mock[ProxyLocationDAO]
+      mockedProxyDAO.getAllProxiesFor(any)(any) returns Future(mockedProxyData.map(entry=>Right(entry)) :+ Left(mockedError))
+
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      initialData.sourceFileProxies must beNone
+      initialData.entry must beNone
+
+      val actor = system.actorOf(Props(new VerifySource(mockedIndexer, mockedProxyDAO)))
+      val result = Await.result((actor ? PerformStep(initialData)).mapTo[MoveActorMessage], 5 seconds)
+
+      result must beAnInstanceOf[StepFailed]
+      val s = result.asInstanceOf[StepFailed]
+      s.err.contains("My hovercraft is full of eels") must beTrue
+
+      there was one(mockedIndexer).getByIdFull("source-entry-id")
+      there was one(mockedProxyDAO).getAllProxiesFor("source-entry-id")
+    }
+
+    "return StepFailed if the main lookup crashes" in new AkkaTestkitSpecs2Support {
+      implicit val mockedHttpClient = mock[HttpClient]
+      implicit val mockedDynamoClient = mock[DynamoClient]
+
+
+      val mockedIndexer = mock[Indexer]
+      mockedIndexer.getByIdFull(any)(any) returns Future.failed(new RuntimeException("Aiiiiiiee!"))
+
+      val mockedProxyDAO = mock[ProxyLocationDAO]
+      mockedProxyDAO.getAllProxiesFor(any)(any) returns Future.failed(new RuntimeException("should not get here"))
+
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      initialData.sourceFileProxies must beNone
+      initialData.entry must beNone
+
+      val actor = system.actorOf(Props(new VerifySource(mockedIndexer, mockedProxyDAO)))
+      val result = Await.result((actor ? PerformStep(initialData)).mapTo[MoveActorMessage], 5 seconds)
+
+      result must beAnInstanceOf[StepFailed]
+      val s = result.asInstanceOf[StepFailed]
+
+      s.updatedData mustEqual initialData
+      s.err.contains("Aiiiiiiee!") must beTrue
+      there was one(mockedIndexer).getByIdFull("source-entry-id")
+      there was no(mockedProxyDAO).getAllProxiesFor("source-entry-id")
+    }
+
+    "return StepFailed if the proxy lookup crashes" in new AkkaTestkitSpecs2Support {
+      implicit val mockedHttpClient = mock[HttpClient]
+      implicit val mockedDynamoClient = mock[DynamoClient]
+
+      val mockedEntry = ArchiveEntry(
+        "some-entry-id",
+        "source-bucket",
+        "path/to/source_media.mxf",
+        None,
+        Some("mxf"),
+        1234L,
+        ZonedDateTime.now(),
+        "some-etag",
+        MimeType("application","x-mxf"),
+        proxied=true,
+        StorageClass.STANDARD_IA,
+        Seq(),
+        mediaMetadata=None,
+        beenDeleted=false
+      )
+
+      val mockedIndexer = mock[Indexer]
+      mockedIndexer.getByIdFull(any)(any) returns Future(Right(mockedEntry))
+
+      val mockedProxyDAO = mock[ProxyLocationDAO]
+      mockedProxyDAO.getAllProxiesFor(any)(any) returns Future.failed(new RuntimeException("Aiiiiiiee!"))
+
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      initialData.sourceFileProxies must beNone
+      initialData.entry must beNone
+
+      val actor = system.actorOf(Props(new VerifySource(mockedIndexer, mockedProxyDAO)))
+      val result = Await.result((actor ? PerformStep(initialData)).mapTo[MoveActorMessage], 5 seconds)
+
+      result must beAnInstanceOf[StepFailed]
+      val s = result.asInstanceOf[StepFailed]
+
+      s.updatedData mustEqual initialData
+      s.err.contains("Aiiiiiiee!") must beTrue
+      there was one(mockedIndexer).getByIdFull("source-entry-id")
+      there was one(mockedProxyDAO).getAllProxiesFor("source-entry-id")
+    }
+  }
+
+  "VerifySource!RollbackStep" should {
+    "always return StepSuccessful" in new AkkaTestkitSpecs2Support {
+      implicit val mockedHttpClient = mock[HttpClient]
+      implicit val mockedDynamoClient = mock[DynamoClient]
+      val mockedIndexer = mock[Indexer]
+      val mockedProxyDAO = mock[ProxyLocationDAO]
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      initialData.sourceFileProxies must beNone
+      initialData.entry must beNone
+
+      val actor = system.actorOf(Props(new VerifySource(mockedIndexer, mockedProxyDAO)))
+      val result = Await.result((actor ? RollbackStep(initialData)).mapTo[MoveActorMessage], 5 seconds)
+
+      result must beAnInstanceOf[StepSucceeded]
+
+    }
+  }
+}

--- a/test/TestFileMove/VerifySourceSpec.scala
+++ b/test/TestFileMove/VerifySourceSpec.scala
@@ -68,7 +68,7 @@ class VerifySourceSpec extends Specification with Mockito {
       val mockedProxyDAO = mock[ProxyLocationDAO]
       mockedProxyDAO.getAllProxiesFor(any)(any) returns Future(mockedProxyData.map(entry=>Right(entry)))
 
-      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket","dest-region")
       initialData.sourceFileProxies must beNone
       initialData.entry must beNone
 
@@ -94,7 +94,7 @@ class VerifySourceSpec extends Specification with Mockito {
       val mockedProxyDAO = mock[ProxyLocationDAO]
       mockedProxyDAO.getAllProxiesFor(any)(any) returns Future.failed(new RuntimeException("should not get here"))
 
-      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket","dest-region")
       initialData.sourceFileProxies must beNone
       initialData.entry must beNone
 
@@ -121,7 +121,7 @@ class VerifySourceSpec extends Specification with Mockito {
       val mockedProxyDAO = mock[ProxyLocationDAO]
       mockedProxyDAO.getAllProxiesFor(any)(any) returns Future.failed(new RuntimeException("should not get here"))
 
-      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket","dest-region")
       initialData.sourceFileProxies must beNone
       initialData.entry must beNone
 
@@ -176,7 +176,7 @@ class VerifySourceSpec extends Specification with Mockito {
       val mockedProxyDAO = mock[ProxyLocationDAO]
       mockedProxyDAO.getAllProxiesFor(any)(any) returns Future(mockedProxyData.map(entry=>Right(entry)) :+ Left(mockedError))
 
-      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket","dest-region")
       initialData.sourceFileProxies must beNone
       initialData.entry must beNone
 
@@ -202,7 +202,7 @@ class VerifySourceSpec extends Specification with Mockito {
       val mockedProxyDAO = mock[ProxyLocationDAO]
       mockedProxyDAO.getAllProxiesFor(any)(any) returns Future.failed(new RuntimeException("should not get here"))
 
-      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket","dest-region")
       initialData.sourceFileProxies must beNone
       initialData.entry must beNone
 
@@ -245,7 +245,7 @@ class VerifySourceSpec extends Specification with Mockito {
       val mockedProxyDAO = mock[ProxyLocationDAO]
       mockedProxyDAO.getAllProxiesFor(any)(any) returns Future.failed(new RuntimeException("Aiiiiiiee!"))
 
-      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket","dest-region")
       initialData.sourceFileProxies must beNone
       initialData.entry must beNone
 
@@ -268,7 +268,7 @@ class VerifySourceSpec extends Specification with Mockito {
       implicit val mockedDynamoClient = mock[DynamoClient]
       val mockedIndexer = mock[Indexer]
       val mockedProxyDAO = mock[ProxyLocationDAO]
-      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket")
+      val initialData = FileMoveTransientData.initialise("source-entry-id","dest-bucket","dest-proxy-bucket","dest-region")
       initialData.sourceFileProxies must beNone
       initialData.entry must beNone
 


### PR DESCRIPTION
Complete implementation of file move, consisting of:
- establish all linked media
- copy to new location
- create new index and proxy records
- remove existing index and proxy records
- remove original files

with full tests for each stage and rollback in case of issues.

Also updates to LegacyProxyScanner to find more than one potential proxy.

Deploying this requires that the indexing configuration of ProxyLocationTable is updated, this involves:
- comment out the GSI definition and associated attributes from the Cloudformation template
- deploy the CloudFormation template to delete the old index
- comment back in the (updated) cloudformation template
- deploy again to build a new index with the correct settings

If the table has been set to on-demand mode then it needs to be set back to provisioned throughput mode for the cfn update to work.