### PR TITLE
update riffraff config to update ami automatically

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,6 +12,7 @@ deployments:
     type: autoscaling
     parameters:
       bucket: gnm-multimedia-rr-deployables
+    dependencies: [ multimedia-ami-update ]
 
   archivehunter-input-lambda:
     template: lambda
@@ -24,3 +25,12 @@ deployments:
     parameters:
       functionNames: [archivehunter-autodown-]
       fileName: autoDowningLambda.jar
+
+  multimedia-ami-update:
+    type: ami-cloudformation-parameter
+    app: archivehunter
+    parameters:
+      amiParameter: AmiId
+      amiTags:
+        BuiltBy: amigo
+        Recipe: multimedia-tools-focal-java11


### PR DESCRIPTION
## What does this change?

Updates the riffraff config file to automatically bump the AMI version at deployment

## How to test

See https://github.com/guardian/multimedia-launchdetector-v3/pull/31, process is exactly the same

## How can we measure success?

No warnings about outdated AMI

## Have we considered potential risks?

n/a this is standard practise

