### PR TITLE
css tweaks to improve player display in details sidebar

### DIFF
--- a/frontend/app/Entry/EntryDetails.jsx
+++ b/frontend/app/Entry/EntryDetails.jsx
@@ -105,7 +105,6 @@ class EntryDetails extends React.Component {
                               autoPlay={this.props.autoPlay}
                               relinkedCb={this.props.lightboxedCb}  //use the lightboxCb to indicate that the item needs reloading
                               triggeredProxyGeneration={this.proxyGenerationWasTriggered}
-                              itemName={this.props.entry.path}
                 />
             <div className="entry-details-insert">{ this.props.preLightboxInsert ? this.props.preLightboxInsert : "" }</div>
             <div className={this.props.classes.entryDetailsLightboxes}>

--- a/frontend/app/Entry/MediaPreview.tsx
+++ b/frontend/app/Entry/MediaPreview.tsx
@@ -17,6 +17,7 @@ interface MediaPreviewProps {
     itemName: string;
     fileExtension: string;
     mimeType: MimeType;
+    className?: string;
     relinkedCb?: ()=>void;
 }
 
@@ -135,11 +136,11 @@ const MediaPreview:React.FC<MediaPreviewProps> = (props) => {
         </div>
     }
 
-    return <div className={classes.centered}>
+    return <div className={props.className}>
         {
             showingCreate ? <>
                 <EntryThumbnail mimeType={props.mimeType} fileExtension={props.fileExtension} entryId={props.itemId}/>
-                <p className={classes.thumbnote}>There is no {selectedPreview} proxy available</p>
+                <p className={clsx(classes.thumbnote, classes.centered)}>There is no {selectedPreview} proxy available</p>
                 <Grid direction="row" container style={{marginTop: "0.4em"}} justify="space-around">
                     <Grid item>
                         <Button variant="outlined"

--- a/frontend/app/ItemView/ItemView.tsx
+++ b/frontend/app/ItemView/ItemView.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {RouteComponentProps} from "react-router";
-import {ArchiveEntry, ObjectGetResponse, UserResponse} from "../types";
+import {ArchiveEntry, ObjectGetResponse, StylesMap, UserResponse} from "../types";
 import axios from "axios";
 import {formatError} from "../common/ErrorViewComponent";
 import {CircularProgress, makeStyles, Paper, Snackbar} from "@material-ui/core";
@@ -12,12 +12,13 @@ import MediaPreview from "../Entry/MediaPreview";
 import LightboxInsert from "../Entry/details/LightboxInsert";
 import ItemActions from "./ItemActions";
 import {extractFileInfo} from "../common/Fileinfo";
+import {baseStyles} from "../BaseStyles";
 
 interface ItemViewParams {
     id: string;
 }
 
-const useStyles = makeStyles((theme)=>({
+const useStyles = makeStyles((theme)=>Object.assign({
     itemWindow: {
         display: "flex",
         flexDirection: "column",
@@ -31,10 +32,6 @@ const useStyles = makeStyles((theme)=>({
         flex: 1,
         padding: "1em",
     },
-    centered: {
-        marginLeft: "auto",
-        marginRight: "auto",
-    },
     inlineThrobber: {
         marginRight: "1em"
     },
@@ -44,7 +41,7 @@ const useStyles = makeStyles((theme)=>({
     title: {
         marginLeft: "0.4em"
     },
-}));
+}, baseStyles as StylesMap));
 
 const ItemView:React.FC<RouteComponentProps<ItemViewParams>> = (props) => {
     const [entry, setEntry] = useState<ArchiveEntry|undefined>(undefined);
@@ -155,6 +152,7 @@ const ItemView:React.FC<RouteComponentProps<ItemViewParams>> = (props) => {
                               fileExtension={entry.file_extension ?? ".dat"}
                               triggeredProxyGeneration={proxyGenerationWasTriggered}
                               onError={subComponentError}
+                              className={classes.centered}
                               /> : undefined }
             {
                 loading ?


### PR DESCRIPTION
## What does this change?
tweaks to the CSS to prevent excessive margins on the player when displayed in the sidebar of the Browse window. This was forcing me to expand the bar larger than necessary just to see it.
Cause was the css limiting width to 66%, useful on the Item player but not on the sidebar player

## How to test
When playing a video on the sidebar, the left edge of the player should extend to the expand/contract buttons

## How can we measure success?
more user-friendly browsing
