### PR TITLE
Feature/link proxy

### DIFF
--- a/app/controllers/ImportController.scala
+++ b/app/controllers/ImportController.scala
@@ -1,17 +1,21 @@
 package controllers
 
 import akka.actor.{ActorRef, ActorSystem}
+import akka.stream.Materializer
 import auth.{BearerTokenAuth, Security}
 import com.amazonaws.services.s3.AmazonS3
+import io.circe.generic.auto._
+import com.gu.scanamo.error.DynamoReadError
 import com.sksamuel.elastic4s.http.ElasticClient
-import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer}
-import com.theguardian.multimedia.archivehunter.common.clientManagers.{ESClientManager, S3ClientManager}
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer, ProxyLocation, ProxyLocationDAO, ProxyTypeEncoder}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager}
 import com.theguardian.multimedia.archivehunter.common.cmn_helpers.PathCacheExtractor
 import com.theguardian.multimedia.archivehunter.common.cmn_models.{PathCacheEntry, PathCacheIndexer, ScanTarget, ScanTargetDAO}
+import helpers.ProxyLocator
 import play.api.Configuration
 import play.api.libs.circe.Circe
-import play.api.mvc.{AbstractController, ControllerComponents}
-import requests.SpecificImportRequest
+import play.api.mvc.{AbstractController, ControllerComponents, Result}
+import requests.{ProxyImportRequest, SpecificImportRequest}
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.slf4j.LoggerFactory
@@ -22,18 +26,21 @@ import services.IngestProxyQueue
 import javax.inject.{Inject, Named, Singleton}
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Try
 
 @Singleton
 class ImportController @Inject()(override val config:Configuration,
                                    override val controllerComponents:ControllerComponents,
                                    scanTargetDAO:ScanTargetDAO,
+                                 proxyLocationDAO:ProxyLocationDAO,
                                    s3ClientMgr: S3ClientManager,
                                    esClientMgr: ESClientManager,
                                    override val bearerTokenAuth: BearerTokenAuth,
                                    override val cache:SyncCacheApi,
+                                    ddbClientMgr:DynamoClientManager,
                                    @Named("ingestProxyQueue") ingestProxyQueue:ActorRef)
