### PR TITLE
ensure lightbox view state is updated when user changes

### DIFF
--- a/frontend/app/Lightbox/NewLightbox.tsx
+++ b/frontend/app/Lightbox/NewLightbox.tsx
@@ -205,11 +205,7 @@ const NewLightbox:React.FC<RouteComponentProps> = (props) => {
     //reload the search if the currently selected bulk changes
     useEffect(()=>{
         refreshData();
-    }, [selectedBulk]);
-
-    useEffect(()=>{
-        refreshData();
-    }, []);
+    }, [selectedBulk, selectedUser]);
 
     const handleComponentError = (desc:string) => {
         setLastError(desc);

--- a/utils/datamigration/lightbox_migration.py
+++ b/utils/datamigration/lightbox_migration.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import boto3
+import logging
+
+source_table = ""
+
+ddb = boto3.resource("dynamodb")
+
+
+class OperationBuffer(object):
+    def __init__(self):
+        pass
+
+
+def iterate_source_records(source_table_name:str):
+    """
+    a generator that yields records from the source table
+    :param source_table_name:
+    :return:
+    """
+    logger = logging.getLogger("iterate_source_records")
+    continuation = None
+    while True:
+        response = ddb.scan(
+            TableName=source_table_name,
+            ExclusiveStartKey=continuation
+        )
+        logger.debug("page response is {}".format(response))
+        if response["LastEvaluatedKey"] is None:
+            break
+
+        for entry in response["Items"]:
+            yield entry
+
+        continuation = {"S":response["LastEvaluatedKey"]}
+    logger.info("Finished iterating source records")
+
+###START MAIN


### PR DESCRIPTION
## What does this change?
Fix to make sure that the lightbox "bulk" panel changes when an administrator requests to view another user's lightbox

## How to test
As an admin, select the lightbox of another user that has different bulks. The bulk panel should change

## How can we measure success?
Admin able to see user's bulks

