### PR TITLE
Feature/split synopsis (bulk api v2)

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,7 +1,7 @@
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{ESClientManager, ESClientManagerImpl}
 import com.google.inject.AbstractModule
 import com.theguardian.multimedia.archivehunter.common.ArchiveHunterConfiguration
-import helpers.ArchiveHunterConfigurationPlay
+import helpers.{ArchiveHunterConfigurationPlay, InjectableRefresher, InjectableRefresherImpl}
 import play.api.libs.concurrent.AkkaGuiceSupport
 import services._
 
@@ -9,6 +9,7 @@ class Module extends AbstractModule with AkkaGuiceSupport {
   override def configure() = {
     bind(classOf[ESClientManager]).to(classOf[ESClientManagerImpl])
     bind(classOf[ArchiveHunterConfiguration]).to(classOf[ArchiveHunterConfigurationPlay])
+    bind(classOf[InjectableRefresher]).to(classOf[InjectableRefresherImpl])
 
     bindActor[BucketScanner]("bucketScannerActor")
     bindActor[LegacyProxiesScanner]("legacyProxiesScannerActor")

--- a/app/controllers/BulkDownloadsController.scala
+++ b/app/controllers/BulkDownloadsController.scala
@@ -293,7 +293,7 @@ class BulkDownloadsController @Inject()(config:Configuration,serverTokenDAO: Ser
               Success(NotFound(GenericErrorResponse("not_found","item has been deleted!").asJson))
             case GlacierRestoreActor.RestoreFailure(err)=>
               logger.error(s"Could not check restore status: ", err)
-              InternalServerError(GenericErrorResponse("error",err.toString).asJson)
+              Success(InternalServerError(GenericErrorResponse("error",err.toString).asJson))
           }).map({
             case Success(httpResponse)=>httpResponse
             case Failure(err)=>

--- a/app/helpers/InjectableRefresher.scala
+++ b/app/helpers/InjectableRefresher.scala
@@ -2,14 +2,37 @@ package helpers
 
 import akka.actor.ActorSystem
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, ContainerCredentialsProvider, InstanceProfileCredentialsProvider}
+import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProviderChain, BasicAWSCredentials, ContainerCredentialsProvider, InstanceProfileCredentialsProvider}
+import com.amazonaws.internal.StaticCredentialsProvider
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.pandomainauth.model.PanDomainAuthSettings
 import com.gu.pandomainauth.service.S3Bucket
+
 import javax.inject.{Inject, Singleton}
 import play.api.{Configuration, Logger}
 
+trait InjectableRefresher {
+  val panDomainSettings:PanDomainAuthSettingsRefresher
+}
+
 @Singleton
-class InjectableRefresher @Inject() (config:Configuration, actorSystem: ActorSystem) {
+class InjectableRefresherMock @Inject() (config:Configuration, actorSystem: ActorSystem) extends InjectableRefresher {
+  private val cpChain = new AWSCredentialsProviderChain(
+    new StaticCredentialsProvider(new BasicAWSCredentials("key","secret"))
+  )
+
+  override lazy val panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
+    domain = config.get[String]("auth.domain"),
+    system = "archivehunter",
+    actorSystem = actorSystem,
+    awsCredentialsProvider = cpChain
+  ) {
+    override def settings: PanDomainAuthSettings = PanDomainAuthSettings(Map.empty)
+  }
+}
+
+@Singleton
+class InjectableRefresherImpl @Inject() (config:Configuration, actorSystem: ActorSystem) extends InjectableRefresher {
   private val profileName = config.getOptional[String]("externalData.awsProfile")
   private val logger = Logger(getClass)
 

--- a/app/responses/BulkDownloadInitiateResponse.scala
+++ b/app/responses/BulkDownloadInitiateResponse.scala
@@ -3,4 +3,4 @@ package responses
 import com.theguardian.multimedia.archivehunter.common.cmn_models.LightboxBulkEntry
 import models.ArchiveEntryDownloadSynopsis
 
-case class BulkDownloadInitiateResponse(status:String, metadata:LightboxBulkEntry, retrievalToken:String, entries:Seq[ArchiveEntryDownloadSynopsis])
+case class BulkDownloadInitiateResponse(status:String, metadata:LightboxBulkEntry, retrievalToken:String, entries:Option[Seq[ArchiveEntryDownloadSynopsis]])

--- a/app/services/GlacierRestoreActor.scala
+++ b/app/services/GlacierRestoreActor.scala
@@ -2,12 +2,12 @@ package services
 
 import java.time.temporal.{ChronoField, ChronoUnit, TemporalAdjusters, TemporalField}
 import java.time.{Instant, Period, ZoneId, ZonedDateTime}
-
 import akka.actor.{Actor, ActorRef, ActorSystem}
-import com.amazonaws.services.s3.model.RestoreObjectRequest
+import com.amazonaws.services.s3.model.{ObjectMetadata, RestoreObjectRequest}
 import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer}
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{ESClientManager, S3ClientManager}
 import com.theguardian.multimedia.archivehunter.common.cmn_models._
+
 import javax.inject.{Inject, Singleton}
 import play.api.{Configuration, Logger}
 
@@ -40,6 +40,7 @@ object GlacierRestoreActor {
   case class RestoreInProgress(entry:ArchiveEntry) extends GRMsg
   case class RestoreExpired(entry:ArchiveEntry) extends GRMsg
   case class RestoreCompleted(entry:ArchiveEntry, expiresAt:ZonedDateTime) extends GRMsg
+  case class ItemLost(entry:ArchiveEntry) extends GRMsg
 }
 
 @Singleton
@@ -85,44 +86,59 @@ class GlacierRestoreActor @Inject() (config:Configuration, esClientMgr:ESClientM
     lbEntryDAO.put(updatedEntry)
   }
 
+  private def checkStatus(result:ObjectMetadata, entry: ArchiveEntry, lbEntry: Option[LightboxEntry], jobs:Option[List[JobModel]], originalSender:ActorRef) = {
+    val isRestoring = Option(result.getOngoingRestore).map(_.booleanValue()) //true, false or null; see https://forums.aws.amazon.com/thread.jspa?threadID=141678. Also map java boolean to scala.
+    isRestoring match {
+      case None =>
+        logger.info(s"s3://${entry.bucket}/${entry.path} has not had any restore requested")
+        if(result.getStorageClass!="GLACIER"){
+          originalSender ! NotInArchive(entry)
+        } else {
+          if(jobs.isDefined) jobs.get.foreach(job=>updateJob(job, JobStatus.ST_ERROR,Some("No restore record in S3")))
+          if(lbEntry.isDefined) updateLightbox(lbEntry.get,None,error=Some(new RuntimeException("No restore record in S3")))
+          originalSender ! RestoreNotRequested(entry)
+        }
+      case Some(true) => //restore is in progress
+        logger.info(s"s3://${entry.bucket}/${entry.path} is currently under restore")
+        if(jobs.isDefined) jobs.get.foreach(job=>updateJob(job, JobStatus.ST_RUNNING, None))
+        if(lbEntry.isDefined) updateLightboxFull(lbEntry.get,RestoreStatus.RS_UNDERWAY,None)
+        originalSender ! RestoreInProgress(entry)
+      case Some(false) => //restore not in progress, may be completed
+        Option(result.getRestoreExpirationTime)
+          .map(date => ZonedDateTime.ofInstant(date.toInstant, ZoneId.systemDefault())) match {
+          case None => //no restore time, so it's gone back again
+            if(lbEntry.isDefined) {
+              if (lbEntry.get.restoreStatus != RestoreStatus.RS_ERROR && lbEntry.get.restoreStatus != RestoreStatus.RS_SUCCESS) {
+                updateLightbox(lbEntry.get, None, Some(new RuntimeException("Item has already expired")))
+              }
+            }
+            originalSender ! RestoreNotRequested(entry)
+          case Some(expiry) =>
+            if(jobs.isDefined) jobs.get.foreach(job=>updateJob(job,JobStatus.ST_SUCCESS,None))
+            if(lbEntry.isDefined) updateLightboxFull(lbEntry.get, RestoreStatus.RS_SUCCESS, Some(expiry))
+            originalSender ! RestoreCompleted(entry, expiry)
+        }
+    }
+  }
+
   override def receive: Receive = {
     case InternalCheckRestoreStatus(lbEntry, entry, jobs, originalSender)=>
       logger.info(s"Checking restore status for s3://${entry.bucket}/${entry.path}")
       logger.info(s"From lightbox entry $lbEntry")
       logger.info(s"With jobs $jobs")
 
-      val result = s3client.getObjectMetadata(entry.bucket, entry.path)
-      val isRestoring = Option(result.getOngoingRestore).map(_.booleanValue()) //true, false or null; see https://forums.aws.amazon.com/thread.jspa?threadID=141678. Also map java boolean to scala.
-      isRestoring match {
-        case None =>
-          logger.info(s"s3://${entry.bucket}/${entry.path} has not had any restore requested")
-          if(result.getStorageClass!="GLACIER"){
-            originalSender ! NotInArchive(entry)
-          } else {
-            if(jobs.isDefined) jobs.get.foreach(job=>updateJob(job, JobStatus.ST_ERROR,Some("No restore record in S3")))
-            if(lbEntry.isDefined) updateLightbox(lbEntry.get,None,error=Some(new RuntimeException("No restore record in S3")))
-            originalSender ! RestoreNotRequested(entry)
+      Try {
+        s3client.getObjectMetadata(entry.bucket, entry.path)
+      } match {
+        case Success(result)=>checkStatus(result, entry, lbEntry, jobs, originalSender)
+        case Failure(s3err:com.amazonaws.services.s3.model.AmazonS3Exception)=>
+          if(s3err.getStatusCode==404) {
+            logger.warn(s"Registered item s3://${entry.bucket}/${entry.path} does not exist any more!")
+            originalSender ! ItemLost(entry)
           }
-        case Some(true) => //restore is in progress
-          logger.info(s"s3://${entry.bucket}/${entry.path} is currently under restore")
-          if(jobs.isDefined) jobs.get.foreach(job=>updateJob(job, JobStatus.ST_RUNNING, None))
-          if(lbEntry.isDefined) updateLightboxFull(lbEntry.get,RestoreStatus.RS_UNDERWAY,None)
-          originalSender ! RestoreInProgress(entry)
-        case Some(false) => //restore not in progress, may be completed
-          Option(result.getRestoreExpirationTime)
-            .map(date => ZonedDateTime.ofInstant(date.toInstant, ZoneId.systemDefault())) match {
-            case None => //no restore time, so it's gone back again
-              if(lbEntry.isDefined) {
-                if (lbEntry.get.restoreStatus != RestoreStatus.RS_ERROR && lbEntry.get.restoreStatus != RestoreStatus.RS_SUCCESS) {
-                  updateLightbox(lbEntry.get, None, Some(new RuntimeException("Item has already expired")))
-                }
-              }
-              originalSender ! RestoreNotRequested(entry)
-            case Some(expiry) =>
-              if(jobs.isDefined) jobs.get.foreach(job=>updateJob(job,JobStatus.ST_SUCCESS,None))
-              if(lbEntry.isDefined) updateLightboxFull(lbEntry.get, RestoreStatus.RS_SUCCESS, Some(expiry))
-              originalSender ! RestoreCompleted(entry, expiry)
-          }
+        case Failure(err)=>
+          logger.warn(s"Could not check restore status for s3://${entry.bucket}/${entry.path}: ${err.getMessage}", err)
+          originalSender ! RestoreFailure(err)
       }
 
     case CheckRestoreStatusBasic(archiveEntry)=>

--- a/app/services/GlacierRestoreActor.scala
+++ b/app/services/GlacierRestoreActor.scala
@@ -50,7 +50,7 @@ class GlacierRestoreActor @Inject() (config:Configuration, esClientMgr:ESClientM
   private val logger = Logger(getClass)
 
   implicit val ec:ExecutionContext = system.getDispatcher
-  val s3client = s3ClientMgr.getClient(config.getOptional[String]("externalData.awsProfile"))
+  lazy val s3client = s3ClientMgr.getClient(config.getOptional[String]("externalData.awsProfile"))
   val defaultExpiry = config.getOptional[Int]("archive.restoresExpireAfter").getOrElse(3)
   logger.info(s"Glacier restores will expire after $defaultExpiry days")
   private val indexer = new Indexer(config.get[String]("externalData.indexName"))

--- a/app/services/GlacierRestoreActor.scala
+++ b/app/services/GlacierRestoreActor.scala
@@ -135,6 +135,9 @@ class GlacierRestoreActor @Inject() (config:Configuration, esClientMgr:ESClientM
           if(s3err.getStatusCode==404) {
             logger.warn(s"Registered item s3://${entry.bucket}/${entry.path} does not exist any more!")
             originalSender ! ItemLost(entry)
+          } else {
+            logger.warn(s"Could not check restore status due to an s3 error s3://${entry.bucket}/${entry.path}: ${s3err.getMessage}", s3err)
+            originalSender ! RestoreFailure(s3err)
           }
         case Failure(err)=>
           logger.warn(s"Could not check restore status for s3://${entry.bucket}/${entry.path}: ${err.getMessage}", err)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,7 +64,7 @@ proxyFramework {
 serverToken {
   serverTokenTable = "archivehunter-DEV-andy-ServerTokensTable-8RYLWCUAIQRH"
   longLivedDuration = 7200  //how long a "long-lived" token should last, in seconds. Defaults to 2 hours if not set.
-  shortLivedDuration = 10   //how long a "short-lived" or immediate use token should last, in seconds. Defaults to 10 seconds if not set.
+  shortLivedDuration = 60   //how long a "short-lived" or immediate use token should last, in seconds. Defaults to 10 seconds if not set.
 }
 
 serverAuth {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,7 +64,7 @@ proxyFramework {
 serverToken {
   serverTokenTable = "archivehunter-DEV-andy-ServerTokensTable-8RYLWCUAIQRH"
   longLivedDuration = 7200  //how long a "long-lived" token should last, in seconds. Defaults to 2 hours if not set.
-  shortLivedDuration = 60   //how long a "short-lived" or immediate use token should last, in seconds. Defaults to 10 seconds if not set.
+  shortLivedDuration = 10   //how long a "short-lived" or immediate use token should last, in seconds. Defaults to 10 seconds if not set.
 }
 
 serverAuth {

--- a/conf/routes
+++ b/conf/routes
@@ -98,6 +98,8 @@ DELETE  /api/proxyFramework/deployments/:forRegion  @controllers.ProxyFrameworkA
 GET     /api/regions                                @controllers.ProxyFrameworkAdminController.getRegions
 
 GET     /api/bulk/:codeValue                @controllers.BulkDownloadsController.initiateWithOnetimeCode(codeValue)
+GET     /api/bulkv2/:codeValue              @controllers.BulkDownloadsController.initiateWithOnetimeCodeV2(codeValue)
+GET     /api/bulkv2/:tokenValue/summary     @controllers.BulkDownloadsController.bulkDownloadSummary(tokenValue, from:Option[Int], limit:Option[Int])
 GET     /api/bulk/:tokenValue/get/:fileId   @controllers.BulkDownloadsController.getDownloadIdWithToken(tokenValue, fileId)
 
 GET     /api/pathcache/size                 @controllers.PathCacheController.pathCacheSize

--- a/conf/routes
+++ b/conf/routes
@@ -99,7 +99,7 @@ GET     /api/regions                                @controllers.ProxyFrameworkA
 
 GET     /api/bulk/:codeValue                @controllers.BulkDownloadsController.initiateWithOnetimeCode(codeValue)
 GET     /api/bulkv2/:codeValue              @controllers.BulkDownloadsController.initiateWithOnetimeCodeV2(codeValue)
-GET     /api/bulkv2/:tokenValue/summary     @controllers.BulkDownloadsController.bulkDownloadSummary(tokenValue, from:Option[Int], limit:Option[Int])
+GET     /api/bulkv2/:tokenValue/summarystream     @controllers.BulkDownloadsController.bulkDownloadSummary(tokenValue)
 GET     /api/bulk/:tokenValue/get/:fileId   @controllers.BulkDownloadsController.getDownloadIdWithToken(tokenValue, fileId)
 
 GET     /api/pathcache/size                 @controllers.PathCacheController.pathCacheSize

--- a/test/BulkDownloadsControllerSpec.scala
+++ b/test/BulkDownloadsControllerSpec.scala
@@ -1,0 +1,155 @@
+import akka.NotUsed
+import akka.stream.scaladsl.{Framing, Keep, Sink, Source}
+import akka.util.ByteString
+import com.sksamuel.elastic4s.streams.ScrollPublisher
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, ArchiveEntryHitReader, MimeType, StorageClass, StorageClassEncoder, ZonedDateTimeEncoder}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{ESClientManager, S3ClientManager}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.{LightboxBulkEntry, LightboxBulkEntryDAO, LightboxEntry, LightboxEntryDAO, RestoreStatusEncoder}
+import controllers.BulkDownloadsController
+import models.{ArchiveEntryDownloadSynopsis, ServerTokenDAO, ServerTokenEntry}
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import play.api.Configuration
+import play.api.mvc.ControllerComponents
+import play.api.test.{FakeRequest, WithApplication}
+import io.circe.generic.auto._
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.global
+import java.time.ZonedDateTime
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+class BulkDownloadsControllerSpec extends Specification with Mockito with ZonedDateTimeEncoder with ArchiveEntryHitReader with StorageClassEncoder {
+  sequential
+
+  def fakeStreamingSource = Source.fromIterator(()=>Seq(
+    ArchiveEntry(
+      "abcde",
+      "bucket1",
+      "path/to/file",
+      None,
+      None,
+      1234L,
+      ZonedDateTime.now(),
+      "tag",
+      MimeType("application","data"),
+      false,
+      StorageClass.STANDARD,
+      Seq(),
+      false,
+      None
+    ),
+    ArchiveEntry("xxyz",
+      "bucket2",
+      "path/to/file2",
+      None,
+      None,
+      1234L,
+      ZonedDateTime.now(),
+      "tag",
+      MimeType("application","data"),
+      false,
+      StorageClass.STANDARD,
+      Seq(),
+      false,
+      None
+    )
+  ).toIterator)
+
+  "BulkDownloadsController.streamingEntriesForBulk" should {
+    "yield a stream of NDJSON formatted ArchiveEntrySynopsis" in new WithApplication() {
+      implicit val actorSystem = app.actorSystem
+      implicit val mat = app.materializer
+
+      val fakeInputData =fakeStreamingSource
+
+      val fakeEntry = LightboxBulkEntry(
+        "axz",
+        "test bulk",
+        "fred@smith.com",
+        ZonedDateTime.now(),
+        0,
+        0,
+        1
+      )
+
+      val fakeConfig = Configuration.from(Map(
+        "externalData"-> Map("indexName"->"archivehunter")
+      ))
+      val toTest = new BulkDownloadsController(fakeConfig, mock[ServerTokenDAO], mock[LightboxBulkEntryDAO],
+        mock[LightboxEntryDAO], mock[ESClientManager], mock[S3ClientManager], mock[ControllerComponents], null) {
+        override protected def getSearchSource(p: ScrollPublisher): Source[ArchiveEntry, NotUsed] = fakeInputData
+
+        def callFunc(bulkEntry:LightboxBulkEntry) =  streamingEntriesForBulk(bulkEntry)
+      }
+
+      val resultsFut = toTest.callFunc(fakeEntry)
+        .via(Framing.delimiter(ByteString("\n"), 65535))
+        .map(_.utf8String)
+        .map(io.circe.parser.parse)
+        .map(_.flatMap(_.as[ArchiveEntryDownloadSynopsis]))
+        .toMat(Sink.seq)(Keep.right)
+        .run()
+
+      val results = Await.result(resultsFut, 30.seconds)
+
+      println(results)
+      val failures = results.collect({case Left(err)=>err})
+      failures.length mustEqual 0
+
+      results.length mustEqual 2
+      results.head.right.get.path mustEqual "path/to/file"
+      results.head.right.get.fileSize mustEqual 1234
+      results.head.right.get.entryId mustEqual "abcde"
+      results(1).right.get.path mustEqual "path/to/file2"
+      results(1).right.get.fileSize mustEqual 1234
+      results(1).right.get.entryId mustEqual "xxyz"
+    }
+  }
+
+  "BulkDownloadsController.saveTokenOnly" should {
+    "update the existing token in the database and create a long-lived token" in new WithApplication() {
+      implicit val actorSystem = app.actorSystem
+      implicit val ec:ExecutionContext = actorSystem.dispatcher
+
+      val fakeConfig = Configuration.from(Map(
+        "externalData"-> Map("indexName"->"archivehunter")
+      ))
+
+      val mockServerTokenDAO = mock[ServerTokenDAO]
+
+      mockServerTokenDAO.put(any) returns Future(None)
+
+      val toTest = new BulkDownloadsController(fakeConfig, mockServerTokenDAO, mock[LightboxBulkEntryDAO],
+        mock[LightboxEntryDAO], mock[ESClientManager], mock[S3ClientManager], mock[ControllerComponents], null) {
+        def callFunc(updatedToken:ServerTokenEntry, bulkEntry:LightboxBulkEntry) = saveTokenOnly(updatedToken, bulkEntry)
+      }
+
+      val startingToken = ServerTokenEntry(
+        "asdffsfsd",
+        ZonedDateTime.now(),
+        Some("fred@smith.com"),
+        Some(ZonedDateTime.now()),
+        0,
+        false,
+        None
+      )
+
+      val bulk = LightboxBulkEntry(
+        "xxxxads",
+        "test bulk",
+        "fred@smith.com",
+        ZonedDateTime.now(),
+        0,
+        1,
+        0
+      )
+      val result = Await.result(toTest.callFunc(startingToken, bulk), 10.seconds)
+
+      there were two(mockServerTokenDAO).put(any)
+      result.header.status mustEqual 200
+    }
+  }
+
+  //I'd +like+ to test the endpoint but can't figure out how to do it while injecting fake data
+}


### PR DESCRIPTION
## What does this change?
Implements a new version of the bulk download protocol that is more suitable for large item downloads.

The existing protocol worked like this:
- client calls /api/bulk/{one-time-code}
- server responds with a long-lived code and a summary for every file to be downloaded.
- client calls /api/bulk/{long-lived-token}/get/{file-id} to obtain a download link for the file

This could time out while compiling the summary at stage 2.

The new protocol works as follows:
- client calls /api/bulkv2/{one-time-code}
- server responds with the SAME json response as before with the long-lived code, but the entries field is null
- client then calls /api/bulkv2/{long-lived-token}/summarystream

the server responds with an NDJSON stream of the same data that would have been included in the entries field of the initial response before.

because it’s a stream, there is no risk of timeout no matter how many entries there are.  However, the client implementation is  more complex.

The existing bulk endpoints are still present so the "v1" protocol will continue to work.

## How to test
You need a client implementation to test this. Follow the instructions at https://github.com/guardian/autopull/pull/4.
Download Manager implementation has not yet been started - https://codemill.atlassian.net/secure/RapidBoard.jspa?rapidView=31&projectKey=GP&view=planning&selectedIssue=GP-440&epics=visible&issueLimit=100.

## How can we measure success?
We can download bulks with 1500 or more files in them

## Have we considered potential risks?
- existing implementation is still present, so only updated clients might show problems.