-                                  (implicit actorSystem:ActorSystem)
-  extends AbstractController(controllerComponents) with Security with Circe {
+                                  (implicit actorSystem:ActorSystem, mat:Materializer)
+  extends AbstractController(controllerComponents) with Security with Circe with ProxyTypeEncoder {
 
   override protected val logger = LoggerFactory.getLogger(getClass)
 
@@ -43,7 +50,8 @@ class ImportController @Inject()(override val config:Configuration,
   private val indexName = config.get[String]("externalData.indexName")
   private implicit val pathCacheIndexer = new PathCacheIndexer(config.getOptional[String]("externalData.pathCacheIndex").getOrElse("pathcache"), esClient)
 
-  private val indexer = new Indexer(indexName)
+  private implicit val ddbAkkaClient = ddbClientMgr.getNewAlpakkaDynamoClient(awsProfile)
+  private implicit val indexer = new Indexer(indexName)
 
   def writePathCacheEntries(newCacheEntries:Seq[PathCacheEntry])
                            (implicit pathCacheIndexer:PathCacheIndexer,  elasticClient:ElasticClient) = {
@@ -123,6 +131,113 @@ class ImportController @Inject()(override val config:Configuration,
             InternalServerError(GenericErrorResponse("error","The import process failed, please see server logs for details").asJson)
         })
 
+    }
+  }
+
+  def proxyBucketForMaybeScanTarget(tgt:Option[Either[DynamoReadError, ScanTarget]]):Future[String] = tgt match {
+    case None=>
+      Future.failed(new RuntimeException("No scan target existed for the item's bucket!"))
+    case Some(Left(err))=>
+      Future.failed(new RuntimeException(err.toString))
+    case Some(Right(actualTarget))=>
+      Future(actualTarget.proxyBucket)
+  }
+
+  /**
+    * Wraps the "saveProxy" method to make it a bit nicer for composition
+    * @param newRecord record to save
+    * @return a Future which completes with the saved record on success and fails on error
+    */
+  private def wrapSaveProxy(newRecord:ProxyLocation) = {
+    proxyLocationDAO.saveProxy(newRecord).flatMap({
+      case None=>Future(newRecord)
+      case Some(Left(err))=>
+        Future.failed(new RuntimeException(err.toString))
+      case Some(Right(rec))=>
+        Future(rec)
+    })
+  }
+
+  /**
+    * Ensures that the requested proxy exists and if so 'connects' it as a proxy to the given item
+    * @param importRequest ProxyImportRequest containing information about the proxy to attach
+    * @param item ArchiveEntry representing the item to attach it to
+    * @param correctProxyBucket validated proxy bucket that it should come from
+    * @return a Future, containing a Play result
+    */
+  private def performProxyImport(importRequest:ProxyImportRequest, item:ArchiveEntry, correctProxyBucket:String) = {
+    implicit val s3client:AmazonS3 = s3ClientMgr.getS3Client(region = item.region)
+    Future.fromTry(Try {
+      s3client.doesObjectExist(correctProxyBucket, importRequest.proxyPath)
+    }).flatMap({
+      case false => Future(BadRequest(GenericErrorResponse("error", "that proxy does not exist").asJson))
+      case true =>
+        ProxyLocation.fromS3(
+          correctProxyBucket,
+          importRequest.proxyPath,
+          item.bucket,
+          item.path,
+          Some(importRequest.proxyType)
+        ).flatMap({
+          case Left(err)=>
+            Future(InternalServerError(GenericErrorResponse("error",s"Could not get proxy location from s3 $err").asJson))
+          case Right(newRecord)=>
+            Future.sequence(Seq(
+              wrapSaveProxy(newRecord),
+              ProxyLocator.setProxiedWithRetry(item.id)
+            )).map(_=>Ok(GenericErrorResponse("ok","proxy set").asJson))
+        })
+    })
+  }
+
+  /**
+    * Ensures that the requested proxy bucket does not conflict with the configured one and that there is not an existing
+    * proxy in place (or we are allowed to over-write).  If both these conditions are met, calls performProxyImport to do the
+    * actual import
+    * @param importRequest ProxyImportRequest containing information about the proxy to attach
+    * @param item ArchiveEntry representing the item to attach it to
+    * @param correctProxyBucket validated proxy bucket that it should come from
+    * @param existingProxies looked-up list of existing proxies for the given item
+    * @return a Future, containing a Play response
+    */
+  def checkAndPerformProxyImport(importRequest:ProxyImportRequest, item:ArchiveEntry, correctProxyBucket:String, existingProxies:List[ProxyLocation]):Future[Result] = {
+    if(importRequest.proxyBucket.isDefined && importRequest.proxyBucket.get != correctProxyBucket) {
+      Future(Conflict(GenericErrorResponse("conflict","incorrect proxy bucket for item").asJson))
+    } else {
+      if(existingProxies.exists(_.proxyType == importRequest.proxyType) && !importRequest.overwrite.getOrElse(false)) {
+        Future(Conflict(GenericErrorResponse("conflict",s"a proxy of type ${importRequest.proxyType} already exists").asJson))
+      } else {
+        performProxyImport(importRequest, item, correctProxyBucket)
+      }
+    }
+  }
+
+  /**
+    * simplifies the Dynamo read response, by failing the Future if any errors are present
+    * @param input original response from DynamoDB
+    * @return a Future containing a list of ProxyLocation.  If any read fails, the whole Future fails.
+    */
+  private def simplifyDynamoReturn(input:Future[List[Either[DynamoReadError, ProxyLocation]]]):Future[List[ProxyLocation]] = input.flatMap(results=>{
+    val failures = results.collect({case Left(err)=>err})
+    if(failures.nonEmpty) {
+      Future.failed(new RuntimeException(failures.map(_.toString).mkString(";")))
+    } else {
+      Future(results.collect({case Right(result)=>result}))
+    }
+  })
+
+  def importProxy = IsAuthenticatedAsync(circe.json(2048)) { uid=> request=>
+    request.body.as[ProxyImportRequest] match {
+      case Left(err)=>
+        Future(BadRequest(GenericErrorResponse("bad_request", err.toString()).asJson))
+      case Right(importRequest)=>
+        for {
+          item <- indexer.getById(importRequest.itemId) //this version fails on a RuntimeException if there is no item present
+          itemsScanTarget <- scanTargetDAO.targetForBucket(item.bucket)
+          proxyBucket <- proxyBucketForMaybeScanTarget(itemsScanTarget)
+          proxyRecords <- simplifyDynamoReturn(proxyLocationDAO.getAllProxiesFor(item.id))
+          result <- checkAndPerformProxyImport(importRequest, item, proxyBucket, proxyRecords)
+        } yield result
     }
   }
 }

