### PR TITLE
Fix/transcode functions

### DIFF
--- a/frontend/app/ScanTargets/ScanTargetEdit.jsx
+++ b/frontend/app/ScanTargets/ScanTargetEdit.jsx
@@ -138,7 +138,7 @@ class ScanTargetEdit extends React.Component {
             ()=>axios.post("/api/scanTarget/" + encodeURIComponent(targetId) + "/" + "checkTranscoder")
             .then(result=>{
                 console.log("Config validation has been started with job ID " + result.data.entity);
-                this.setState({loading: false, lastError: null, currentActionCaption: null}, );
+                this.setState({loading: false}, );
             }).catch(err=>{
                 console.error(err);
                 this.setState({loading: false, lastError: err, lastErrorSeverity: "error", showingAlert: "true", currentActionCaption: null});
@@ -154,7 +154,7 @@ class ScanTargetEdit extends React.Component {
             }, ()=>axios.post("/api/scanTarget/" + encodeURIComponent(targetId) + "/" + "createPipelines?force=true")
             .then(result=>{
                 console.log("Transcode setup has been started with job ID " + result.data.entity);
-                this.setState({loading: false, lastError: null, currentActionCaption: null});
+                this.setState({loading: false});
             }).catch(err=>{
                 console.error(err);
                 this.setState({loading: false, lastError: err, currentActionCaption: null});


### PR DESCRIPTION
## What does this change?
Makes the "validate transcode config" and "perform transcode setup" functions in Scan Targets Admin work again. Replace the existing non-working icons with MUI IconButtons

## How to test
Go to any Scan Target in the CODE system.  Note the new buttons.  Clicking "Validate" should pop up a message, refreshing the page after a minute or so should update the "last checked" time to "a few seconds ago" and clicking on the "details" link should show the pipeline that was found.

Clicking on "(redo) transcode setup" will create a new pipeline linking the relevant media bucket to the relevant proxy bucket.  This can be verified in Elastic Transcoder console in the AWS console

## How can we measure success?
functionality works again

## Have we considered potential risks?
No risks

## Images
<img width="1148" alt="Screen Shot 2021-02-23 at 12 10 41" src="https://user-images.githubusercontent.com/12482441/108841870-54209180-75d0-11eb-9da0-c9151565d39b.png">

