### PR TITLE
HMAC auth for entry endpoint

### DIFF
--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -42,7 +42,7 @@ with PanDomainAuthActions {
   private val esClient = esClientManager.getClient()
   import com.sksamuel.elastic4s.http.ElasticDsl._
 
-  def getEntry(fileId:String) = APIAuthAction.async {
+  def getEntry(fileId:String) = HMACAuthAction.async {
     esClient.execute {
       search(indexName) query termQuery("id",fileId)
     }.map({

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -66,6 +66,7 @@
     <logger name="controllers.BulkDownloadsController" level="DEBUG"/>
 
     <logger name="com.gu.pandomainauth.action.AuthActions" level="INFO"/>
+    <logger name="com.gu" level="DEBUG"/>
 
     <logger name="helpers.DDBSink" level="INFO"/>
     <logger name="helpers.S3ToProxyLocationFlow" level="INFO"/>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Warn
 
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/testscripts/hmac-client.py
+++ b/testscripts/hmac-client.py
@@ -1,25 +1,43 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import hashlib
 import hmac
 from optparse import OptionParser
-from datetime import datetime
+from datetime import datetime, timedelta
 import base64
 from email.utils import formatdate
 import requests
 from time import mktime
-from urlparse import urlparse
+from urllib.parse import urlparse
 from pprint import pprint
 import json
 
+#uncomment this block to get request-level debug output
+# import logging
+#
+# try:
+#     import http.client as http_client
+# except ImportError:
+#     # Python 2
+#     import httplib as http_client
+# http_client.HTTPConnection.debuglevel = 1
+#
+# # You must initialize logging, otherwise you'll not see debug output.
+# logging.basicConfig()
+# logging.getLogger().setLevel(logging.DEBUG)
+# requests_log = logging.getLogger("requests.packages.urllib3")
+# requests_log.setLevel(logging.DEBUG)
+# requests_log.propagate = True
+
 def get_token(uri, secret):
-    httpdate = formatdate(timeval=mktime(datetime.now().timetuple()),localtime=False,usegmt=True)
+    t = datetime.now()
+    httpdate = formatdate(timeval=mktime(t.timetuple()),localtime=False,usegmt=True)
     url_parts = urlparse(uri)
 
     string_to_sign = "{0}\n{1}".format(httpdate, url_parts.path)
-    print "string_to_sign: " + string_to_sign
-    hm = hmac.new(secret, string_to_sign,hashlib.sha256)
-    return "HMAC {0}".format(base64.b64encode(hm.digest())), httpdate
+    print("string_to_sign: " + string_to_sign)
+    hm = hmac.digest(secret.encode("UTF-8"), msg=string_to_sign.encode("UTF-8"), digest=hashlib.sha256)
+    return "HMAC {0}".format(base64.b64encode(hm).decode("UTF-8")), httpdate
 
 #START MAIN
 parser = OptionParser()
@@ -37,7 +55,7 @@ parser.add_option("--raw",dest="raw",help="Call the provided url and display the
 (options, args) = parser.parse_args()
 
 if options.secret is None:
-    print "You must supply the password in --secret"
+    print("You must supply the password in --secret")
     exit(1)
 
 if options.remove:
@@ -49,16 +67,16 @@ elif options.raw:
 else:
     uri = "https://{host}/api/proxy".format(host=options.host)
 
-print "uri is " + uri
+print("uri is " + uri)
 authtoken, httpdate = get_token(uri, options.secret)
-print authtoken
+print(authtoken)
 
 headers = {
         'X-Gu-Tools-HMAC-Date': httpdate,
         'X-Gu-Tools-HMAC-Token': authtoken,
 }
 
-print headers
+print(headers)
 extra_kwargs = {}
 if options.sslnoverify:
     extra_kwargs['verify'] = False
@@ -80,9 +98,9 @@ else:
     headers['Content-Type'] = "application/json"
     response = requests.post(uri, data=requestbody, headers=headers, **extra_kwargs)
 
-print "Server returned {0}".format(response.status_code)
+print("Server returned {0}".format(response.status_code))
 pprint(response.headers)
 if response.status_code==200:
     pprint(response.json())
 else:
-    print response.text
+    print(response.text)


### PR DESCRIPTION
## What does this change?
Allows server-server access to the /api/entry/{id} endpoint. Required for validation of deliverable IDs from pluto-deliverables.
Also update the test script to python3

## How to test
Use the test script to hit /api/entry/{id} where {id} is any valid archivehunter id. With the correct shared key you should get a json response, without you should get 403.