--- a/app/helpers/IndexerFactory.scala
+++ b/app/helpers/IndexerFactory.scala
@@ -1,0 +1,16 @@
+package helpers
+
+import com.theguardian.multimedia.archivehunter.common.Indexer
+import play.api.Configuration
+
+import javax.inject.{Inject, Singleton}
+
+/**
+  * this seems ugly, but until I have time to properly go through and refactor how indexer works and is supplied to
+  * its users it will have to do
+  * @param config
+  */
+@Singleton
+class IndexerFactory @Inject() (config:Configuration){
+  def get() = new Indexer(config.get[String]("externalData.indexName"))
+}

--- a/app/requests/ProxyImportRequest.scala
+++ b/app/requests/ProxyImportRequest.scala
@@ -1,0 +1,15 @@
+package requests
+
+import com.theguardian.multimedia.archivehunter.common.ProxyType.ProxyType
+
+/**
+  * Represents a request to add a specific proxy to the given item
+  * @param itemId item ID to add the proxy to
+  * @param proxyPath path to the proxy file, in the item's proxy bucket
+  * @param proxyBucket optional string indicating the proxy's bucket. If this does not agree with the bucket expected for the
+  *                    given item ID, then a 409 (Conflict) is returned
+  * @param proxyType ProxyType enum value indicating which proxy this is to set
+  * @param overwrite If set and true, allow over-writing an existing proxy. Otherwise a 409 (Conflict) is returned if the given
+  *                  proxy type already exists on the item
+  */
+case class ProxyImportRequest(itemId:String, proxyPath:String, proxyBucket:Option[String], proxyType:ProxyType, overwrite:Option[Boolean])

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocation.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyLocation.scala
@@ -108,7 +108,7 @@ object ProxyLocation extends DocId {
         case Some(value) => value
       }
       logger.debug(s"doc ID is ${makeDocId(mainMediaBucket, mediaItemKey)} from $mainMediaBucket and $key")
