### PR TITLE
Error Messages for Failed Log In Attempts

### DIFF
--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -252,8 +252,8 @@ class Auth @Inject() (config:Configuration,
   private def isErrorPresent(response: Either[String, JWTClaimsSet]) = {
     response match {
       case Left(err)=>
-        val numberPattern: Regex = "(?<=\\().*(?=\\))".r
-        Future("?error=%s".format((numberPattern findFirstIn err).get))
+        val stringPattern: Regex = "(?<=\\().*(?=\\))".r
+        Future("?error=%s".format((stringPattern findFirstIn err).get))
       case Right(claims)=>
         Future(s"")
     }

--- a/frontend/app/LoginComponent.tsx
+++ b/frontend/app/LoginComponent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState, useEffect} from "react";
 import {Button, Grid, makeStyles, Paper, Typography} from "@material-ui/core";
 import clsx from "clsx";
 import {ChevronRight} from "@material-ui/icons";
@@ -22,12 +22,24 @@ const useStyles = makeStyles((theme)=>({
         marginRight: "auto",
         marginTop: "10em",
     },
+    errorText: {
+        marginLeft: "1em",
+        marginRight: "1em",
+    },
 }));
 
 const LoginComponent = ()=>{
     const classes = useStyles();
+    const [lastError, setLastError] = useState<string|undefined>(undefined);
 
     const doLogin = ()=>window.location.href = "/login";
+
+    useEffect(() => {
+        const dataToTest = new URLSearchParams(window.location.search).get("error");
+        if (dataToTest) {
+            setLastError(dataToTest)
+        }
+    }, []);
 
     return (
         <Paper className={clsx(classes.actionPanel, classes.loginBox)}>
@@ -48,6 +60,19 @@ const LoginComponent = ()=>{
                         Log me in
                     </Button>
                 </Grid>
+                {lastError ?
+                    <>
+                        <Grid item>
+                            <Typography>
+                                An error occurred when attempting to log you in.
+                            </Typography>
+                        </Grid>
+                        <Grid item className={classes.errorText}>
+                            <Typography>
+                                {lastError}
+                            </Typography>
+                        </Grid>
+                    </> : null}
             </Grid>
         </Paper>
     );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest  --unhandled-rejections=strict",
-    "dev": "webpack --mode development --watch",
-    "build": "webpack --mode production"
+    "dev": "webpack --mode development --watch --openssl-legacy-provider",
+    "build": "webpack --mode production --openssl-legacy-provider"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest  --unhandled-rejections=strict",
-    "dev": "webpack --mode development --watch --openssl-legacy-provider",
-    "build": "webpack --mode production --openssl-legacy-provider"
+    "dev": "webpack --mode development --watch",
+    "build": "webpack --mode production"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,7 +88,7 @@
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
     "uuid": "^3.4.0",
-    "webpack": "^5.0.0",
+    "webpack": "^5.61.0",
     "webpack-cli": "^4.5.0",
     "yarn": "^1.22.10"
   },

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -9,8 +9,7 @@ var config = {
     entry: APP_DIR + '/index.tsx',
     output: {
         path: BUILD_DIR,
-        filename: 'bundle.js',
-        hashFunction: "xxhash64"
+        filename: 'bundle.js'
     },
     resolve: {
         extensions: [".ts", ".tsx", ".js", ".jsx"],

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -9,7 +9,8 @@ var config = {
     entry: APP_DIR + '/index.tsx',
     output: {
         path: BUILD_DIR,
-        filename: 'bundle.js'
+        filename: 'bundle.js',
+        hashFunction: "xxhash64"
     },
     resolve: {
         extensions: [".ts", ".tsx", ".js", ".jsx"],


### PR DESCRIPTION
## What does this change?

Adds error messages in the GUI if a log in attempt fails.

Also fixes webpack builds by using a later webpack version.

## How to test

To test with a local version of KeyCloak, break your admin claim setup by changing the string from 'multimedia_admin' to something like 'multimedia_admin_test'. This should allow you to see error messages when you attempt to log in.

## How can we measure success?

Log in error messages are displayed to users when log in attempts fail.

## Images

![image](https://user-images.githubusercontent.com/10620802/143477989-473ac632-5eae-4884-a5bf-2eef67d7b57a.png)
