### PR TITLE
Feature / Graviton (ARM) support

### DIFF
--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -65,11 +65,17 @@ Parameters:
     Description: What type of instance to launch
     AllowedValues:
     - t3.nano
+    - t4g.nano
     - t3.micro
+    - t4g.micro
     - t3.small
+    - t4g.small
     - t3.medium
+    - t4g.medium
     - t3.large
+    - t4g.large
     - t3.xlarge
+    - t4g.xlargs
     Default: t3.medium
   KeyPair:
     Type: AWS::EC2::KeyPair::KeyName

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -33,4 +33,4 @@ deployments:
       amiParameter: AmiId
       amiTags:
         BuiltBy: amigo
-        Recipe: multimedia-tools-focal-java11
+        Recipe: multimedia-tools-focal-java11-arm


### PR DESCRIPTION
## What does this change?

- Updates cloudformation to list graviton instance types
- Updates riffraff to choose arm version bake

## How to test

Redeploy the cloudformation and select a `t4g` instance type. Then redeploy via Riffraff and watch the logs

## How can we measure success?
System works on ARM
