### PR TITLE
Display Warning when a Bulk has Expired

### DIFF
--- a/app/controllers/ConfigController.scala
+++ b/app/controllers/ConfigController.scala
@@ -1,0 +1,29 @@
+package controllers
+
+import helpers.InjectableRefresher
+import io.circe.generic.auto._
+import io.circe.syntax._
+import javax.inject.{Inject, Singleton}
+import play.api.libs.circe.Circe
+import play.api.libs.ws.WSClient
+import play.api.mvc.{AbstractController, ControllerComponents}
+import play.api.{Configuration}
+import responses.{ObjectListResponse}
+
+@Singleton
+class ConfigController @Inject()(override val config:Configuration,
+                                 override val controllerComponents:ControllerComponents,
+                                 override val refresher:InjectableRefresher,
+                                 override val wsClient:WSClient)
+  extends AbstractController(controllerComponents) with Circe with PanDomainAuthActions {
+
+  /**
+    * Endpoint that returns configuration settings
+    * @return
+    */
+  def getConfig = APIAuthAction { request=>
+    val defaultExpiry = config.getOptional[Int]("archive.restoresExpireAfter").getOrElse(3)
+    val configSettings = List(defaultExpiry.toString)
+    Ok(ObjectListResponse("ok","config. settings",configSettings,configSettings.length).asJson)
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -81,6 +81,7 @@ PUT     /api/lightbox/:user/redoRestore/:fileId @controllers.LightboxController.
 PUT     /api/lightbox/:user/bulk/verifiy/:bulkId     @controllers.LightboxController.verifyBulkLightbox(user, bulkId)
 PUT     /api/lightbox/:user/bulk/redoRestore/:bulkId @controllers.LightboxController.redoBulk(user:String, bulkId:String)
 GET     /api/lightbox/bulk/appDownload/:bulkId  @controllers.LightboxController.bulkDownloadInApp(bulkId)
+GET     /api/config @controllers.ConfigController.getConfig
 
 GET     /api/download/:fileId           @controllers.LightboxController.getDownloadLink(fileId)
 
@@ -102,4 +103,3 @@ GET     /api/bulk/:tokenValue/get/:fileId   @controllers.BulkDownloadsController
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)
 GET     /*tail                      @controllers.Application.index(tail)
-

--- a/frontend/app/Lightbox/BulkSelectionsScroll.jsx
+++ b/frontend/app/Lightbox/BulkSelectionsScroll.jsx
@@ -108,7 +108,7 @@ class BulkSelectionsScroll extends React.Component {
                             evt.stopPropagation();
                             this.props.onDeleteClicked(entry.id);
                         }}/>
-                        <span data-tip="Some or all of the media may have returned to the deep archive and may be unavailable."><ReactTooltip/><FontAwesomeIcon icon="exclamation-triangle" style={{marginRight: "6px" ,color: "red", float: "left", display: this.showExpiryWarning(entry.addedAt)}} /></span>
+                        <span data-tip="Some or all of the media may have returned to the deep archive and therefore be unavailable."><ReactTooltip/><FontAwesomeIcon icon="exclamation-triangle" style={{marginRight: "6px" ,color: "red", float: "left", display: this.showExpiryWarning(entry.addedAt)}} /></span>
                         <p className="entry-date black">Added <TimestampFormatter relative={true} value={entry.addedAt}/></p>
 
 

--- a/frontend/app/Lightbox/BulkSelectionsScroll.jsx
+++ b/frontend/app/Lightbox/BulkSelectionsScroll.jsx
@@ -4,6 +4,7 @@ import TimestampFormatter from "../common/TimestampFormatter.jsx";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import axios from 'axios';
 import LoadingThrobber from "../common/LoadingThrobber.jsx";
+import ReactTooltip from "react-tooltip";
 
 class BulkSelectionsScroll extends React.Component {
     static propTypes = {
@@ -12,7 +13,8 @@ class BulkSelectionsScroll extends React.Component {
         onSelected: PropTypes.func,
         onDeleteClicked: PropTypes.func,
         forUser: PropTypes.string.isRequired,
-        isAdmin: PropTypes.boolean
+        isAdmin: PropTypes.boolean,
+        expiryDays: PropTypes.string.isRequired,
     };
 
     static nameExtractor = /^([^:]+):(.*)$/;
@@ -62,6 +64,17 @@ class BulkSelectionsScroll extends React.Component {
         })
     }
 
+    showExpiryWarning(addedAt) {
+        let date = Date.now()
+        let addedTime = Date.parse(addedAt)
+        let setting = this.props.expiryDays * 86400000
+        if ((date - addedTime) > setting) {
+            return "inline"
+        } else {
+            return "none"
+        }
+    }
+
     render(){
         return <div className="bulk-selections-scroll">
             {
@@ -95,6 +108,7 @@ class BulkSelectionsScroll extends React.Component {
                             evt.stopPropagation();
                             this.props.onDeleteClicked(entry.id);
                         }}/>
+                        <span data-tip="Some or all of the media may have returned to the deep archive and may be unavailable."><ReactTooltip/><FontAwesomeIcon icon="exclamation-triangle" style={{marginRight: "6px" ,color: "red", float: "left", display: this.showExpiryWarning(entry.addedAt)}} /></span>
                         <p className="entry-date black">Added <TimestampFormatter relative={true} value={entry.addedAt}/></p>
 
 

--- a/frontend/app/Lightbox/MyLightbox.jsx
+++ b/frontend/app/Lightbox/MyLightbox.jsx
@@ -28,7 +28,8 @@ class MyLightbox extends CommonSearchView {
             selectedUser: "my",
             showingArchiveSpinner: false,
             selectedRestoreStatus: null,
-            pageSize: 500
+            pageSize: 500,
+            expiryDays: 3
         };
 
         this.checkArchiveStatus = this.checkArchiveStatus.bind(this);
@@ -44,7 +45,8 @@ class MyLightbox extends CommonSearchView {
         const summaryRequest = axios.get("/api/search/myLightBox?user=" + this.state.selectedUser + "&size=" + this.state.pageSize);
         const loginDetailsRequest = axios.get("/api/loginStatus");
         const bulkSelectionsRequest = axios.get("/api/lightbox/" + this.state.selectedUser+"/bulks");
-        return Promise.all([detailsRequest, summaryRequest, loginDetailsRequest, bulkSelectionsRequest]);
+        const configRequest = axios.get("/api/config");
+        return Promise.all([detailsRequest, summaryRequest, loginDetailsRequest, bulkSelectionsRequest, configRequest]);
     }
 
     userChanged(evt){
@@ -57,6 +59,7 @@ class MyLightbox extends CommonSearchView {
             const summaryResult = results[1];   //this is an array
             const loginDetailsResult = results[2];  //this is a map of key->value
             const bulkSelectionsResult = results[3];    //this is an object with "entries" and "entryCount" fields
+            const configResult = results[4];
 
             this.setState({loading: false,
                 lastError: null,
@@ -67,7 +70,8 @@ class MyLightbox extends CommonSearchView {
                 ),
                 userDetails: loginDetailsResult.data,
                 bulkSelections: bulkSelectionsResult.data.entries,
-                bulkSelectionsCount: bulkSelectionsResult.data.entryCount
+                bulkSelectionsCount: bulkSelectionsResult.data.entryCount,
+                expiryDays: configResult.data.entries[0]
             })
         }).catch(err=>{
             console.error(err);
@@ -255,6 +259,7 @@ class MyLightbox extends CommonSearchView {
                                   currentSelection={this.state.bulkSelectionSelected}
                                   forUser={this.state.selectedUser}
                                   isAdmin={this.state.userDetails && this.state.userDetails.isAdmin}
+                                  expiryDays={this.state.expiryDays}
             />
             <BulkSelectionStats user={this.state.selectedUser} bulkId={this.state.bulkSelectionSelected}/>
 


### PR DESCRIPTION
Display a warning icon when a bulk was restored more than the number of days set in the server configuration as the expiry time in the past. When the user moves their mouse over the icon, pop-up text is displayed which explains why the icon is there.

Includes a new endpoint for returning information about the server configuration. It currently only contains the expiry time in days.

![image](https://user-images.githubusercontent.com/10620802/71362260-7c0c0380-258d-11ea-8fe0-1c3ecdd9ab3e.png)

Tested on a machine running macOS 10.12.6.

@fredex42 