### PR TITLE
Feature / blank cache paths index

### DIFF
--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/PathCacheIndexer.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/PathCacheIndexer.scala
@@ -70,6 +70,15 @@ class PathCacheIndexer(val indexName:String, client:ElasticClient, batchSize:Int
       .run()
   }
 
+  def removeIndex(implicit actorSystem:ActorSystem, mat:Materializer) = {
+    client.execute { deleteIndex(indexName) }
+  } flatMap { response=>
+    if(response.status>299 || response.status<200) {
+      Future.failed(new RuntimeException(s"Delete index failed with a ${response.status} error: ${response.error.toString}"))
+    } else {
+      Future(response)
+    }
+  }
   /**
    * returns a list of the paths that match the given query list
    * @param collectionName collection to check

--- a/conf/routes
+++ b/conf/routes
@@ -108,7 +108,7 @@ GET     /api/bulkv2/:tokenValue/summarystream     @controllers.BulkDownloadsCont
 GET     /api/bulk/:tokenValue/get/:fileId   @controllers.BulkDownloadsController.getDownloadIdWithToken(tokenValue, fileId)
 
 GET     /api/pathcache/size                 @controllers.PathCacheController.pathCacheSize
-PUT     /api/pathcache/rebuild              @controllers.PathCacheController.startCacheBuild
+PUT     /api/pathcache/rebuild              @controllers.PathCacheController.startCacheBuild(blankFirst:Boolean ?= false)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)

--- a/frontend/app/admin/PathCacheAdmin.jsx
+++ b/frontend/app/admin/PathCacheAdmin.jsx
@@ -3,7 +3,7 @@ import axios from "axios";
 import MuiAlert from "@material-ui/lab/Alert";
 import {formatError} from "../common/ErrorViewComponent.jsx";
 import AdminContainer from "./AdminContainer";
-import {Button, createStyles, withStyles, Paper, Snackbar, Typography} from "@material-ui/core";
+import {Button, createStyles, withStyles, Paper, Snackbar, Typography, FormControlLabel, Switch} from "@material-ui/core";
 import {LibraryBooks} from "@material-ui/icons";
 import {Helmet} from "react-helmet";
 
@@ -23,7 +23,8 @@ class PathCacheAdmin extends React.Component {
             showingError:false,
             cachedPathCount: 0,
             reindexWaiting: false,
-            reindexSuccessful: false
+            reindexSuccessful: false,
+            shouldBlank: false,
         };
 
         this.requestReindex = this.requestReindex.bind(this);
@@ -47,7 +48,9 @@ class PathCacheAdmin extends React.Component {
     }
 
     requestReindex() {
-        this.setState({reindexWaiting: true, reindexSuccessful: false}, ()=>axios.put("/api/pathcache/rebuild")
+        const args = this.state.shouldBlank ? "?blankFirst=true" : "?blankFirst=false";
+
+        this.setState({reindexWaiting: true, reindexSuccessful: false}, ()=>axios.put("/api/pathcache/rebuild" + args)
             .then(response=>{
                 this.setState({reindexWaiting: false, reindexSuccessful: true})
             })
@@ -77,7 +80,14 @@ class PathCacheAdmin extends React.Component {
                         <Typography>Loading...</Typography> :
                         <Typography>There are currently {this.state.cachedPathCount} cached path fragments</Typography>
                     }
-                    <Typography>You can rebuild the index here. It's not blanked before use.  The process should take less than half an hour.</Typography>
+                    <Typography>You can rebuild the index here. The process should take less than half an hour.</Typography>
+                    <FormControlLabel
+                        control={
+                            <Switch checked={this.state.shouldBlank} onChange={(evt)=>this.setState({shouldBlank: evt.target.checked})}/>
+                        }
+                        label="Blank index before rebuild"
+                    />
+
                     <Button variant="outlined"
                             startIcon={<LibraryBooks/>}
                             onClick={this.requestReindex}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -904,7 +904,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1349,7 +1348,6 @@
       "dependencies": {
         "camelcase": "^5.3.1",
         "loader-utils": "1.2.3",
-        "prettier": "*",
         "schema-utils": "^2.0.1"
       },
       "optionalDependencies": {
@@ -5372,7 +5370,6 @@
         "jest-resolve": "^25.5.1",
         "jest-util": "^25.5.0",
         "jest-worker": "^25.5.0",
-        "node-notifier": "^6.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^3.1.0",
@@ -5906,7 +5903,6 @@
         "@types/graceful-fs": "^4.1.2",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-serializer": "^25.5.0",
         "jest-util": "^25.5.0",
@@ -6848,7 +6844,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",


### PR DESCRIPTION
## What does this change?
Adds an option to blank the paths cache index before rebuild - presented in the Path Cache admin page and implemented in the backend.

Practically, this performs an index delete on the paths cache index before kicking off the rebuild, ensuring that it is built from clean slate.

This is needed to clean out some paths which are now un-used
