### PR TITLE
Filter for Browse and Lightbox Pages

### DIFF
--- a/frontend/app/Lightbox/NewLightbox.tsx
+++ b/frontend/app/Lightbox/NewLightbox.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles({
     browserWindow: {
         display: "grid",
         gridTemplateColumns: "repeat(20, 5%)",
-        gridTemplateRows: "[top] 40px [title-area] 130px [filter-area] 80px [info-area] auto [bottom]",
+        gridTemplateRows: "[top] 40px [title-area] 200px [filter-area] 80px [info-area] auto [bottom]",
         height: "95vh"
     },
     userNameBox: {

--- a/frontend/app/Lightbox/NewLightbox.tsx
+++ b/frontend/app/Lightbox/NewLightbox.tsx
@@ -18,12 +18,13 @@ import MuiAlert from "@material-ui/lab/Alert";
 import EntryDetails from "../Entry/EntryDetails";
 import LightboxDetailsInsert from "./LightboxDetailsInsert";
 import {UserContext} from "../Context/UserContext";
+import BrowseFilter from "../browse/BrowseFilter";
 
 const useStyles = makeStyles({
     browserWindow: {
         display: "grid",
         gridTemplateColumns: "repeat(20, 5%)",
-        gridTemplateRows: "[top] 40px [title-area] 200px [info-area] auto [bottom]",
+        gridTemplateRows: "[top] 40px [title-area] 130px [filter-area] 80px [info-area] auto [bottom]",
         height: "95vh"
     },
     userNameBox: {
@@ -47,7 +48,7 @@ const useStyles = makeStyles({
         gridColumnStart: 1,
         gridColumnEnd: -5,
         gridRowStart: "title-area",
-        gridRowEnd: "info-area",
+        gridRowEnd: "filter-area",
         overflowY: "hidden",
         overflowX: "auto"
     },
@@ -65,6 +66,13 @@ const useStyles = makeStyles({
         gridRowEnd: "bottom",
         padding: "1em",
         borderLeft: "1px"
+    },
+    filterArea: {
+        gridColumnStart: 1,
+        gridColumnEnd: -5,
+        gridRowStart: "filter-area",
+        gridRowEnd: "info-area",
+        padding: "1em"
     }
 });
 
@@ -89,6 +97,7 @@ const NewLightbox:React.FC<RouteComponentProps> = (props) => {
     const [itemLimit, setItemLimit] = useState(300);
     const [basicSearchUrl, setBasicSearchUrl] = useState<string|undefined>(undefined);
     const [showingArchiveSpinner, setShowingArchiveSpinner] = useState(false);
+    const [filterString, setFilterString] = useState<string>("");
 
     const userContext = useContext(UserContext);
 
@@ -216,7 +225,10 @@ const NewLightbox:React.FC<RouteComponentProps> = (props) => {
                                   onError={handleComponentError}
             />
         </div>
-
+        <div className={classes.filterArea}>
+        <BrowseFilter filterString={filterString}
+                      filterStringChanged={(newString)=>setFilterString(newString)}/>
+        </div>
         <div className={classes.itemsArea}>
             <NewSearchComponent pageSize={pageSize}
                                 itemLimit={itemLimit}
@@ -225,6 +237,7 @@ const NewLightbox:React.FC<RouteComponentProps> = (props) => {
                                 selectedEntry={selectedEntry}
                                 onEntryClicked={(newEntry)=>setSelectedEntry(newEntry)}
                                 onErrorOccurred={handleComponentError}
+                                filterString={filterString}
             />
         </div>
 

--- a/frontend/app/browse/BrowseFilter.tsx
+++ b/frontend/app/browse/BrowseFilter.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import {
-    FormControlLabel,
     Grid,
     makeStyles,
-    MenuItem,
-    Radio,
-    RadioGroup,
-    Select,
     Typography,
     Input
 } from "@material-ui/core";

--- a/frontend/app/browse/BrowseFilter.tsx
+++ b/frontend/app/browse/BrowseFilter.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import {
+    FormControlLabel,
+    Grid,
+    makeStyles,
+    MenuItem,
+    Radio,
+    RadioGroup,
+    Select,
+    Typography,
+    Input
+} from "@material-ui/core";
+
+interface BrowseFilterProps {
+    filterString: string;
+    filterStringChanged: (newString:string)=>void;
+}
+
+const useStyles = makeStyles({
+    selector: {
+        width: "100%"
+    }
+});
+
+const BrowseFilter:React.FC<BrowseFilterProps> = (props) => {
+    const classes = useStyles();
+
+    return <Grid container direction="column" >
+        <Grid item>
+            <Typography variant="h6">Filter</Typography>
+        </Grid>
+        <Grid item>
+            <Input id="filter-input" value={props.filterString} onChange={(evt) => props.filterStringChanged(evt.target.value as string)} />
+        </Grid>
+    </Grid>
+}
+
+export default BrowseFilter;

--- a/frontend/app/browse/NewBrowseComponent.tsx
+++ b/frontend/app/browse/NewBrowseComponent.tsx
@@ -13,6 +13,7 @@ import EntryDetails from "../Entry/EntryDetails";
 import BoxSizing from "../common/BoxSizing";
 import {urlParamsFromSearch} from "../common/UrlPathHelpers";
 import Helmet from "react-helmet";
+import BrowseFilter from "./BrowseFilter";
 
 const useStyles = makeStyles({
     browserWindow: {
@@ -63,7 +64,15 @@ const useStyles = makeStyles({
         gridRowStart: "top",
         gridRowEnd: "bottom",
         overflow: "hidden", //scrollbars are displayed by the child component
-    }
+    },
+    filterArea: {
+        gridColumnStart: 6,
+        gridColumnEnd: 8,
+        gridRowStart: "top",
+        gridRowEnd: "info-area",
+        padding: "1em",
+        overflow: "hidden"
+    },
 });
 
 const NewBrowseComponent:React.FC<RouteComponentProps> = (props) => {
@@ -89,6 +98,7 @@ const NewBrowseComponent:React.FC<RouteComponentProps> = (props) => {
     const [rightDividerPos, setRightDividerPos] = useState(-4);
 
     const classes = useStyles();
+    const [filterString, setFilterString] = useState<string>("");
 
     const refreshCollectionNames = async () => {
         try {
@@ -245,6 +255,10 @@ const NewBrowseComponent:React.FC<RouteComponentProps> = (props) => {
                              orderChanged={(newOrder)=>setSortOrder(newOrder)}
                              fieldChanged={(newField)=>setSortField(newField)}/>
         </div>
+        <div className={classes.filterArea}>
+            <BrowseFilter filterString={filterString}
+                             filterStringChanged={(newString)=>setFilterString(newString)}/>
+        </div>
         <div className={classes.pathSelector} style={{gridColumnEnd: leftDividerPos}}>
             <BoxSizing justify="right"
                        onRightClicked={()=>setLeftDividerPos((prev)=>prev+1)}
@@ -279,6 +293,7 @@ const NewBrowseComponent:React.FC<RouteComponentProps> = (props) => {
                                 onLoadingStarted={()=>setLoading(true)}
                                 onLoadingFinished={loadingDidComplete}
                                 extraRequiredItemId={urlRequestedItem}
+                                filterString={filterString}
             />
         </div>
         <div className={classes.detailsArea} style={{gridColumnStart: rightDividerPos}}>

--- a/frontend/app/common/NewSearchComponent.tsx
+++ b/frontend/app/common/NewSearchComponent.tsx
@@ -18,6 +18,7 @@ interface NewSearchComponentProps {
     onLoadingStarted?: ()=>void;
     onLoadingFinished?: (loadedData:ArchiveEntry[])=>void;
     extraRequiredItemId?: string;         //if the container wants to be sure certain items are loaded, given that they exist, put the id here
+    filterString?: string;
 }
 
 const useStyles = makeStyles({
@@ -45,6 +46,13 @@ const NewSearchComponent:React.FC<NewSearchComponentProps> = (props) => {
 
     const [cancelToken, setCancelToken] = useState<CancelToken|undefined>(undefined);
     const classes = useStyles();
+    const [localFilter, setLocalFilter] = useState<string>("");
+
+    useEffect(()=>{
+        if((props.filterString) || (props.filterString == "")) {
+            setLocalFilter(props.filterString);
+        }
+    }, [props.filterString]);
 
     const makeSearchRequest = (token:CancelToken, startAt: number):Promise<AxiosResponse<SearchResponse>> => {
         if(props.advancedSearch) {
@@ -215,7 +223,7 @@ const NewSearchComponent:React.FC<NewSearchComponentProps> = (props) => {
 
     return <Grid container className={classes.searchResultsContainer}>
         {
-            entries.map((entry,idx)=><EntryView
+            entries.filter(entry => entry.path.toLowerCase().includes(localFilter.toLowerCase())).map((entry,idx)=><EntryView
                                                 key={idx}
                                                 isSelected={ props.selectedEntry ? props.selectedEntry.id===entry.id : false}
                                                 entry={entry}


### PR DESCRIPTION
## What does this change?

Adds a simple string filter to the Browse and Lightbox pages which works on the path.

## How to test

Run the new code using IDEA. The filter should show up and work on the Browse and Lightbox pages.

## How can we measure success?

Users should be able to use the new filters.

## Images

![image](https://user-images.githubusercontent.com/10620802/146402108-04217d3a-d592-4a3f-ad8e-2547fcbf0a7a.png)

![image](https://user-images.githubusercontent.com/10620802/146402179-5696a4e3-60cf-4994-a411-3c2e89e3c936.png)


