### PR TITLE
Fix/more autodown improvements

### DIFF
--- a/lambda/autodowning/src/main/scala/ApacheComms.scala
+++ b/lambda/autodowning/src/main/scala/ApacheComms.scala
@@ -86,7 +86,8 @@ class ApacheComms(contactAddress:String, contactPort:Int) extends UriDecoder {
     logger.debug(s"address is $addr")
 
     val nvps = new util.ArrayList[NameValuePair]()
-    nvps.add(new BasicNameValuePair("operation","leave"))
+    //"down" is usually the best option here - https://discuss.lightbend.com/t/downing-vs-leaving/5203
+    nvps.add(new BasicNameValuePair("operation","down"))
     val entity = new UrlEncodedFormEntity(nvps)
     val request = new HttpPut(addr)
     request.setEntity(entity)

--- a/lambda/autodowning/src/main/scala/AutoDowningLambdaMain.scala
+++ b/lambda/autodowning/src/main/scala/AutoDowningLambdaMain.scala
@@ -159,17 +159,16 @@ class AutoDowningLambdaMain extends RequestHandler[java.util.LinkedHashMap[Strin
     case Success(Some(info))=>
       println(s"Got $info")
       if(shouldHandle(info)) {
-        if (state == "terminated") {
-          println("registering shutdown")
+        if (state == "shutting-down" || state == "terminated") {
+          logger.info("registering shutdown")
           registerInstanceTerminated(details)
         } else if(state == "running"){
-          println("registering startup")
+          logger.info("registering startup")
           registerInstanceStarted(details, info)
         } else {
-          println(s"don't need to register $state state")
+          logger.info(s"don't need to register $state state")
         }
       } else {
-        println("not handling")
         logger.info(s"We are not interested in this instance, tags are ${getEc2Tags(info)} but we want $tagsComparison")
       }
     case Success(None)=>


### PR DESCRIPTION
## What does this change?

Improves the autodowning lamba which was failing before

## How to test

Start the cluster up from zero, then terminate an instance
You should see the lambda respond, and you should see the instance connection errors in the log stop after a couple of minutes

## How can we measure success?

Less halting of message processing due to cluster communication breakdown because of failed nodes