-      Right(new ProxyLocation(makeDocId(mainMediaBucket, mediaItemKey), makeDocId(proxyBucket, key), pt, proxyBucket, key, Some(client.getRegionName), StorageClass.safeWithName(meta.getStorageClass)))
+      Right(new ProxyLocation(makeDocId(mainMediaBucket, mediaItemKey), makeDocId(proxyBucket, key), pt, proxyBucket, key, Option(client.getRegionName), StorageClass.safeWithName(meta.getStorageClass)))
     } catch {
       case ex:Throwable=>
         logger.error("could not find proxyLocation in s3: ", ex)

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyType.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyType.scala
@@ -4,7 +4,7 @@ import io.circe.{Decoder, Encoder}
 
 object ProxyType extends Enumeration {
   type ProxyType = Value
-  val VIDEO, AUDIO, THUMBNAIL,UNKNOWN = Value
+  val VIDEO, AUDIO, THUMBNAIL, METADATA, UNKNOWN = Value
 }
 
 trait ProxyTypeEncoder {

--- a/conf/routes
+++ b/conf/routes
@@ -114,6 +114,7 @@ PUT     /api/pathcache/rebuild              @controllers.PathCacheController.sta
 
 POST    /api/rundatamigration                  @controllers.Application.runDataMigration
 POST    /api/import                         @controllers.ImportController.importFromPath
+POST    /api/importProxy                    @controllers.ImportController.importProxy
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)

--- a/test/controllers/ImportControllerSpec.scala
+++ b/test/controllers/ImportControllerSpec.scala
@@ -1,0 +1,302 @@
+package controllers
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.testkit.TestProbe
+import auth.BearerTokenAuth
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{ObjectMetadata, Region}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.ScanTargetDAO
+import com.theguardian.multimedia.archivehunter.common.{ArchiveEntry, Indexer, MimeType, ProxyLocation, ProxyLocationDAO, ProxyType, StorageClass}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager}
+import helpers.IndexerFactory
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+import play.api.Configuration
+import play.api.cache.SyncCacheApi
+import play.api.mvc.ControllerComponents
+import requests.ProxyImportRequest
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import java.time.ZonedDateTime
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+class ImportControllerSpec extends Specification with AfterAll with Mockito {
+  private implicit val sys:ActorSystem = ActorSystem("ImportControllerSpec")
+  private implicit val mat:Materializer = Materializer.matFromSystem
+
+  override def afterAll() = {
+    Await.ready(sys.terminate(), 30.seconds)
+  }
+
+  "Importcontroller.checkAndPerformProxyImport" should {
+    "create and save a proxy record then update the item record" in {
+      val config = Configuration.from(Map("externalData.indexName"->"testindex"))
+      val cc = mock[ControllerComponents]
+      val scanTargetDAO = mock[ScanTargetDAO]
+      val proxyTargetDAO = mock[ProxyLocationDAO]
+      proxyTargetDAO.saveProxy(any)(any) returns Future(None)
+      val mockS3Client = mock[AmazonS3]
+      mockS3Client.doesObjectExist(any,any) returns true
+      mockS3Client.getRegionName returns "region-name"
+      val mockedObjectMetadata = mock[ObjectMetadata]
+      mockS3Client.getObjectMetadata(any,any) returns mockedObjectMetadata
+
+      val mockedIndexer = mock[Indexer]
+      val mockedIndexerFactory = mock[IndexerFactory]
+      mockedIndexerFactory.get() returns mockedIndexer
+
+      val s3ClientMgr = mock[S3ClientManager]
+      s3ClientMgr.getS3Client(any,any) returns mockS3Client
+
+      val esClientMgr = mock[ESClientManager]
+      val ddbClientMgr = mock[DynamoClientManager]
+      val probe = TestProbe()
+
+      val toTest = new ImportController(config, cc, scanTargetDAO,
+        proxyTargetDAO, s3ClientMgr, esClientMgr,
+        mock[BearerTokenAuth], mock[SyncCacheApi], ddbClientMgr, mockedIndexerFactory, probe.ref)
+
+      val req = ProxyImportRequest(
+        "some-item-id",
+        "path/to/proxy.mp3",
+        Some("a-proxy-bucket"),
+        ProxyType.AUDIO,
+        None
+      )
+
+      val item = ArchiveEntry("some-item-id","some-bucket","path/to/media.wav",Some("region-name"), Some(".wav"),
+        1234L, ZonedDateTime.now(),"", MimeType("audio","wav"), false, StorageClass.STANDARD, Seq(), mediaMetadata=None)
+
+      mockedIndexer.getById(any)(any) returns Future(item)
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("some-item-id"))
+
+      val existingProxies = List()
+      val result = Await.result(toTest.checkAndPerformProxyImport(req, item, "a-proxy-bucket", existingProxies), 2.seconds)
+
+      result.header.status mustEqual 200
+      there was one(mockS3Client).doesObjectExist("a-proxy-bucket","path/to/proxy.mp3")
+      there was one(s3ClientMgr).getS3Client(null,Some("region-name"))
+      val expectedProxyRecord = ProxyLocation("c29tZS1idWNrZXQ6cGF0aC90by9tZWRpYS53YXY=","YS1wcm94eS1idWNrZXQ6cGF0aC90by9wcm94eS5tcDM=",ProxyType.AUDIO,"a-proxy-bucket","path/to/proxy.mp3", Some("region-name"), StorageClass.STANDARD)
+      there was one(proxyTargetDAO).saveProxy(org.mockito.ArgumentMatchers.eq(expectedProxyRecord))(org.mockito.ArgumentMatchers.eq(null))
+      there was one(mockedIndexer).getById(org.mockito.ArgumentMatchers.eq("some-item-id"))(any)
+      there was one(mockedIndexer).indexSingleItem(any,any,any)(any)
+    }
+
+    "not save a new proxy record if there is one already present and overwrite is not set" in {
+      val config = Configuration.from(Map("externalData.indexName"->"testindex"))
+      val cc = mock[ControllerComponents]
+      val scanTargetDAO = mock[ScanTargetDAO]
+      val proxyTargetDAO = mock[ProxyLocationDAO]
+      proxyTargetDAO.saveProxy(any)(any) returns Future(None)
+      val mockS3Client = mock[AmazonS3]
+      mockS3Client.doesObjectExist(any,any) returns true
+      mockS3Client.getRegionName returns "region-name"
+      val mockedObjectMetadata = mock[ObjectMetadata]
+      mockS3Client.getObjectMetadata(any,any) returns mockedObjectMetadata
+
+      val mockedIndexer = mock[Indexer]
+      val mockedIndexerFactory = mock[IndexerFactory]
+      mockedIndexerFactory.get() returns mockedIndexer
+
+      val s3ClientMgr = mock[S3ClientManager]
+      s3ClientMgr.getS3Client(any,any) returns mockS3Client
+
+      val esClientMgr = mock[ESClientManager]
+      val ddbClientMgr = mock[DynamoClientManager]
+      val probe = TestProbe()
+
+      val toTest = new ImportController(config, cc, scanTargetDAO,
+        proxyTargetDAO, s3ClientMgr, esClientMgr,
+        mock[BearerTokenAuth], mock[SyncCacheApi], ddbClientMgr, mockedIndexerFactory, probe.ref)
+
+      val req = ProxyImportRequest(
+        "some-item-id",
+        "path/to/proxy.mp3",
+        Some("a-proxy-bucket"),
+        ProxyType.AUDIO,
+        None
+      )
+
+      val item = ArchiveEntry("some-item-id","some-bucket","path/to/media.wav",Some("region-name"), Some(".wav"),
+        1234L, ZonedDateTime.now(),"", MimeType("audio","wav"), false, StorageClass.STANDARD, Seq(), mediaMetadata=None)
+
+      mockedIndexer.getById(any)(any) returns Future(item)
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("some-item-id"))
+
+      val existingProxies = List(
+        ProxyLocation("some-file-id","some-proxy-id",ProxyType.AUDIO,"a-proxy-bucket","path/to/proxy.mp3",Some("region-name"), StorageClass.STANDARD)
+      )
+      val result = Await.result(toTest.checkAndPerformProxyImport(req, item, "a-proxy-bucket", existingProxies), 2.seconds)
+
+      result.header.status mustEqual 409
+      there was no(mockS3Client).doesObjectExist("a-proxy-bucket","path/to/proxy.mp3")
+      there was no(s3ClientMgr).getS3Client(null,Some("region-name"))
+      there was no(proxyTargetDAO).saveProxy(any)(org.mockito.ArgumentMatchers.eq(null))
+      there was no(mockedIndexer).getById(org.mockito.ArgumentMatchers.eq("some-item-id"))(any)
+      there was no(mockedIndexer).indexSingleItem(any,any,any)(any)
+    }
+
+    "create and save a new proxy record if overwrite is allowed, even if one exists already" in {
+      val config = Configuration.from(Map("externalData.indexName"->"testindex"))
+      val cc = mock[ControllerComponents]
+      val scanTargetDAO = mock[ScanTargetDAO]
+      val proxyTargetDAO = mock[ProxyLocationDAO]
+      proxyTargetDAO.saveProxy(any)(any) returns Future(None)
+      val mockS3Client = mock[AmazonS3]
+      mockS3Client.doesObjectExist(any,any) returns true
+      mockS3Client.getRegionName returns "region-name"
+      val mockedObjectMetadata = mock[ObjectMetadata]
+      mockS3Client.getObjectMetadata(any,any) returns mockedObjectMetadata
+
+      val mockedIndexer = mock[Indexer]
+      val mockedIndexerFactory = mock[IndexerFactory]
+      mockedIndexerFactory.get() returns mockedIndexer
+
+      val s3ClientMgr = mock[S3ClientManager]
+      s3ClientMgr.getS3Client(any,any) returns mockS3Client
+
+      val esClientMgr = mock[ESClientManager]
+      val ddbClientMgr = mock[DynamoClientManager]
+      val probe = TestProbe()
+
+      val toTest = new ImportController(config, cc, scanTargetDAO,
+        proxyTargetDAO, s3ClientMgr, esClientMgr,
+        mock[BearerTokenAuth], mock[SyncCacheApi], ddbClientMgr, mockedIndexerFactory, probe.ref)
+
+      val req = ProxyImportRequest(
+        "some-item-id",
+        "path/to/proxy.mp3",
+        Some("a-proxy-bucket"),
+        ProxyType.AUDIO,
+        Some(true)
+      )
+
+      val item = ArchiveEntry("some-item-id","some-bucket","path/to/media.wav",Some("region-name"), Some(".wav"),
+        1234L, ZonedDateTime.now(),"", MimeType("audio","wav"), false, StorageClass.STANDARD, Seq(), mediaMetadata=None)
+
+      mockedIndexer.getById(any)(any) returns Future(item)
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("some-item-id"))
+
+      val existingProxies = List(
+        ProxyLocation("some-file-id","some-proxy-id",ProxyType.AUDIO,"a-proxy-bucket","path/to/proxy.mp3",Some("region-name"), StorageClass.STANDARD)
+      )
+      val result = Await.result(toTest.checkAndPerformProxyImport(req, item, "a-proxy-bucket", existingProxies), 2.seconds)
+
+      result.header.status mustEqual 200
+      there was one(mockS3Client).doesObjectExist("a-proxy-bucket","path/to/proxy.mp3")
+      there was one(s3ClientMgr).getS3Client(null,Some("region-name"))
+      val expectedProxyRecord = ProxyLocation("c29tZS1idWNrZXQ6cGF0aC90by9tZWRpYS53YXY=","YS1wcm94eS1idWNrZXQ6cGF0aC90by9wcm94eS5tcDM=",ProxyType.AUDIO,"a-proxy-bucket","path/to/proxy.mp3", Some("region-name"), StorageClass.STANDARD)
+      there was one(proxyTargetDAO).saveProxy(org.mockito.ArgumentMatchers.eq(expectedProxyRecord))(org.mockito.ArgumentMatchers.eq(null))
+      there was one(mockedIndexer).getById(org.mockito.ArgumentMatchers.eq("some-item-id"))(any)
+      there was one(mockedIndexer).indexSingleItem(any,any,any)(any)
+    }
+
+    "return a Conflict if the requested proxy bucket is not the one for the item's media bucket" in {
+      val config = Configuration.from(Map("externalData.indexName"->"testindex"))
+      val cc = mock[ControllerComponents]
+      val scanTargetDAO = mock[ScanTargetDAO]
+      val proxyTargetDAO = mock[ProxyLocationDAO]
+      proxyTargetDAO.saveProxy(any)(any) returns Future(None)
+      val mockS3Client = mock[AmazonS3]
+      mockS3Client.doesObjectExist(any,any) returns true
+      mockS3Client.getRegionName returns "region-name"
+      val mockedObjectMetadata = mock[ObjectMetadata]
+      mockS3Client.getObjectMetadata(any,any) returns mockedObjectMetadata
+
+      val mockedIndexer = mock[Indexer]
+      val mockedIndexerFactory = mock[IndexerFactory]
+      mockedIndexerFactory.get() returns mockedIndexer
+
+      val s3ClientMgr = mock[S3ClientManager]
+      s3ClientMgr.getS3Client(any,any) returns mockS3Client
+
+      val esClientMgr = mock[ESClientManager]
+      val ddbClientMgr = mock[DynamoClientManager]
+      val probe = TestProbe()
+
+      val toTest = new ImportController(config, cc, scanTargetDAO,
+        proxyTargetDAO, s3ClientMgr, esClientMgr,
+        mock[BearerTokenAuth], mock[SyncCacheApi], ddbClientMgr, mockedIndexerFactory, probe.ref)
+
+      val req = ProxyImportRequest(
+        "some-item-id",
+        "path/to/proxy.mp3",
+        Some("a-proxy-bucket"),
+        ProxyType.AUDIO,
+        None
+      )
+
+      val item = ArchiveEntry("some-item-id","some-bucket","path/to/media.wav",Some("region-name"), Some(".wav"),
+        1234L, ZonedDateTime.now(),"", MimeType("audio","wav"), false, StorageClass.STANDARD, Seq(), mediaMetadata=None)
+
+      mockedIndexer.getById(any)(any) returns Future(item)
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("some-item-id"))
+
+      val existingProxies = List()
+      val result = Await.result(toTest.checkAndPerformProxyImport(req, item, "different-proxy-bucket", existingProxies), 2.seconds)
+
+      result.header.status mustEqual 409
+      there was no(mockS3Client).doesObjectExist("a-proxy-bucket","path/to/proxy.mp3")
+      there was no(s3ClientMgr).getS3Client(null,Some("region-name"))
+      there was no(proxyTargetDAO).saveProxy(any)(org.mockito.ArgumentMatchers.eq(null))
+      there was no(mockedIndexer).getById(org.mockito.ArgumentMatchers.eq("some-item-id"))(any)
+      there was no(mockedIndexer).indexSingleItem(any,any,any)(any)
+    }
+
+    "return Bad Request if the requested proxy does not exist" in {
+      val config = Configuration.from(Map("externalData.indexName"->"testindex"))
+      val cc = mock[ControllerComponents]
+      val scanTargetDAO = mock[ScanTargetDAO]
+      val proxyTargetDAO = mock[ProxyLocationDAO]
+      proxyTargetDAO.saveProxy(any)(any) returns Future(None)
+      val mockS3Client = mock[AmazonS3]
+      mockS3Client.doesObjectExist(any,any) returns false
+      mockS3Client.getRegionName returns "region-name"
+      val mockedObjectMetadata = mock[ObjectMetadata]
+      mockS3Client.getObjectMetadata(any,any) throws new RuntimeException("the file does not exist, this should not be called")
+
+      val mockedIndexer = mock[Indexer]
+      val mockedIndexerFactory = mock[IndexerFactory]
+      mockedIndexerFactory.get() returns mockedIndexer
+
+      val s3ClientMgr = mock[S3ClientManager]
+      s3ClientMgr.getS3Client(any,any) returns mockS3Client
+
+      val esClientMgr = mock[ESClientManager]
+      val ddbClientMgr = mock[DynamoClientManager]
+      val probe = TestProbe()
+
+      val toTest = new ImportController(config, cc, scanTargetDAO,
+        proxyTargetDAO, s3ClientMgr, esClientMgr,
+        mock[BearerTokenAuth], mock[SyncCacheApi], ddbClientMgr, mockedIndexerFactory, probe.ref)
+
+      val req = ProxyImportRequest(
+        "some-item-id",
+        "path/to/proxy.mp3",
+        Some("a-proxy-bucket"),
+        ProxyType.AUDIO,
+        None
+      )
+
+      val item = ArchiveEntry("some-item-id","some-bucket","path/to/media.wav",Some("region-name"), Some(".wav"),
+        1234L, ZonedDateTime.now(),"", MimeType("audio","wav"), false, StorageClass.STANDARD, Seq(), mediaMetadata=None)
+
+      mockedIndexer.getById(any)(any) returns Future(item)
+      mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("some-item-id"))
+
+      val existingProxies = List()
+      val result = Await.result(toTest.checkAndPerformProxyImport(req, item, "a-proxy-bucket", existingProxies), 2.seconds)
+
+      result.header.status mustEqual 400
+      there was one(mockS3Client).doesObjectExist("a-proxy-bucket","path/to/proxy.mp3")
+      there was one(s3ClientMgr).getS3Client(null,Some("region-name"))
+      there was no(proxyTargetDAO).saveProxy(any)(org.mockito.ArgumentMatchers.eq(null))
+      there was no(mockedIndexer).getById(any)(any)
+      there was no(mockedIndexer).indexSingleItem(any,any,any)(any)
+    }
+
+  }
+}


### PR DESCRIPTION
## What does this change?
A new endpoint is provided to attach a newly uploaded proxy file to an existing record. This is required for Storagetier integration.

## How to test
Perform an authenticated POST request to /api/importProxy, with a JSON payload as follows:
```json
{
  "itemId": "valid-item-id",
  "proxyPath": "path/to/proxyfile",
  "proxyBucket": "bucket-of-proxyfile",
  "proxyType": "THUMBNAIL"|"VIDEO"|"AUDIO"
}
```

- If the item is not found you should get a 404
- If the proxy path does not exist you should get a 400
- If the proxy bucket is not the one set up as the designated proxy storage corresponding to the media bucket of the given item, you should get a 409
- If there is already a proxy of the given type present on the item, you should get a 409.
- Otherwise you should get a 200 OK

## How can we measure success?
Storagetier integration works

## Have we considered potential risks?
None apparent
