### PR TITLE
Proxy relink improvements

### DIFF
--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -47,7 +47,10 @@ Parameters:
     - t3.nano
     - t3.micro
     - t3.small
-    Default: t3.nano
+    - t3.medium
+    - t3.large
+    - t3.xlarge
+    Default: t3.medium
   KeyPair:
     Type: AWS::EC2::KeyPair::KeyName
     Description: Root access keypair
@@ -1072,6 +1075,7 @@ Resources:
               bind-hostname = "0.0.0.0"
               port = 8558
               bind-port = 8558
+              route-providers-read-only = false
             }
 
             cluster {

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocation.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocation.scala
@@ -89,19 +89,21 @@ object ProxyLocation extends DocId {
           MimeType("application", "octet-stream")
       }
 
-      val storageClass = Option(meta.getStorageClass) match {
-        case Some(sc) => sc
-        case None =>
-          logger.warn(s"s3://$proxyBucket/$key has no storage class! Assuming STANDARD.")
-          "STANDARD"
-      }
       val pt = proxyType match {
         case None =>
           proxyTypeForMime(mimeType) match {
             case Success(pt) => pt
             case Failure(err) =>
               logger.error(s"Could not determine proxy type for s3://$proxyBucket/$key: ${err.toString}")
-              ProxyType.UNKNOWN
+              if(key.endsWith(".mp4")) { //go through the obvious file extensions, as a fallback
+                ProxyType.VIDEO
+              } else if(key.endsWith(".mp3")) {
+                ProxyType.AUDIO
+              } else if(key.endsWith(".jpg") || key.endsWith(".jpeg")) {
+                ProxyType.THUMBNAIL
+              } else {
+                ProxyType.UNKNOWN
+              }
           }
         case Some(value) => value
       }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -132,6 +132,10 @@ akka.cluster {
 
 akka.io.dns.resolver = async-dns
 
+akka.management {
+  http.route-providers-read-only = false  //this is needed for the auto-downing lambda to work
+}
+
 akka.discovery {
   method = akka-dns
   # Set the following in your application.conf if you want to use this discovery mechanism:

--- a/conf/routes
+++ b/conf/routes
@@ -35,7 +35,7 @@ GET     /api/searchpath                 @controllers.SearchController.searchByFi
 GET     /api/search/proxyStats          @controllers.SearchController.getProxyFacets
 
 GET     /api/proxy/searchForFile            @controllers.ProxiesController.searchFor(id:String)
-GET     /api/proxy/:id/associate            @controllers.ProxiesController.associate(fileId:Option[String],id)
+PUT     /api/proxy/:id/associate            @controllers.ProxiesController.associate(fileId:Option[String],id)
 GET     /api/proxy/:id/playable             @controllers.ProxiesController.getPlayable(id, proxyType:Option[String])
 GET     /api/proxy/:id/all                  @controllers.ProxiesController.getAllProxyRefs(id)
 GET     /api/proxy/:id                      @controllers.ProxiesController.proxyForId(id, proxyType:Option[String])

--- a/frontend/app/Entry/EntryDetails.jsx
+++ b/frontend/app/Entry/EntryDetails.jsx
@@ -35,7 +35,8 @@ class EntryDetails extends React.Component {
         postLightboxInsert: PropTypes.object,
         postJobsInsert: PropTypes.object,
         tableRowsInsert: PropTypes.object,
-        onError: PropTypes.func.isRequired
+        onError: PropTypes.func.isRequired,
+        openClicked: PropTypes.func
     };
 
     constructor(props){
@@ -98,10 +99,13 @@ class EntryDetails extends React.Component {
         }
         return <div className={this.props.classes.entryDetails}>
                 <MediaPreview itemId={this.props.entry.id}
+                              itemName={this.props.entry.path}
                               fileExtension={this.props.entry.file_extension}
                               mimeType={this.props.entry.mimeType}
                               autoPlay={this.props.autoPlay}
+                              relinkedCb={this.props.lightboxedCb}  //use the lightboxCb to indicate that the item needs reloading
                               triggeredProxyGeneration={this.proxyGenerationWasTriggered}
+                              itemName={this.props.entry.path}
                 />
             <div className="entry-details-insert">{ this.props.preLightboxInsert ? this.props.preLightboxInsert : "" }</div>
             <div className={this.props.classes.entryDetailsLightboxes}>
@@ -122,10 +126,10 @@ class EntryDetails extends React.Component {
             }
             <div className="entry-details-insert">{ this.props.postJobsInsert ? this.props.postJobsInsert : "" }</div>
             <div className="entry-details-insert">
-                <MetadataTable entry={this.props.entry}/>
+                <MetadataTable entry={this.props.entry} openClicked={this.props.openClicked}/>
             </div>
             <div className={this.props.classes.centered} style={{marginTop: "1em"}}>
-                <Button variant="outlined" onClick={this.triggerAnalyse}>Refresh metadata</Button>
+                <Button variant="outlined" onClick={this.triggerAnalyse}>Re-analyse metadata</Button>
             </div>
         </div>
     }

--- a/frontend/app/Entry/MediaPlayer.tsx
+++ b/frontend/app/Entry/MediaPlayer.tsx
@@ -79,27 +79,53 @@ const MediaPlayer:React.FC<MediaPlayerProps> = (props) => {
         loadPlayableData();
     }, [props.entryId]);
 
-    return previewData ? <>
-        {
-            previewData?.mimeType.major==="video" ?
-                <div className={classes.videoPreview}>
-                    <video className={classes.videoPreview} src={previewData.uri} controls={true} autoPlay={props.autoPlay}/>
-                </div> :
-                null
-        }
-        {
-            previewData?.mimeType.major==="audio" ?
-                <div className={classes.audioPlayer}>
-                    <audio src={previewData.uri} controls={true} autoPlay={props.autoPlay} />
-                </div> :
-                null
-        }
-        {
-            previewData?.mimeType.major==="image" ?
-                <img src={previewData.uri} alt="Thumbnail" className={classes.thumbnailPreview}/> :
-                null
-        }
+    if(previewData?.mimeType.major!=="application") {
+        return previewData ? <>
+            {
+                previewData?.mimeType.major === "video" ?
+                    <div className={classes.videoPreview}>
+                        <video className={classes.videoPreview} src={previewData.uri} controls={true}
+                               autoPlay={props.autoPlay}/>
+                    </div> :
+                    null
+            }
+            {
+                previewData?.mimeType.major === "audio" ?
+                    <div className={classes.audioPlayer}>
+                        <audio src={previewData.uri} controls={true} autoPlay={props.autoPlay}/>
+                    </div> :
+                    null
+            }
+            {
+                previewData?.mimeType.major === "image" ?
+                    <img src={previewData.uri} alt="Thumbnail" className={classes.thumbnailPreview}/> :
+                    null
+            }
         </> : <span className={classes.errorText}>No preview data</span>
+    } else {    //if we don't have a valid MIME type fall back to using the requested playable type to determine the player
+        return <>
+            {
+                props.playableType == "VIDEO" ?
+                    <div className={classes.videoPreview}>
+                        <video className={classes.videoPreview} src={previewData.uri} controls={true}
+                               autoPlay={props.autoPlay}/>
+                    </div> :
+                    null
+            }
+            {
+                props.playableType == "AUDIO"  ?
+                    <div className={classes.audioPlayer}>
+                        <audio src={previewData.uri} controls={true} autoPlay={props.autoPlay}/>
+                    </div> :
+                    null
+            }
+            {
+                props.playableType=="THUMBNAIL" || props.playableType=="POSTER" ?
+                    <img src={previewData.uri} alt="Thumbnail" className={classes.thumbnailPreview}/> :
+                    null
+            }
+        </>
+    }
 }
 
 export default MediaPlayer;

--- a/frontend/app/Entry/ReconnectDialog.tsx
+++ b/frontend/app/Entry/ReconnectDialog.tsx
@@ -44,7 +44,7 @@ const ReconnectDialog:React.FC<ReconnectDialogProps> = (props)=>{
         try {
             setInProgress(true);
             setActionMessage("Saving...");
-            await axios.put(`/api/proxy/${encodeURIComponent(props.itemId)}/associate?id=${encodeURIComponent(selectedProxyId)}`);
+            await axios.put(`/api/proxy/${encodeURIComponent(selectedProxyId)}/associate?fileId=${encodeURIComponent(props.itemId)}`);
             setInProgress(false);
             setActionMessage("Proxy associated");
             props.onDialogClose(true);
@@ -77,10 +77,10 @@ const ReconnectDialog:React.FC<ReconnectDialogProps> = (props)=>{
                                 <Typography className={classes.selectorText}>{entry.bucketName}</Typography>
                             </Grid>
                             <Grid item>
-                                <Typography className={classes.selectorText}>{entry.bucketPath}</Typography>
+                                <Typography className={classes.selectorText}>{entry.region}</Typography>
                             </Grid>
                             <Grid item>
-                                <Typography className={classes.selectorText}>{entry.region}</Typography>
+                                <Typography className={classes.selectorText}>{entry.bucketPath}</Typography>
                             </Grid>
                         </Grid>
                     </li>)

--- a/frontend/app/Entry/ReconnectDialog.tsx
+++ b/frontend/app/Entry/ReconnectDialog.tsx
@@ -1,0 +1,110 @@
+import React, {useEffect, useState} from "react";
+import {ProxyLocation} from "../types";
+import {
+    Button, CircularProgress,
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    Divider,
+    Grid,
+    makeStyles,
+    Radio,
+    Typography
+} from "@material-ui/core";
+import axios from "axios";
+import {formatError} from "../common/ErrorViewComponent";
+
+interface ReconnectDialogProps {
+    potentialProxies: ProxyLocation[];
+    itemName: string;
+    itemId: string;
+    onDialogClose: (saved:boolean)=>void;
+    onError?: (err:string)=>void;
+}
+
+const useStyles = makeStyles({
+    mainlist: {
+        listStyle: "none",
+        padding: 0
+    },
+    selectorText: {
+        paddingTop: "0.5em"
+    },
+    spinner: {width: "26px", height: "26px", display:"inline", marginRight: "0.4em"}
+});
+
+const ReconnectDialog:React.FC<ReconnectDialogProps> = (props)=>{
+    const [selectedProxyId, setSelectedProxyId] = useState<string>(props.potentialProxies.length>0 ? props.potentialProxies[0].proxyId : "");
+    const [actionMessage, setActionMessage] = useState<string|undefined>(undefined);
+    const [inProgress, setInProgress] = useState(false);
+
+    const classes = useStyles();
+
+    const saveSelection = async ()=> {
+        try {
+            setInProgress(true);
+            setActionMessage("Saving...");
+            await axios.put(`/api/proxy/${encodeURIComponent(props.itemId)}/associate?id=${encodeURIComponent(selectedProxyId)}`);
+            setInProgress(false);
+            setActionMessage("Proxy associated");
+            props.onDialogClose(true);
+        } catch(err) {
+            setInProgress(false);
+            setActionMessage(formatError(err, true));
+            if(props.onError) props.onError(formatError(err, false));
+        }
+    }
+
+    return <Dialog open={true} onClose={props.onDialogClose} aria-labelledby="reconnect-title">
+        <DialogTitle id="reconnect-title">
+            Reconnect {props.itemName}
+        </DialogTitle>
+        <DialogContent dividers>
+            <ul className={classes.mainlist}>
+                {
+                    props.potentialProxies.map((entry,idx)=><li className={classes.mainlist} key={idx}>
+                        <Grid container direction="row" spacing={3}>
+                            <Grid item>
+                                <Radio
+                                    checked={selectedProxyId===entry.proxyId}
+                                    onChange={()=>setSelectedProxyId(entry.proxyId)}
+                                />
+                            </Grid>
+                            <Grid item>
+                                <Typography className={classes.selectorText}>{entry.proxyType}</Typography>
+                            </Grid>
+                            <Grid item>
+                                <Typography className={classes.selectorText}>{entry.bucketName}</Typography>
+                            </Grid>
+                            <Grid item>
+                                <Typography className={classes.selectorText}>{entry.bucketPath}</Typography>
+                            </Grid>
+                            <Grid item>
+                                <Typography className={classes.selectorText}>{entry.region}</Typography>
+                            </Grid>
+                        </Grid>
+                    </li>)
+                }
+            </ul>
+            <Divider/>
+            <Grid container direction="row" justify="space-between">
+                <Grid item>
+                    <Button variant="contained" onClick={()=>props.onDialogClose(false)} disabled={inProgress}>Cancel</Button>
+                </Grid>
+                <Grid item>
+                        <>
+                            {inProgress ? <CircularProgress className={classes.spinner}/> : null}
+                            {actionMessage ? <Typography>{actionMessage}</Typography>: null}
+                        </>
+                </Grid>
+                <Grid item>
+                    <Button variant="contained" onClick={saveSelection} disabled={inProgress}>Link selected</Button>
+                </Grid>
+            </Grid>
+        </DialogContent>
+    </Dialog>
+}
+
+export default ReconnectDialog;
+
+

--- a/frontend/app/Entry/details/MetadataTable.tsx
+++ b/frontend/app/Entry/details/MetadataTable.tsx
@@ -2,14 +2,16 @@ import React, {useState, useEffect} from "react";
 import MediaDurationComponent from "../../common/MediaDurationComponent";
 import FileSizeView from "../FileSizeView";
 import {ArchiveEntry} from "../../types";
-import {makeStyles} from "@material-ui/core";
+import {IconButton, makeStyles} from "@material-ui/core";
 import clsx from "clsx";
 import PathDisplayComponent from "../../browse/PathDisplayComponent";
 import {FileInfo, extractFileInfo} from "../../common/Fileinfo";
+import {Launch} from "@material-ui/icons";
 
 interface MetadataTableProps {
     entry: ArchiveEntry;
     tableRowsInsert?: React.ReactFragment[];
+    openClicked?: (itemId:string)=>void;
 }
 
 const useStyles = makeStyles({
@@ -68,7 +70,16 @@ const MetadataTable:React.FC<MetadataTableProps> = (props) => {
 
     return <table className={classes.metadataTable}>
         <tbody>
-
+        {
+            props.openClicked ? <tr>
+                <td className={clsx(classes.metadataHeading, classes.spaceBelow)}>Open</td>
+                <td className={classes.metadataEntry}>
+                    <IconButton onClick={()=>props.openClicked ? props.openClicked(props.entry.id) : null}>
+                        <Launch/>
+                    </IconButton>
+                </td>
+            </tr> : null
+        }
         <tr>
             <td className={clsx(classes.metadataHeading, classes.spaceBelow)}>Name</td>
             <td className={classes.metadataEntry}>{fileinfo.filename}</td>

--- a/frontend/app/ItemView/ItemView.tsx
+++ b/frontend/app/ItemView/ItemView.tsx
@@ -150,6 +150,7 @@ const ItemView:React.FC<RouteComponentProps<ItemViewParams>> = (props) => {
         <div className={classes.previewArea}>
             {entry ?
                 <MediaPreview itemId={entry.id}
+                              itemName={entry.path}
                               mimeType={entry.mimeType}
                               fileExtension={entry.file_extension ?? ".dat"}
                               triggeredProxyGeneration={proxyGenerationWasTriggered}

--- a/frontend/app/browse/NewBrowseComponent.tsx
+++ b/frontend/app/browse/NewBrowseComponent.tsx
@@ -294,6 +294,7 @@ const NewBrowseComponent:React.FC<RouteComponentProps> = (props) => {
                               setLastError(message);
                               setShowingAlert(true);
                           }}
+                          openClicked={(itemId:string)=>props.history.push(`/item/${encodeURIComponent(itemId)}`)}
                 //when the user adds to lightbox we record it here. This state var is bound to the NewSearchComponent
                 //which will then re-load data for the given entry (after a short delay)
                           lightboxedCb={(entryId:string)=>setNewlyLightboxed((prevState) => prevState.concat(entryId))}

--- a/frontend/app/search/NewBasicSearch.tsx
+++ b/frontend/app/search/NewBasicSearch.tsx
@@ -107,6 +107,7 @@ const NewBasicSearch:React.FC<RouteComponentProps> = (props) => {
                                   setLastError(message);
                                   setShowingAlert(true);
                               }}
+                              openClicked={(itemId:string)=>props.history.push(`/item/${encodeURIComponent(itemId)}`)}
                               //when the user adds to lightbox we record it here. This state var is bound to the NewSearchComponent
                                 //which will then re-load data for the given entry (after a short delay)
                               lightboxedCb={(entryId:string)=>setNewlyLightboxedList((prevState) => prevState.concat(entryId))}


### PR DESCRIPTION
## What does this change?
Bundle of improvements relating to proxy linkage

- when scanning for proxies, ignore xml metadata files
- fallback to match on expected file extensions if proxy does not have a MIME type registered
- ability to manually reconnect a proxy from the frontend
- bugfix for "reconnect proxies" action in Scan Targets not working
- bugfix for autodowning lambda not working (tightened permissions on akka management needed explicit setup)
- allow for larger instances as was observing "brownouts" with instances dropping out and restarting
- Open button in the Browse and Search view sidebars that jump you through to the Item view for the given item (i.e. large player)

## How to test
- with the Network console open, click 'Rescan proxies' on the Scan Target page. Previously a "scan started" message was shown, but the request was sent to 'undefined'.  Now the request should be sent to the name of the scan target in question
- click on an item missing proxies in the browse view or go to one in the Item view.  You'll see a new button next to 'Create', 'Rescan'.
- clicking 'Rescan' should complete in a couple of seconds and a message is shown in the sidebar indicating if any proxies were found.  If 0 were found, nothing happens. If one was found, then it's automatically linked. Click of the item and back on again to reload the selector and you should be able to view it.  If more than one was found, then 'Rescan' changes to 'Reconnect'. Clicking this opens a dialog that you can use to choose the proxy to connect.
- watch the logs in Kibana after a deployment.  You'll see the normal Akka can't connect messages but they should stop after a few minutes.
- alternatively go to the autodowning lambda in the Lambda control panel in AWS, click Monitoring and look at Logs.  When the "terminated" messages come through (NOT "shutting-down") you should see that it successfully removes the nodes in question from the cluster

## How can we measure success?
- not getting akka breakages after instances drop
- able to reconnect proxies following migration proxy upload runs
- able to investigate specific files and find relevant proxies for them

## Have we considered potential risks?
Testing and observation has been carried out, not expecting any risks beyond the usual accidental regression of any update

## Images
<img width="1010" alt="Screen Shot 2021-03-10 at 17 20 55" src="https://user-images.githubusercontent.com/12482441/110670752-a6170900-81c5-11eb-8736-dd177e5c4c58.png">
<img width="1010" alt="Screen Shot 2021-03-10 at 17 20 39" src="https://user-images.githubusercontent.com/12482441/110670759-a911f980-81c5-11eb-9c73-e2415e36392d.png">
<img width="693" alt="Screen Shot 2021-03-10 at 17 20 23" src="https://user-images.githubusercontent.com/12482441/110670765-a9aa9000-81c5-11eb-8c2f-b72465a61276.png">
<img width="1084" alt="Screen Shot 2021-03-10 at 17 18 14" src="https://user-images.githubusercontent.com/12482441/110670767-aa432680-81c5-11eb-8669-d8753ac44bfa.png">

