### PR TITLE
Fix / deprecated ActorMaterializer

### DIFF
--- a/ProxyStatsGathering/src/main/scala/MainContent.scala
+++ b/ProxyStatsGathering/src/main/scala/MainContent.scala
@@ -19,7 +19,7 @@ trait MainContent extends ProblemItemRequestBuilder with ProblemItemHitReader{
   import com.sksamuel.elastic4s.streams.ReactiveElastic._
 
   implicit val system:ActorSystem = ActorSystem("root")
-  implicit val mat:Materializer = ActorMaterializer.create(system)
+  implicit val mat:Materializer = Materializer.matFromSystem
 
   protected val injector = Guice.createInjector(new Module(system))
 

--- a/app/controllers/BulkDownloadsController.scala
+++ b/app/controllers/BulkDownloadsController.scala
@@ -50,7 +50,7 @@ class BulkDownloadsController @Inject()(override val config:Configuration,
                                         cc:ControllerComponents,
                                         override val bearerTokenAuth:BearerTokenAuth,
                                         @Named("glacierRestoreActor") glacierRestoreActor:ActorRef,
-                                       )(implicit system:ActorSystem)
+                                       )(implicit system:ActorSystem, mat:Materializer)
   extends AbstractController(cc) with Security with Circe with ArchiveEntryHitReader with ZonedDateTimeEncoder with RestoreStatusEncoder {
 
   override protected val logger=LoggerFactory.getLogger(getClass)
@@ -66,8 +66,6 @@ class BulkDownloadsController @Inject()(override val config:Configuration,
   protected implicit val esClient = esClientManager.getClient()
 
   private val indexer = new Indexer(config.get[String]("externalData.indexName"))
-
-  private implicit val mat:Materializer = ActorMaterializer.create(system)
 
   private def errorResponse(updatedToken:ServerTokenEntry) = serverTokenDAO
     .put(updatedToken)

--- a/app/controllers/LightboxController.scala
+++ b/app/controllers/LightboxController.scala
@@ -48,6 +48,7 @@ class LightboxController @Inject() (override val config:Configuration,
                                     dynamoClientManager:DynamoClientManager,
                                     userAvatarHelper:UserAvatarHelper)
                                    (implicit val system:ActorSystem,
+                                    mat:Materializer,
                                     injector:Injector,
                                     lightboxEntryDAO: LightboxEntryDAO,
                                     userProfileDAO: UserProfileDAO)
@@ -59,7 +60,6 @@ class LightboxController @Inject() (override val config:Configuration,
   private val s3Client = s3ClientMgr.getClient(awsProfile)
   private implicit val ec:ExecutionContext  = controllerComponents.executionContext
   private val indexName = config.get[String]("externalData.indexName")
-  private implicit val mat:Materializer = ActorMaterializer.create(system)
 
   implicit val timeout:akka.util.Timeout = 30 seconds
 

--- a/app/controllers/ProxiesController.scala
+++ b/app/controllers/ProxiesController.scala
@@ -49,10 +49,10 @@ class ProxiesController @Inject()(override val config:Configuration,
                                   override val bearerTokenAuth:BearerTokenAuth,
                                   override val cache:SyncCacheApi,
                                   @Named("proxiesRelinker") proxiesRelinker:ActorRef)
-                                 (implicit actorSystem:ActorSystem, scanTargetDAO:ScanTargetDAO, jobModelDAO:JobModelDAO, proxyLocationDAO:ProxyLocationDAO)
+                                 (implicit actorSystem:ActorSystem, mat:Materializer, scanTargetDAO:ScanTargetDAO, jobModelDAO:JobModelDAO, proxyLocationDAO:ProxyLocationDAO)
   extends AbstractController(controllerComponents) with Circe with ProxyLocationEncoder with Security {
   import akka.pattern.ask
-  implicit private val mat:Materializer = ActorMaterializer.create(actorSystem)
+
   override protected val logger=LoggerFactory.getLogger(getClass)
 
   private val indexName = config.getOptional[String]("elasticsearch.index").getOrElse("archivehunter")

--- a/app/controllers/ScanTargetController.scala
+++ b/app/controllers/ScanTargetController.scala
@@ -43,10 +43,9 @@ class ScanTargetController @Inject() (@Named("bucketScannerActor") bucketScanner
                                       proxyGenerators:ProxyGenerators,
                                       scanTargetDAO:ScanTargetDAO,
                                       jobModelDAO:JobModelDAO)
-                                     (implicit system:ActorSystem)
+                                     (implicit system:ActorSystem, mat:Materializer)
   extends AbstractController(controllerComponents) with Security with Circe with ZonedDateTimeEncoder with ZonedTimeFormat with JobModelEncoder {
   override protected val logger=LoggerFactory.getLogger(getClass)
-  implicit val mat:Materializer = ActorMaterializer.create(system)
 
   val table = Table[ScanTarget](config.get[String]("externalData.scanTargets"))
 

--- a/app/helpers/HasThumbnailFilter.scala
+++ b/app/helpers/HasThumbnailFilter.scala
@@ -18,12 +18,10 @@ import scala.concurrent.duration._
   * @param ddbClientManager injected [[DynamoClientManager]] instance
   * @param config injected [[ArchiveHunterConfiguration]] instance
   */
-class HasThumbnailFilter @Inject() (ddbClientManager:DynamoClientManager, config:ArchiveHunterConfiguration, proxyLocationDAO: ProxyLocationDAO)(implicit system:ActorSystem) extends GraphStage[FlowShape[ArchiveEntry,ArchiveEntry]]{
+class HasThumbnailFilter @Inject() (ddbClientManager:DynamoClientManager, config:ArchiveHunterConfiguration, proxyLocationDAO: ProxyLocationDAO)(implicit system:ActorSystem, mat:Materializer) extends GraphStage[FlowShape[ArchiveEntry,ArchiveEntry]]{
   private final val in:Inlet[ArchiveEntry] = Inlet.create("HasProxyFilter.in")
   private final val out:Outlet[ArchiveEntry] = Outlet.create("HasProxyFilter.out")
   private val logger = Logger(getClass)
-
-  private implicit val mat:Materializer = ActorMaterializer.create(system)
 
   override def shape: FlowShape[ArchiveEntry, ArchiveEntry] = FlowShape.of(in,out)
 

--- a/app/helpers/ProxyVerifyFlow.scala
+++ b/app/helpers/ProxyVerifyFlow.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
   * @param ddbClientMgr
   * @param proxyLocationDAO
   */
-class ProxyVerifyFlow @Inject()(config:Configuration, ddbClientMgr:DynamoClientManager)(implicit system:ActorSystem, proxyLocationDAO: ProxyLocationDAO) extends GraphStage[FlowShape[ArchiveEntry,ArchiveEntry]]{
+class ProxyVerifyFlow @Inject()(config:Configuration, ddbClientMgr:DynamoClientManager)(implicit system:ActorSystem, proxyLocationDAO: ProxyLocationDAO, mat:Materializer) extends GraphStage[FlowShape[ArchiveEntry,ArchiveEntry]]{
   private val in:Inlet[ArchiveEntry] = Inlet.create("ProxyVerifyFlow.in")
   private val out:Outlet[ArchiveEntry] = Outlet.create("ProxyVerifyFlow.in")
 
@@ -28,7 +28,6 @@ class ProxyVerifyFlow @Inject()(config:Configuration, ddbClientMgr:DynamoClientM
   val logger = Logger(getClass)
 
   private implicit val ec:ExecutionContext = system.dispatcher
-  private implicit val mat:Materializer = ActorMaterializer.create(system)
 
   override def shape: FlowShape[ArchiveEntry, ArchiveEntry] = FlowShape.of(in,out)
 

--- a/app/services/BucketScanner.scala
+++ b/app/services/BucketScanner.scala
@@ -38,7 +38,7 @@ object BucketScanner {
 @Singleton
 class BucketScanner @Inject()(override val config:Configuration, ddbClientMgr:DynamoClientManager, s3ClientMgr:S3ClientManager,
                               esClientMgr:ESClientManager, scanTargetDAO: ScanTargetDAO, jobModelDAO:JobModelDAO,
-                              injector:Injector)(implicit system:ActorSystem)
+                              injector:Injector)(implicit system:ActorSystem, mat:Materializer)
   extends Actor with BucketScannerFunctions with ZonedTimeFormat with ArchiveEntryRequestBuilder{
   import BucketScanner._
 
@@ -47,7 +47,6 @@ class BucketScanner @Inject()(override val config:Configuration, ddbClientMgr:Dy
 
   protected val logger=Logger(getClass)
 
-  implicit val mat = ActorMaterializer.create(system)
   implicit val ec:ExecutionContext = system.dispatcher
 
   override val indexName: String = config.get[String]("externalData.indexName")

--- a/app/services/BulkThumbnailer.scala
+++ b/app/services/BulkThumbnailer.scala
@@ -34,7 +34,7 @@ object BulkThumbnailer {
 @Singleton
 class BulkThumbnailer @Inject() (@Named("dynamoCapacityActor") dynamoCapacityActor: ActorRef,
                                   ESClientManager: ESClientManager, hasThumbnailFilter: HasThumbnailFilter,
-                                 createProxySink: CreateProxySink, config:ArchiveHunterConfiguration, system:ActorSystem)
+                                 createProxySink: CreateProxySink, config:ArchiveHunterConfiguration, system:ActorSystem)(implicit mat:Materializer)
   extends Actor{
 
   import com.sksamuel.elastic4s.streams.ReactiveElastic._
@@ -49,7 +49,6 @@ class BulkThumbnailer @Inject() (@Named("dynamoCapacityActor") dynamoCapacityAct
   val jobHistoryTableName = config.get[String]("externalData.jobTable")
   val scanTargetTableName = config.get[String]("externalData.scanTargets")
 
-  implicit val mat:Materializer = ActorMaterializer.create(system)
   implicit val ec:ExecutionContext = system.dispatcher
 
   override def receive: Receive = {

--- a/app/services/IngestProxyQueue.scala
+++ b/app/services/IngestProxyQueue.scala
@@ -40,7 +40,7 @@ class IngestProxyQueue @Inject()(config: Configuration,
                                  s3ClientMgr: S3ClientManager,
                                  dynamoClientMgr: DynamoClientManager,
                                  esClientMgr:ESClientManager,
-                                )(implicit scanTargetDAO: ScanTargetDAO, proxyLocationDAO: ProxyLocationDAO)
+                                )(implicit scanTargetDAO: ScanTargetDAO, proxyLocationDAO: ProxyLocationDAO, override val mat:Materializer)
   extends GenericSqsActor[IngestMessage] with ZonedDateTimeEncoder with StorageClassEncoder {
 
   import IngestProxyQueue._
@@ -51,7 +51,6 @@ class IngestProxyQueue @Inject()(config: Configuration,
   lazy override protected val sqsClient = sqsClientManager.getClient(config.getOptional[String]("externalData.awsProfile"))
 
   override protected implicit val implSystem = system
-  override protected implicit val mat: Materializer = ActorMaterializer.create(system)
 
   private implicit val esClient = esClientMgr.getClient()
   lazy protected implicit val indexer = new Indexer(config.get[String]("externalData.indexName"))

--- a/app/services/LegacyProxiesScanner.scala
+++ b/app/services/LegacyProxiesScanner.scala
@@ -2,7 +2,7 @@ package services
 
 import akka.actor.{Actor, ActorSystem, Cancellable}
 import akka.stream.scaladsl.{Keep, Source}
-import akka.stream.{ActorMaterializer, KillSwitches}
+import akka.stream.{ActorMaterializer, KillSwitches, Materializer}
 import com.theguardian.multimedia.archivehunter.common.clientManagers.{DynamoClientManager, ESClientManager, S3ClientManager}
 import com.google.inject.Injector
 import com.theguardian.multimedia.archivehunter.common.ProxyLocation
@@ -30,13 +30,12 @@ object LegacyProxiesScanner {
 
 @Singleton
 class LegacyProxiesScanner @Inject()(config:Configuration, ddbClientMgr:DynamoClientManager, s3ClientMgr:S3ClientManager,
-                                     esClientMgr:ESClientManager, scanTargetDAO: ScanTargetDAO, injector:Injector)(implicit system:ActorSystem)extends Actor {
+                                     esClientMgr:ESClientManager, scanTargetDAO: ScanTargetDAO, injector:Injector)(implicit system:ActorSystem, mat:Materializer)extends Actor {
   import LegacyProxiesScanner._
   import com.sksamuel.elastic4s.streams.ReactiveElastic._
   import com.sksamuel.elastic4s.http.ElasticDsl._
 
   private val logger = Logger(getClass)
-  implicit val mat = ActorMaterializer.create(system)
   val indexName = config.getOptional[String]("elasticsearch.index").getOrElse("archivehunter")
   val tableName = config.get[String]("proxies.tableName")
 

--- a/app/services/ProblemItemRetry.scala
+++ b/app/services/ProblemItemRetry.scala
@@ -33,12 +33,11 @@ object ProblemItemRetry {
 class ProblemItemRetry @Inject()(config:Configuration, proxyGenerators:ProxyGenerators,
                                  esClientManager:ESClientManager, jobModelDAO:JobModelDAO,
                                  problemItemReproxySink: ProblemItemReproxySink)
-                                (implicit actorSystem: ActorSystem, proxyLocationDAO:ProxyLocationDAO) extends Actor with ProblemItemHitReader{
+                                (implicit actorSystem: ActorSystem, proxyLocationDAO:ProxyLocationDAO, mat:Materializer) extends Actor with ProblemItemHitReader{
   import ProblemItemRetry._
 
   private val logger=Logger(getClass)
 
-  implicit val mat:Materializer = ActorMaterializer.create(actorSystem)
   private val problemItemIndexName = config.get[String]("externalData.problemItemsIndex")
   private val problemItemIndexer = new ProblemItemIndexer(problemItemIndexName)
 

--- a/app/services/ProxiesRelinker.scala
+++ b/app/services/ProxiesRelinker.scala
@@ -39,6 +39,7 @@ object ProxiesRelinker {
 class ProxiesRelinker @Inject() (config:Configuration,
                                  esClientMgr:ESClientManager, ddbClientMgr:DynamoClientManager, system:ActorSystem,
                                  proxyVerifyFlow: ProxyVerifyFlow, jobModelDAO:JobModelDAO, scanTargetDAO:ScanTargetDAO)
+                                (implicit mat:Materializer)
   extends Actor with ArchiveEntryRequestBuilder {
   import ProxiesRelinker._
   import com.sksamuel.elastic4s.http.ElasticDsl._
@@ -46,7 +47,6 @@ class ProxiesRelinker @Inject() (config:Configuration,
   private val logger = Logger(getClass)
   override val indexName = config.get[String]("externalData.indexName")
   private val indexer = new Indexer(indexName)
-  private implicit val mat:Materializer = ActorMaterializer.create(system)
   private val esClient = esClientMgr.getClient()
 
   protected def getIndexScanSource(targetBucket:Option[String]) = {

--- a/app/services/ProxyFrameworkQueue.scala
+++ b/app/services/ProxyFrameworkQueue.scala
@@ -73,7 +73,7 @@ class ProxyFrameworkQueue @Inject() (config: Configuration,
                                      jobModelDAO: JobModelDAO,
                                      scanTargetDAO: ScanTargetDAO,
                                      esClientMgr:ESClientManager
-                                    )(implicit proxyLocationDAO: ProxyLocationDAO)
+                                    )(implicit proxyLocationDAO: ProxyLocationDAO, override val mat:Materializer)
   extends GenericSqsActor[JobReportNew] with ProxyFrameworkQueueFunctions {
   import ProxyFrameworkQueue._
   import GenericSqsActor._
@@ -83,7 +83,6 @@ class ProxyFrameworkQueue @Inject() (config: Configuration,
   override protected val sqsClient = sqsClientManager.getClient(config.getOptional[String]("externalData.awsProfile"))
 
   override protected implicit val implSystem = system
-  override protected implicit val mat: Materializer = ActorMaterializer.create(system)
 
   //override this in testing
   protected val ownRef: ActorRef = self

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyTranscodeFramework/ProxyGenerators.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ProxyTranscodeFramework/ProxyGenerators.scala
@@ -35,10 +35,8 @@ class ProxyGenerators @Inject() (config:ArchiveHunterConfiguration,
                                  scanTargetDAO:ScanTargetDAO,
                                  jobModelDAO:JobModelDAO,
                                  proxyFrameworkInstanceDAO: ProxyFrameworkInstanceDAO)
-                                (implicit system:ActorSystem) extends RequestModelEncoder {
+                                (implicit system:ActorSystem, mat:Materializer) extends RequestModelEncoder {
   private implicit val logger = LogManager.getLogger(getClass)
-
-  protected implicit val mat:Materializer = ActorMaterializer.create(system)
 
   protected val awsProfile = config.getOptional[String]("externalData.awsProfile")
   protected implicit val s3Client = s3ClientMgr.getClient(awsProfile)

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/JobModelDAO.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/JobModelDAO.scala
@@ -23,7 +23,7 @@ import javax.inject.{Inject, Singleton}
 import org.apache.logging.log4j.LogManager
 
 @Singleton
-class JobModelDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr: DynamoClientManager)(implicit actorSystem:ActorSystem)
+class JobModelDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr: DynamoClientManager)(implicit actorSystem:ActorSystem, mat:Materializer)
   extends ZonedDateTimeEncoder with ZonedTimeFormat with JobModelEncoder with ExtValueConverters {
 
   private val logger = LogManager.getLogger(getClass)
@@ -36,8 +36,6 @@ class JobModelDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr: Dyn
   val maxRetries = config.getOptional[Int]("externalData.maxRetries").getOrElse(10)
   val initialRetryDelay = config.getOptional[Int]("externalData.initialRetryDelay").getOrElse(2)
   val retryDelayFactor = config.getOptional[Double]("externalData.retryDelayFactor").getOrElse(1.5)
-
-  implicit val mat:Materializer = ActorMaterializer.create(actorSystem)
 
   private val awsProfile = config.getOptional[String]("externalData.awsProfile")
 

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxBulkEntryDAO.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxBulkEntryDAO.scala
@@ -13,12 +13,10 @@ import javax.inject.Inject
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class LightboxBulkEntryDAO @Inject() (config:ArchiveHunterConfiguration, ddbClientMgr:DynamoClientManager)(implicit system:ActorSystem)
+class LightboxBulkEntryDAO @Inject() (config:ArchiveHunterConfiguration, ddbClientMgr:DynamoClientManager)(implicit system:ActorSystem, mat:Materializer)
   extends ZonedDateTimeEncoder with ZonedTimeFormat {
   import org.scanamo.syntax._
   import org.scanamo.generic.auto._
-
-  private implicit val mat:Materializer = ActorMaterializer.create(system)
 
   private val scanamoAlpakka = ScanamoAlpakka(
     ddbClientMgr.getNewAsyncDynamoClient(config.getOptional[String]("externalData.awsProfile"))

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxEntryDAO.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxEntryDAO.scala
@@ -2,7 +2,7 @@ package com.theguardian.multimedia.archivehunter.common.cmn_models
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.Materializer
 import org.scanamo.{DynamoReadError, ScanamoAlpakka, Table}
 import com.theguardian.multimedia.archivehunter.common.{ArchiveHunterConfiguration, ZonedDateTimeEncoder}
 import com.theguardian.multimedia.archivehunter.common.clientManagers.DynamoClientManager
@@ -17,11 +17,10 @@ import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class LightboxEntryDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr:DynamoClientManager)(implicit system:ActorSystem)
+class LightboxEntryDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr:DynamoClientManager)(implicit system:ActorSystem, mat:Materializer)
   extends ZonedDateTimeEncoder with ZonedTimeFormat with RestoreStatusEncoder {
 
   private val logger = LoggerFactory.getLogger(getClass)
-  private implicit val mat:Materializer = ActorMaterializer.create(system)
 
   private val awsProfile = config.getOptional[String]("externalData.awsProfile")
   private val lightboxTableName = config.get[String]("lightbox.tableName")

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/ScanTargetDAO.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/ScanTargetDAO.scala
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.LogManager
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 @Singleton
-class ScanTargetDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr: DynamoClientManager)(implicit actorSystem:ActorSystem)
+class ScanTargetDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr: DynamoClientManager)(implicit actorSystem:ActorSystem, mat:Materializer)
   extends ZonedDateTimeEncoder with ZonedTimeFormat with JobModelEncoder with ExtValueConverters {
   private val logger = LogManager.getLogger(getClass)
 
@@ -32,8 +32,6 @@ class ScanTargetDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr: D
   val maxRetries = config.getOptional[Int]("externalData.maxRetries").getOrElse(10)
   val initialRetryDelay = config.getOptional[Int]("externalData.initialRetryDelay").getOrElse(2)
   val retryDelayFactor = config.getOptional[Double]("externalData.retryDelayFactor").getOrElse(1.5)
-
-  implicit private val materializer:Materializer = ActorMaterializer.create(actorSystem)
 
   val scanamoAlpakka = ScanamoAlpakka(ddbClientMgr.getNewAsyncDynamoClient(config.getOptional[String]("externalData.awsProfile")))
   implicit val ddbClient : DynamoDbClient = ddbClientMgr.getNewDynamoClient(config.getOptional[String]("externalData.awsProfile"))

--- a/test/ProxyFrameworkQueueSpec.scala
+++ b/test/ProxyFrameworkQueueSpec.scala
@@ -53,6 +53,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
       mockedIndexer.getById(any)(any) returns Future(mockedEntry)
       mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("fake-id"))
 
+      implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
       val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
         Configuration.from(Map("proxyFramework.notificationsQueue" -> "someQueue", "externalData.indexName" -> "someIndex", "externalData.problemItemsIndex" -> "problem-items")),
         system,
@@ -62,7 +63,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         mockedJobModelDAO,
         mockedScanTargetDAO,
         mock[ESClientManager]
-      )(mock[ProxyLocationDAO]) {
+      ) {
         override val sqsClient = mockedSqsClient
 
         override def thumbnailJobOriginalMedia(jobDesc: JobModel): Future[Either[String, ArchiveEntry]] = Future(Right(mockedArchiveEntry))
@@ -109,7 +110,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
       mockedIndexer.getById(any)(any) returns Future(mockedEntry)
       mockedIndexer.indexSingleItem(any,any,any)(any) returns Future(Right("fake-id"))
 
-
+      implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
       val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
         Configuration.from(Map("proxyFramework.notificationsQueue" -> "someQueue", "externalData.indexName" -> "someIndex", "externalData.problemItemsIndex" -> "problem-items")),
         system,
@@ -119,7 +120,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         mockedJobModelDAO,
         mockedScanTargetDAO,
         mock[ESClientManager]
-      )(mock[ProxyLocationDAO]) {
+      ){
         override val sqsClient = mockedSqsClient
 
         override def thumbnailJobOriginalMedia(jobDesc: JobModel): Future[Either[String, ArchiveEntry]] = Future(Left("So there"))
@@ -157,6 +158,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
       val mockedSqsClient = mock[AmazonSQS]
       mockedSqsClient.deleteMessage(any) returns new DeleteMessageResult()
 
+      implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
       val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
         Configuration.from(Map("proxyFramework.notificationsQueue" -> "someQueue", "externalData.indexName" -> "someIndex", "externalData.problemItemsIndex" -> "problem-items")),
         system,
@@ -166,7 +168,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         mockedJobModelDAO,
         mockedScanTargetDAO,
         mock[ESClientManager]
-      )(mock[ProxyLocationDAO]) {
+      ) {
         override protected val sqsClient = mockedSqsClient
       }
       ))
@@ -198,6 +200,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
       val mockedSqsClient = mock[AmazonSQS]
       mockedSqsClient.deleteMessage(any) returns new DeleteMessageResult()
 
+      implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
       val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
         Configuration.from(Map(
           "proxyFramework.notificationsQueue" -> "someQueue",
@@ -211,7 +214,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         mockedJobModelDAO,
         mockedScanTargetDAO,
         mock[ESClientManager]
-      )(mock[ProxyLocationDAO]) {
+      ) {
         override protected val sqsClient = mockedSqsClient
       }
       ))
@@ -248,6 +251,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
       val mockedSqsClient = mock[AmazonSQS]
       mockedSqsClient.deleteMessage(any) returns new DeleteMessageResult()
 
+      implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
       val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
         Configuration.from(Map("proxyFramework.notificationsQueue" -> "someQueue", "externalData.indexName" -> "someIndex", "externalData.problemItemsIndex" -> "problem-items")),
         system,
@@ -257,7 +261,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         mockedJobModelDAO,
         mockedScanTargetDAO,
         mock[ESClientManager]
-      )(mock[ProxyLocationDAO]) {
+      ) {
         override protected val sqsClient = mockedSqsClient
         override protected val ownRef = testProbeRef
       }
@@ -294,6 +298,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
       val mockedSqsClient = mock[AmazonSQS]
       mockedSqsClient.deleteMessage(any) returns new DeleteMessageResult()
 
+      implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
       val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
         Configuration.from(Map("proxyFramework.notificationsQueue" -> "someQueue", "externalData.indexName" -> "someIndex", "externalData.problemItemsIndex" -> "problem-items")),
         system,
@@ -303,7 +308,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         mockedJobModelDAO,
         mockedScanTargetDAO,
         mock[ESClientManager]
-      )(mock[ProxyLocationDAO]) {
+      ) {
         override protected val sqsClient = mockedSqsClient
         override protected val ownRef = testProbeRef
       }
@@ -378,6 +383,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         val mockThumnailJobOriginalMedia = mock[Function1[JobModel, Future[Either[String, ArchiveEntry]]]]
         mockThumnailJobOriginalMedia.apply(any) returns Future(Right(mockedArchiveEntry))
 
+        implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
         val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
           Configuration.from(Map("proxyFramework.notificationsQueue" -> "someQueue", "externalData.indexName" -> "someIndex", "externalData.problemItemsIndex" -> "problem-items")),
           system,
@@ -387,7 +393,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
           mockedJobModelDAO,
           mockedScanTargetDAO,
           mock[ESClientManager]
-        )(mock[ProxyLocationDAO]) {
+        ) {
           override protected val sqsClient = mockedSqsClient
 
           override def thumbnailJobOriginalMedia(jobDesc: JobModel): Future[Either[String, ArchiveEntry]] = mockThumnailJobOriginalMedia(jobDesc)
@@ -430,6 +436,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         val mockThumnailJobOriginalMedia = mock[Function1[JobModel, Future[Either[String, ArchiveEntry]]]]
         mockThumnailJobOriginalMedia.apply(any) returns Future(Right(mockedArchiveEntry))
 
+        implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
         val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
           Configuration.from(Map("proxyFramework.notificationsQueue" -> "someQueue", "externalData.indexName" -> "someIndex", "externalData.problemItemsIndex" -> "problem-items")),
           system,
@@ -439,7 +446,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
           mockedJobModelDAO,
           mockedScanTargetDAO,
           mock[ESClientManager]
-        )(mock[ProxyLocationDAO]) {
+        ) {
           override protected val sqsClient = mockedSqsClient
 
           override def thumbnailJobOriginalMedia(jobDesc: JobModel): Future[Either[String, ArchiveEntry]] = mockThumnailJobOriginalMedia(jobDesc)
@@ -499,6 +506,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
       val mockedEsClientManager = mock[ESClientManager]
       mockedEsClientManager.getClient() returns mockedEsClient
 
+      implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
       val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
         Configuration.from(Map("proxyFramework.notificationsQueue" -> "someQueue", "externalData.indexName" -> "someIndex", "externalData.problemItemsIndex" -> "problem-items")),
         system,
@@ -508,7 +516,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         mockedJobModelDAO,
         mockedScanTargetDAO,
         mockedEsClientManager
-      )(mock[ProxyLocationDAO]) {
+      ){
         override val problemItemIndexName = "problem-items"
 
         override val problemItemIndexer = mockedProblemItemIndexer
@@ -569,6 +577,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
       val mockedEsClientManager = mock[ESClientManager]
       mockedEsClientManager.getClient() returns mockedEsClient
 
+      implicit val fakeProxyLocationDAO = mock[ProxyLocationDAO]
       val toTest = system.actorOf(Props(new ProxyFrameworkQueue(
         Configuration.from(Map("proxyFramework.notificationsQueue" -> "someQueue", "externalData.indexName" -> "someIndex", "externalData.problemItemsIndex" -> "problem-items")),
         system,
@@ -578,7 +587,7 @@ class ProxyFrameworkQueueSpec extends Specification with Mockito {
         mockedJobModelDAO,
         mockedScanTargetDAO,
         mockedEsClientManager
-      )(mock[ProxyLocationDAO]) {
+      ) {
         override val problemItemIndexName = "problem-items"
 
         override val problemItemIndexer = mockedProblemItemIndexer

--- a/test/SaveLightboxEntryFlowSpec.scala
+++ b/test/SaveLightboxEntryFlowSpec.scala
@@ -42,7 +42,7 @@ class SaveLightboxEntryFlowSpec extends Specification with Mockito {
         ZonedDateTime.now(),"fakeetag",MimeType("application","octet-stream"),false, StorageClass.STANDARD,Seq(), false,None)
       val testUserProfile = UserProfile("userEmail@company.org",false,Some("test"),Some("test"),Seq(),true,None,None,Some(12345678L),None,None,None)
 
-      implicit val mat = ActorMaterializer.create(system)
+      implicit val mat = Materializer.matFromSystem
       implicit val ec:ExecutionContext = system.dispatcher
       implicit val lightboxEntryDAO = mock[LightboxEntryDAO]
       implicit val esClient = mock[ElasticClient]


### PR DESCRIPTION
## What does this change?

replace deprecated ActorMaterializer.create calls with recommended equivalents

## How to test
Run up on CODE, no changes should be seen

## How can we measure success?

Less warnings, easier to maintain codebase
