### PR TITLE
update to latest log4j... again...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,9 @@ val jacksonCoreVersion = "2.9.10.8"
 lazy val commonSettings = Seq(
   version := "1.0",
   scalaVersion := "2.12.2",
-  libraryDependencies ++= Seq("org.apache.logging.log4j" % "log4j-core" % "2.15.0",
+  libraryDependencies ++= Seq("org.apache.logging.log4j" % "log4j-core" % "2.17.1",
     "com.beust" % "jcommander" % "1.75", //snyk identified as vulnerable
-    "org.apache.logging.log4j" % "log4j-api" % "2.15.0",
+    "org.apache.logging.log4j" % "log4j-api" % "2.17.1",
     "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0",
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-elastictranscoder"% awsSdkVersion,
@@ -70,7 +70,7 @@ lazy val `archivehunter` = (project in file("."))
       "com.nimbusds" % "nimbus-jose-jwt" % "9.11.1",
       "com.gu" % "kinesis-logback-appender" % "2.0.1",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.11.4",  //fix vulnerable dependency for kinesis-logback-appender
-      "org.apache.logging.log4j" % "log4j-api" % "2.15.0",
+      "org.apache.logging.log4j" % "log4j-api" % "2.17.1",
       "com.typesafe.akka" %% "akka-testkit" % akkaVersion,
       "io.sentry" % "sentry-logback" % "1.7.2",
       guice, ehcache, ws)
@@ -104,9 +104,9 @@ lazy val inputLambda = (project in file("lambda/input"))
   .settings(commonSettings,
   // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-lambda
   libraryDependencies ++= Seq(
-    "org.apache.logging.log4j" % "log4j-core" % "2.15.0",
-    "org.apache.logging.log4j" % "log4j-api" % "2.15.0",
-    "org.apache.logging.log4j" % "log4j-1.2-api" % "2.15.0",
+    "org.apache.logging.log4j" % "log4j-core" % "2.17.1",
+    "org.apache.logging.log4j" % "log4j-api" % "2.17.1",
+    "org.apache.logging.log4j" % "log4j-1.2-api" % "2.17.1",
     "com.sksamuel.elastic4s" %% "elastic4s-http" % elastic4sVersion,
     "com.sksamuel.elastic4s" %% "elastic4s-circe" % elastic4sVersion,
     "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test",


### PR DESCRIPTION
## What does this change?

bumps log4j to latest, 2.17

## How to test

roll out and check no problems

## How can we measure success?
Snyk errors go away :smiley: 