### PR TITLE
Fixes / autodowning

### DIFF
--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -711,7 +711,7 @@ Resources:
       FunctionName: !Sub archivehunter-autodown-${Stage}
       MemorySize: 768
       Role: !GetAtt AutodowningLambdaRole.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 60
       VpcConfig:
         SecurityGroupIds:

--- a/lambda/autodowning/src/main/scala/ApacheComms.scala
+++ b/lambda/autodowning/src/main/scala/ApacheComms.scala
@@ -19,7 +19,7 @@ import scala.util.{Failure, Success, Try}
 class ApacheComms(contactAddress:String, contactPort:Int) extends UriDecoder {
   import models.EnhancedLambdaLogger._
 
-  private val httpClient = Try { HttpClients.createDefault() }
+  protected val httpClient = Try { HttpClients.createDefault() }
 
   def consumeResponseEntity(e:HttpEntity) = {
     Try { e.getContent } match {

--- a/lambda/autodowning/src/main/scala/AutoDowningLambdaMain.scala
+++ b/lambda/autodowning/src/main/scala/AutoDowningLambdaMain.scala
@@ -106,7 +106,7 @@ class AutoDowningLambdaMain extends RequestHandler[java.util.LinkedHashMap[Strin
           akkaNodes.foreach(info=>logger.info(s"Got akka node: $info"))
           findAkkaNode(record.ipAddress, akkaNodes) match {
             case None=>
-              logger.error(s"Could not find node ${details.EC2InstanceId.get} in the Akka cluster")
+              logger.error(s"Could not find node ${details.EC2InstanceId.get} (${record.ipAddress}) in the Akka cluster")
               Success(false)
             case Some(akkaNode)=>
               akkaComms.downAkkaNode(akkaNode)

--- a/lambda/autodowning/src/main/scala/models/AkkaMembersResponse.scala
+++ b/lambda/autodowning/src/main/scala/models/AkkaMembersResponse.scala
@@ -18,5 +18,5 @@ package models
  }
  */
  */
-case class AkkaMembersResponse (selfNode:String, members:Seq[AkkaMember], unreachable:Seq[AkkaUnreachable], leader:String, oldest:String)
+case class AkkaMembersResponse (selfNode:String, members:Seq[AkkaMember], unreachable:Seq[AkkaUnreachable], leader:String)
 

--- a/lambda/autodowning/src/test/scala/ApacheCommsSpec.scala
+++ b/lambda/autodowning/src/test/scala/ApacheCommsSpec.scala
@@ -1,0 +1,113 @@
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import models.AkkaMember
+import org.apache.http.client.{ClientProtocolException, HttpResponseException}
+import org.apache.http.{HttpEntity, StatusLine}
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.impl.client.CloseableHttpClient
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import software.amazon.awssdk.utils.StringInputStream
+
+import java.io.ByteArrayInputStream
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import scala.util.{Success, Try}
+
+class ApacheCommsSpec extends Specification with Mockito {
+  implicit val logToConsole:LambdaLogger = new LambdaLogger {
+    override def log(string: String): Unit = println(string)
+  }
+
+  "ApacheComms.getNodes" should {
+    "parse the list-node output from akka management" in {
+      val fakeResponse =
+        """ {
+          |   "selfNode": "akka.tcp://test@10.10.10.10:1111",
+          |   "members": [
+          |     {
+          |       "node": "akka.tcp://test@10.10.10.10:1111",
+          |       "nodeUid": "1116964444",
+          |       "status": "Up",
+          |       "roles": []
+          |     }
+          |   ],
+          |   "unreachable": [],
+          |   "leader": "akka.tcp://test@10.10.10.10:1111",
+          |   "oldest": "akka.tcp://test@10.10.10.10:1111"
+          | }""".stripMargin
+
+      val mockHttpClient = mock[CloseableHttpClient]
+      val mockStatusLine = mock[StatusLine]
+      mockStatusLine.getStatusCode returns 200
+      mockStatusLine.getReasonPhrase returns "OK"
+
+      val mockEntity = mock[HttpEntity]
+      mockEntity.getContent returns new ByteArrayInputStream(fakeResponse.getBytes(StandardCharsets.UTF_8))
+
+      val mockHttpResponse = mock[CloseableHttpResponse]
+      mockHttpResponse.getStatusLine returns mockStatusLine
+      mockHttpResponse.getEntity returns mockEntity
+      mockHttpClient.execute(any) returns mockHttpResponse
+
+      val toTest = new ApacheComms("myhost.com", 8558) {
+        override protected val httpClient: Try[CloseableHttpClient] = Success(mockHttpClient)
+      }
+
+      val result = toTest.getNodes()
+      result must beASuccessfulTry
+      result.get.headOption must beSome(AkkaMember(new URI("akka.tcp://test@10.10.10.10:1111"), "1116964444", "Up", Seq()))
+      there was one(mockHttpClient).execute(any)
+    }
+
+    "gracefully handle exceptions from apache http" in {
+      val mockHttpClient = mock[CloseableHttpClient]
+      val mockStatusLine = mock[StatusLine]
+      mockStatusLine.getStatusCode returns 200
+      mockStatusLine.getReasonPhrase returns "OK"
+
+      val mockEntity = mock[HttpEntity]
+      mockEntity.getContent throws new RuntimeException("Kersplaaaat!")
+
+      val mockHttpResponse = mock[CloseableHttpResponse]
+      mockHttpResponse.getStatusLine returns mockStatusLine
+      mockHttpResponse.getEntity returns mockEntity
+      mockHttpClient.execute(any) returns mockHttpResponse
+
+      val toTest = new ApacheComms("myhost.com", 8558) {
+        override protected val httpClient: Try[CloseableHttpClient] = Success(mockHttpClient)
+      }
+
+      val result = toTest.getNodes()
+      there was one(mockHttpClient).execute(any)
+      result must beAFailedTry
+      result.failed.get.getMessage mustEqual "Kersplaaaat!"
+    }
+
+    "fail on 500 error" in {
+      val fakeResponse =
+        """{"error":"something broke badly"}""".stripMargin
+
+      val mockHttpClient = mock[CloseableHttpClient]
+      val mockStatusLine = mock[StatusLine]
+      mockStatusLine.getStatusCode returns 500
+      mockStatusLine.getReasonPhrase returns "OK"
+
+      val mockEntity = mock[HttpEntity]
+      mockEntity.getContent returns new ByteArrayInputStream(fakeResponse.getBytes(StandardCharsets.UTF_8))
+
+      val mockHttpResponse = mock[CloseableHttpResponse]
+      mockHttpResponse.getStatusLine returns mockStatusLine
+      mockHttpResponse.getEntity returns mockEntity
+      mockHttpClient.execute(any) throws new HttpResponseException(500, "Internal server error")
+
+      val toTest = new ApacheComms("myhost.com", 8558) {
+        override protected val httpClient: Try[CloseableHttpClient] = Success(mockHttpClient)
+      }
+
+      val result = toTest.getNodes()
+      result must beAFailedTry
+      there was one(mockHttpClient).execute(any)
+      result.failed.get.getMessage mustEqual "status code: 500, reason phrase: Internal server error"
+    }
+  }
+}


### PR DESCRIPTION

## What does this change?

- Update cloudformation to ensure java 11 runtime for autodowning (was causing hidden failures).
- Improve tests and logging for autodowning lambda.

## How to test

- Deploy the updated version, then terminate and restart some of the EC2 instances.
- Check the Cloudformation logs for "archivehunter-autodown-{ENV}" lambda function
- You should see it correctly note that it has detected and removed the instance from the cluster

## How can we measure success?

- No more "akka.remote.artery.OutboundHandshake$HandshakeTimeoutException" style errors repeating over and over
- No more mysterious automatic-function failures in archivehunter

## Have we considered potential risks?

Just needs monitoring once in production to ensure it is working properly
