### PR TITLE
Feature/refactor bulk selection

### DIFF
--- a/frontend/app/Lightbox/BulkSelectionsScroll.tsx
+++ b/frontend/app/Lightbox/BulkSelectionsScroll.tsx
@@ -10,10 +10,8 @@ import clsx from "clsx";
 import {AirportShuttle, DeleteOutline, GetApp, Timelapse, WarningRounded} from "@material-ui/icons";
 
 interface BulkSelectionsScrollProps {
-    entries: LightboxBulk[];
     currentSelection?: string;
-    onSelected: (newId:string)=>void;
-    onDeleteClicked: (idToDelete:string)=>void;
+    onSelected: (newId:string|undefined)=>void;
     forUser: string;
     isAdmin: boolean;
     expiryDays: number;
@@ -62,6 +60,7 @@ const useStyles = makeStyles((theme)=>({
     bulkSelectionScroll: {
         overflowY: "hidden",
         overflowX: "auto",
+        width: "max-content"
     },
     clickable: {
         cursor: "pointer",
@@ -105,6 +104,7 @@ const useStyles = makeStyles((theme)=>({
 }));
 
 const BulkSelectionsScroll:React.FC<BulkSelectionsScrollProps> = (props) => {
+    const [bulkSelections, setBulkSelections] = useState<LightboxBulk[]>([]);
     const classes = useStyles();
 
     const nameExtractor = /^([^:]+):(.*)$/;
@@ -115,6 +115,22 @@ const BulkSelectionsScroll:React.FC<BulkSelectionsScrollProps> = (props) => {
             return ({name: result[1], pathArray: result[2].split("/")})
         } else {
             return ({name: str, pathArray: []})
+        }
+    }
+
+    const bulkSearchDeleteRequested = async (entryId:string) => {
+        try {
+            await axios.delete("/api/lightbox/"+props.forUser+"/bulk/" + entryId);
+            console.log("lightbox entry " + entryId + " deleted.");
+            //if we are deleting the current selection, the update the selection to undefined otherwise do a no-op update
+            //to trugger reload
+            const updatedSelected = props.currentSelection===entryId ? undefined : props.currentSelection;
+
+            setBulkSelections((prevState) => prevState.filter(entry=>entry.id!==entryId));
+            props.onSelected(updatedSelected);
+        } catch(err) {
+            console.error(err);
+            if(props.onError) props.onError(formatError(err, false));
         }
     }
 
@@ -152,7 +168,7 @@ const BulkSelectionsScroll:React.FC<BulkSelectionsScrollProps> = (props) => {
 
     return <div className={classes.bulkSelectionScroll}>
         {
-            props.entries.map((entry,idx)=>{
+            bulkSelections.map((entry,idx)=>{
                 const bulkInfo = extractNameAndPathArray(entry.description);
                 const baseClasses = [
                     classes.entryView,
@@ -212,7 +228,7 @@ const BulkSelectionsScroll:React.FC<BulkSelectionsScrollProps> = (props) => {
                                     <Tooltip title="Remove this bulk from your lightbox">
                                         <IconButton style={{float: "right"}} onClick={(evt)=>{
                                             evt.stopPropagation();
-                                            props.onDeleteClicked(entry.id);
+                                            bulkSearchDeleteRequested(entry.id);
                                         }}>
                                             <DeleteOutline style={{color: "red"}}/>
                                         </IconButton>

--- a/frontend/app/Lightbox/BulkSelectionsScroll.tsx
+++ b/frontend/app/Lightbox/BulkSelectionsScroll.tsx
@@ -5,7 +5,7 @@ import axios from 'axios';
 import LoadingThrobber from "../common/LoadingThrobber.jsx";
 import {LightboxBulk, LightboxBulkResponse} from "../types";
 import {formatError} from "../common/ErrorViewComponent";
-import {Grid, IconButton, makeStyles, Tooltip, Typography} from "@material-ui/core";
+import {Grid, IconButton, LinearProgress, makeStyles, Tooltip, Typography} from "@material-ui/core";
 import clsx from "clsx";
 import {AirportShuttle, DeleteOutline, GetApp, Timelapse, WarningRounded} from "@material-ui/icons";
 
@@ -151,7 +151,7 @@ const BulkSelectionsScroll:React.FC<BulkSelectionsScrollProps> = (props) => {
 
     useEffect(()=>{
         loadData();
-    }, []);
+    }, [props.forUser]);
 
     const initiateDownloadInApp = (entryId:string) => {
         axios.get("/api/lightbox/bulk/appDownload/" + entryId, )
@@ -187,7 +187,7 @@ const BulkSelectionsScroll:React.FC<BulkSelectionsScrollProps> = (props) => {
 
     return <div className={classes.bulkSelectionScroll}>
         {
-            bulkSelections.map((entry,idx)=>{
+            loading ? <LinearProgress/> : bulkSelections.map((entry,idx)=>{
                 const bulkInfo = extractNameAndPathArray(entry.description);
                 const baseClasses = [
                     classes.entryView,

--- a/frontend/app/Lightbox/BulkSelectionsScroll.tsx
+++ b/frontend/app/Lightbox/BulkSelectionsScroll.tsx
@@ -1,9 +1,9 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import TimestampFormatter from "../common/TimestampFormatter";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import axios from 'axios';
 import LoadingThrobber from "../common/LoadingThrobber.jsx";
-import {LightboxBulk} from "../types";
+import {LightboxBulk, LightboxBulkResponse} from "../types";
 import {formatError} from "../common/ErrorViewComponent";
 import {Grid, IconButton, makeStyles, Tooltip, Typography} from "@material-ui/core";
 import clsx from "clsx";
@@ -105,6 +105,7 @@ const useStyles = makeStyles((theme)=>({
 
 const BulkSelectionsScroll:React.FC<BulkSelectionsScrollProps> = (props) => {
     const [bulkSelections, setBulkSelections] = useState<LightboxBulk[]>([]);
+    const [loading, setLoading] = useState(true);
     const classes = useStyles();
 
     const nameExtractor = /^([^:]+):(.*)$/;
@@ -133,6 +134,24 @@ const BulkSelectionsScroll:React.FC<BulkSelectionsScrollProps> = (props) => {
             if(props.onError) props.onError(formatError(err, false));
         }
     }
+
+
+    const loadData = async () => {
+        setLoading(true);
+        try {
+            const bulkSelections = await axios.get<LightboxBulkResponse>("/api/lightbox/" + props.forUser + "/bulks");
+            setBulkSelections(bulkSelections.data.entries);
+            setLoading(false);
+        } catch(err) {
+            setLoading(false);
+            console.error("Could not load in bulks: ", err);
+            if(props.onError) props.onError(formatError(err, false));
+        }
+    }
+
+    useEffect(()=>{
+        loadData();
+    }, []);
 
     const initiateDownloadInApp = (entryId:string) => {
         axios.get("/api/lightbox/bulk/appDownload/" + entryId, )

--- a/frontend/app/Lightbox/NewLightbox.tsx
+++ b/frontend/app/Lightbox/NewLightbox.tsx
@@ -99,9 +99,9 @@ const NewLightbox:React.FC<RouteComponentProps> = (props) => {
     const performLoad = () => {
         const detailsRequest = axios.get<LightboxDetailsResponse>("/api/lightbox/" + selectedUser+"/details");
         const loginDetailsRequest = axios.get<UserDetailsResponse>("/api/loginStatus");
-        const bulkSelectionsRequest = axios.get<LightboxBulkResponse>("/api/lightbox/" + selectedUser+"/bulks");
+
         const configRequest = axios.get<ObjectListResponse<string>>("/api/config");
-        return Promise.all([detailsRequest, loginDetailsRequest, bulkSelectionsRequest, configRequest]);
+        return Promise.all([detailsRequest, loginDetailsRequest, configRequest]);
     }
 
     const refreshData = async () => {
@@ -111,11 +111,9 @@ const NewLightbox:React.FC<RouteComponentProps> = (props) => {
 
             const detailsResult = results[0].data as LightboxDetailsResponse;
             const loginDetailsResult = results[1].data as UserDetailsResponse;
-            const bulkSelectionsResult = results[2].data as LightboxBulkResponse;
-            const configResult = results[3].data as ObjectListResponse<string>;
+            const configResult = results[2].data as ObjectListResponse<string>;
             setLightboxDetails(detailsResult.entries)
             setUserDetails(loginDetailsResult);
-            setBulkSelectionsCount(bulkSelectionsResult.entryCount);
             setExpiryDays(configResult.entries.length>0 ? parseInt(configResult.entries[0]) : 10);
 
         } catch(err) {


### PR DESCRIPTION
## What does this change?
Fixes CSS for lightbox bulk selection to make it scroll across the top of the page instead of overlapping the media area.
Refactors the code to bring the data load into the scroll component, this loads the view much faster and makes the code a bit easier to read

## How to test
Switch to a user who has more than five or six bulks added and you'll see that it side-scrolls instead of overlapping.  You'll see that it does not now wait for all of the image tiles to be fully loaded before displaying

## How can we measure success?
Usability improved

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![Screenshot 2021-08-16 at 13 38 15](https://user-images.githubusercontent.com/12482441/129565055-77cd8b43-e133-42ae-934a-875f3b9ab44b.png)
