### PR TITLE
Feature/notification validation

### DIFF
--- a/app/responses/CheckNotificationResponse.scala
+++ b/app/responses/CheckNotificationResponse.scala
@@ -1,0 +1,3 @@
+package responses
+
+case class CheckNotificationResponse(status:String, updatesRequired:Boolean, didUpdate:Boolean)

--- a/app/services/BucketNotificationConfigScalaWrapper.scala
+++ b/app/services/BucketNotificationConfigScalaWrapper.scala
@@ -1,0 +1,38 @@
+package services
+
+import com.amazonaws.services.s3.model.{BucketNotificationConfiguration, NotificationConfiguration}
+import scala.jdk.CollectionConverters._
+
+/**
+  * Scala case-class compatible wrapper for BucketNotificationConfiguration.
+  * This allows us to easily track if there has been an update to the configuration and only make the write call
+  * if an update has taken place.
+  * @param wrapped BucketNotificationConfiguration object to be wrapped
+  * @param isUpdated boolean flag. Don't specify this on initial construction and it will default to `false`.
+  */
+case class BucketNotificationConfigScalaWrapper(wrapped:BucketNotificationConfiguration, isUpdated:Boolean) {
+  def withConfiguration(name:String, config:NotificationConfiguration):BucketNotificationConfigScalaWrapper = {
+    copy(wrapped.addConfiguration(name, config), true)
+  }
+
+  def withConfiguration(defn:(String, NotificationConfiguration)):BucketNotificationConfigScalaWrapper = {
+    withConfiguration(defn._1, defn._2)
+  }
+
+  def getConfigurations:Map[String, NotificationConfiguration] = {
+    wrapped.getConfigurations.asScala.toMap
+  }
+
+  def getConfigurationByName(name:String) = {
+    wrapped.getConfigurationByName(name)
+  }
+
+  def withoutConfiguration(name:String):BucketNotificationConfigScalaWrapper = {
+    wrapped.removeConfiguration(name)
+    copy(wrapped, true)
+  }
+}
+
+object BucketNotificationConfigScalaWrapper {
+  def apply(wrapped:BucketNotificationConfiguration) = new BucketNotificationConfigScalaWrapper(wrapped, isUpdated=false)
+}

--- a/app/services/BucketNotificationConfigurations.scala
+++ b/app/services/BucketNotificationConfigurations.scala
@@ -1,0 +1,211 @@
+package services
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{BucketNotificationConfiguration, LambdaConfiguration, NotificationConfiguration, S3Event}
+import com.theguardian.multimedia.archivehunter.common.clientManagers.S3ClientManager
+import org.slf4j.LoggerFactory
+import play.api.Configuration
+
+import java.util
+import javax.inject.{Inject, Singleton}
+import scala.util.{Success, Try}
+import scala.jdk.CollectionConverters._
+
+@Singleton
+class BucketNotificationConfigurations @Inject()(s3ClientMgr:S3ClientManager, config:Configuration) {
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val maybeProfile = config.getOptional[String]("externalData.awsProfile")
+
+  /**
+    * Filter function to extract notifications relevant to us - specifically ones that point to a Lambda function called
+    * `archivehunter-input-`
+    * @param defn notificqtion definition, in the form of a tuple name:String->NotificationConfiguration
+    * @return true if this is one of ours, otherwise false
+    */
+  protected def findRelevantNotification(defn:(String, NotificationConfiguration)):Boolean = {
+    logger.debug(s"Notification with name ${defn._1}: ${defn._2.getClass.getName}")
+    defn._2 match {
+      case lambdaNotification:LambdaConfiguration=>
+        lambdaNotification.getFunctionARN.contains("archivehunter-input")
+      case _=>
+        logger.debug(s"Notification ${defn._1} is not a lambda function notification")
+        false
+    }
+  }
+
+  private val expectedEvents = Set(
+    S3Event.ObjectCreated,
+    S3Event.ObjectRemoved,
+    S3Event.ObjectRestoreCompleted,
+    S3Event.ObjectRestoreDelete,
+    S3Event.ReducedRedundancyLostObject,
+    S3Event.LifecycleTransition,
+    S3Event.LifecycleExpiration
+  )
+
+  /**
+    * Creates a new configuration for the bucket monitor lambda function
+    * @param lambdaArn ARN of the lambda function
+    * @return a new LambdaConfiguration
+    */
+  def createNewNotification(lambdaArn:String) = {
+    new LambdaConfiguration(lambdaArn, util.EnumSet.copyOf(expectedEvents.asJavaCollection))
+  }
+
+  /**
+    * If the given notification configuration needs updating, then returns an updated version of it.
+    * Otherwise, returns None
+    * @param configuration s3 notification configuration
+    * @return
+    */
+  protected def maybeUpdate(configuration: NotificationConfiguration):Option[NotificationConfiguration] = {
+    val events = configuration.getEvents.asScala
+    logger.debug(s"NotificationConfiguration has these events: ${events.mkString(";")}")
+    val missingEvents = expectedEvents.map(_.toString).diff(events)
+
+    val firstUpdate = if(missingEvents.nonEmpty) {
+      logger.info(s"NotificationConfiguration is missing the following events: ${missingEvents.mkString(";")}, it will be re-written")
+      Some(configuration.withEvents(expectedEvents.map(_.toString).asJava))
+    } else {
+      None
+    }
+
+    val secondUpdate = if(Option(configuration.getFilter).isDefined) {
+      logger.info(s"NotificationConfiguration has a filter present: ${configuration.getFilter}, removing")
+      Some(configuration.withFilter(null))
+    } else {
+      None
+    }
+
+    (firstUpdate, secondUpdate) match {
+      case (None, None) => None
+      case (Some(u), None)=> Some(u)
+      case (None, Some(u))=> Some(u)
+      case (Some(evts), Some(_)) => Some(evts.withFilter(null))
+    }
+  }
+
+  protected def maybeUpdateNotification(defn:(String, NotificationConfiguration)):Option[(String, NotificationConfiguration)] = {
+    logger.debug(s"Notification with name ${defn._1}: ${defn._2.getClass.getName}")
+
+    defn._2 match {
+      case lambdaNotification:LambdaConfiguration=>
+        if(lambdaNotification.getFunctionARN.contains("archivehunter-input")) {
+          maybeUpdate(defn._2).map(updated=>(defn._1, updated))
+        } else {
+          None
+        }
+      case _=>
+        logger.debug(s"Notification ${defn._1} is not a lambda function notification")
+      None
+    }
+  }
+
+  /**
+    * Returns true if there are none of our notifications found in the given configuration, therefore requiring
+    * a new configuration to be added
+    * @param config BucketNotificaitonConfiguration instance to test
+    * @return a boolean value indicating whether we need to add one of our own configurations
+    */
+  protected def isAdditionRequired(config:BucketNotificationConfiguration):Boolean = {
+    config.getConfigurations.asScala.foldLeft(true)((prevValue, defn)=>{
+      defn._2 match {
+        case lambdaNotification: LambdaConfiguration=>
+          if(lambdaNotification.getFunctionARN.contains("archivehunter-input")) {
+            false
+          } else {
+            prevValue
+          }
+        case _=>
+          prevValue
+      }
+    })
+  }
+
+  /**
+    * Gathers the additions and modifications, compares them to the previous values and writes to S3 if they differ
+    * @param bucketName bucket name to write to
+    * @param response initial BucketNotificationConfiguration
+    * @param maybeLambdaArn lambda ARN for creating a new notification if required
+    * @param requiredUpdates list of updates required to existing notifications
+    * @param s3client implicitly provided AmazonS3 client object
+    * @return a Try, containing a tuple of two boolean values. The first is `true` if updates were required, the second is true if they were written.
+    *         This is for compatibility with the return value of parent function verifyNotificationSetup
+    */
+  private def writeUpdatesIfRequired(bucketName:String,
+                                     response:BucketNotificationConfiguration,
+                                     maybeLambdaArn:Option[String],
+                                     requiredUpdates:Seq[(String, NotificationConfiguration)])(implicit s3client:AmazonS3) = {
+    //step one - do we need to add a new monitoring configuration? If so put it into the list
+    val initialConfiguration = if (isAdditionRequired(response)) {
+      maybeLambdaArn match {
+        case Some(lambdaArn) =>
+          response.addConfiguration("ArchiveHunter", createNewNotification(lambdaArn))
+        case None =>
+          throw new RuntimeException("Cannot add a lambda monitor because externalData.bucketMonitorLambdaARN is not set in the application config file")
+      }
+    } else {
+      response
+    }
+
+    //step two - do we need to update any of the existing configurations? If so put them into the list
+    val updatedConfiguration = if (requiredUpdates.nonEmpty) {
+      requiredUpdates.foldLeft(initialConfiguration)((config, defn) => {
+        config.removeConfiguration(defn._1)
+        config.addConfiguration(defn._1, defn._2)
+      })
+    } else {
+      initialConfiguration
+    }
+
+    //step three - if the config we built has no changes then do nothing, otherwise write out the updated configuration to S3
+    if (updatedConfiguration == response) {
+      logger.info(s"$bucketName - No monitoring configuration updates required")
+      Success((false, false))
+    } else {
+      Try {
+        s3client.setBucketNotificationConfiguration(bucketName, updatedConfiguration)
+      }.map(_=>(true, true))
+    }
+  }
+
+  /**
+    *
+    * @param bucketName
+    * @param region
+    * @param shouldWriteUpdates
+    * @return a Try, which fails on error and on success contains a tuple of two boolean values.
+    *         The first value is `true` if updates to the given bucket were _required_, and the second value
+    *         is `true` if required updates to the bucket were _made_.
+    */
+  def verifyNotificationSetup(bucketName:String, region:Option[String], shouldWriteUpdates:Boolean) = {
+    val maybeLambdaArn = config.getOptional[String]("externalData.bucketMonitorLambdaARN")
+
+    implicit val s3client = s3ClientMgr.getS3Client(maybeProfile, region)
+    logger.debug(s"Looking for S3 notifications on bucket $bucketName in region ${region.getOrElse("default")}")
+
+    for {
+      response <- Try { s3client.getBucketNotificationConfiguration(bucketName) }
+      requiredUpdates <- Try {
+        response
+          .getConfigurations
+          .asScala
+          .map(maybeUpdateNotification)
+          .collect({case Some(update)=>update})
+          .toSeq
+      }
+      result <- if(shouldWriteUpdates) {
+        writeUpdatesIfRequired(bucketName, response, maybeLambdaArn, requiredUpdates)
+      } else {
+        val needsUpdate = requiredUpdates.nonEmpty || isAdditionRequired(response)
+        if(needsUpdate) {
+          logger.info(s"$bucketName configuration is incorrect and requires updates")
+        } else {
+          logger.info(s"$bucketName - no updates need to be made to notification configuration")
+        }
+        Success((needsUpdate, false))
+      }
+    } yield result
+
+  }
+}

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -888,6 +888,8 @@ Resources:
               - s3:ListBucket
               - s3:GetObject
               - s3:RestoreObject
+              - s3:GetBucketNotification
+              - s3:PutBucketNotification
             Resource:
               - arn:aws:s3:::*
               - arn:aws:s3:::*/*

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -138,6 +138,10 @@ Parameters:
     Description: Shared secret for script->server communication
     Type: String
     NoEcho: true
+  BucketNotificationLambda:
+    Description: Optional ARN of the bucket notifications lambda. Specify this so that it can be configured automatically by the app
+    Type: String
+    AllowedPattern: ^arn:[^:\n]*:[^:\n]*:[^:\n]*:[^:\n]*:[^:\/\n]*[:\/]?.*$
 Resources:
   AccessorSG: #this group is exported and used by bucketmonitor yaml. defined here so that it can be marked for access to ES
     Type: AWS::EC2::SecurityGroup
@@ -1049,6 +1053,7 @@ Resources:
             problemItemsIndex="proxy-issues"
             problemSummaryIndex="proxy-issues-summary"
             avatarBucket="${AvatarBucket}"
+            bucketMonitorLambdaARN="${BucketNotificationLambda}"
           }
 
           scanner {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -155,7 +155,7 @@ akka.cluster {
   auto-down-unreachable-after = 30s //important for EC2
 }
 
-akka.io.dns.resolver = async-dns
+akka.io.dns.resolver = inet-address //this is required to get /etc/hosts resolving. async-dns is preferred in production.
 
 akka.management {
   http.route-providers-read-only = false  //this is needed for the auto-downing lambda to work

--- a/conf/logback-deployment.xml
+++ b/conf/logback-deployment.xml
@@ -109,6 +109,7 @@
     <logger name="helpers.LightboxHelper$" level="INFO"/>
     <logger name="helpers.LightboxHelper" level="INFO"/>
 
+    <logger name="services.BucketNotificationConfigurations" level="DEBUG"/>
 
     <logger name="services.FileMoveActor" level="DEBUG"/>
     <logger name="services.FileMove" level="DEBUG"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -91,7 +91,6 @@
     <logger name="services.IngestProxyQueue" level="INFO"/>
     <logger name="services.ProblemItemRetry" level="INFO"/>
     <logger name="requests.JobSearchRequest" level="INFO"/>
-    <logger name="services.FileMoveQueue" level="DEBUG"/>
     <logger name="ProblemItemRetry" level="INFO"/>
     <logger name="helpers.ProblemItemReproxySink" level="INFO"/>
 
@@ -107,10 +106,10 @@
     <logger name="helpers.LightboxHelper$" level="INFO"/>
     <logger name="helpers.LightboxHelper" level="INFO"/>
 
-    <logger name="services.FileMoveActor" level="DEBUG"/>
+    <logger name="services.FileMoveActor" level="INFO"/>
     <logger name="services.FileMove" level="INFO"/>
-    <logger name="services.ClockPerInstance" level="DEBUG"/>
-
+    <logger name="services.ClockPerInstance" level="INFO"/>
+    <logger name="services.BucketNotificationConfigurations" level="DEBUG"/>
     <root level="WARN">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="ASYNCFILE"/>

--- a/conf/routes
+++ b/conf/routes
@@ -25,6 +25,8 @@ POST    /api/scanTarget/:id/legacyProxiesScan @controllers.ScanTargetController.
 POST    /api/scanTarget/:id/genProxies  @controllers.ScanTargetController.genProxies(id)
 POST    /api/scanTarget/:id/checkTranscoder @controllers.ScanTargetController.initiateCheckJob(id)
 POST    /api/scanTarget/:id/createPipelines @controllers.ScanTargetController.createPipelines(id, force:Boolean ?=false)
+GET     /api/scanTarget/:id/monitoringConfiguration @controllers.ScanTargetController.checkNotificationConfiguration(id)
+POST     /api/scanTarget/:id/monitoringConfiguration @controllers.ScanTargetController.fixNotificationConfiguration(id)
 
 GET     /api/search/basic      @controllers.SearchController.simpleStringSearch(q:Option[String],start:Option[Int],length:Option[Int])
 GET     /api/entry/:id                  @controllers.SearchController.getEntry(id)

--- a/frontend/app/ScanTargets/MonitoringSetupCheck.tsx
+++ b/frontend/app/ScanTargets/MonitoringSetupCheck.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme)=>({
         color: theme.palette.warning.main
     },
     ok: {
-        color: theme.palette.info.main
+        color: theme.palette.success.main
     }
 }))
 
@@ -35,6 +35,7 @@ const MonitoringSetupCheck:React.FC<MonitoringSetupCheckProps> = (props) => {
     const classes = useStyles();
 
     const request = async (test:boolean)=> {
+        setLoading(true);
         try {
             const url = `/api/scanTarget/${encodeURIComponent(props.scanTarget)}/monitoringConfiguration`;
             const response = test ?
@@ -77,7 +78,7 @@ const MonitoringSetupCheck:React.FC<MonitoringSetupCheckProps> = (props) => {
                     </Tooltip>
                     </Grid>
                 </> : <>
-                    <Grid item><CheckCircle className={clsx(classes.ok, classes.inlineIcon)}/></Grid>
+                    <Grid item className={classes.extraMargin}><CheckCircle className={clsx(classes.ok, classes.inlineIcon)}/></Grid>
                     <Grid item><Typography>Configuration is valid</Typography></Grid>
                 </>
             }

--- a/frontend/app/ScanTargets/MonitoringSetupCheck.tsx
+++ b/frontend/app/ScanTargets/MonitoringSetupCheck.tsx
@@ -1,0 +1,94 @@
+import React, {useEffect, useState} from "react";
+import axios from "axios";
+import {MonitoringConfigurationResponse} from "../types";
+import {CircularProgress, Grid, IconButton, makeStyles, Tooltip, Typography} from "@material-ui/core";
+import {Build, CheckCircle, Refresh, WarningRounded} from "@material-ui/icons";
+import clsx from "clsx";
+
+interface MonitoringSetupCheckProps {
+    scanTarget:string;
+}
+
+const useStyles = makeStyles((theme)=>({
+    inlineIcon: {
+        height: "24px",
+        marginRight: "0.4em"
+    },
+    warning: {
+        color: theme.palette.warning.main
+    },
+    ok: {
+        color: theme.palette.info.main
+    }
+}))
+
+const MonitoringSetupCheck:React.FC<MonitoringSetupCheckProps> = (props) => {
+    const [loading, setLoading] = useState(true);
+    const [needsAttention, setNeedsAttention] = useState(false);
+    const [lastError, setLastError] = useState("");
+
+    const classes = useStyles();
+
+    const request = async (test:boolean)=> {
+        try {
+            const url = `/api/scanTarget/${encodeURIComponent(props.scanTarget)}/monitoringConfiguration`;
+            const response = test ?
+                await axios.get<MonitoringConfigurationResponse>(url) :
+                await axios.post<MonitoringConfigurationResponse>(url);
+
+            setLoading(false);
+            setNeedsAttention(response.data.updatesRequired);
+        } catch(err) {
+            console.error(`Could not get monitoring configuration for scan target ${encodeURIComponent(props.scanTarget)}: `, err);
+            setLoading(false);
+            setLastError("Could not check monitoring configuration, consult the browser console logs for more information");
+        }
+    }
+
+    const updateInfo = async ()=> request(true);
+
+    const fixConfig = async ()=>request(false);
+
+    useEffect(()=>{
+        updateInfo();
+    }, [props.scanTarget]);
+
+    return (
+        <Grid container>
+            {
+                loading ? <Grid item><CircularProgress className={classes.inlineIcon}/></Grid> : undefined
+            }
+            {
+                needsAttention ? <>
+                    <Grid item><WarningRounded className={clsx(classes.warning, classes.inlineIcon)}/></Grid>
+                    <Grid item><Typography>Configuration is not valid</Typography></Grid>
+                    <Grid item>
+                    <Tooltip title="Try to fix">
+                        <IconButton onClick={fixConfig}><Build className={classes.inlineIcon}/></IconButton>
+                    </Tooltip>
+                    </Grid>
+                    <Grid item>
+                    <Tooltip title="Check again">
+                        <IconButton onClick={updateInfo}><Refresh className={classes.inlineIcon}/></IconButton>
+                    </Tooltip>
+                    </Grid>
+                </> : <>
+                    <Grid item><CheckCircle className={clsx(classes.ok, classes.inlineIcon)}/></Grid>
+                    <Grid item><Typography>Configuration is valid</Typography></Grid>
+                </>
+            }
+            {
+                lastError ? <Grid item><Typography>{lastError}</Typography></Grid> : undefined
+            }
+            {
+                <Grid item>
+                    <Tooltip title="Check again">
+                        <IconButton onClick={updateInfo}><Refresh className={classes.inlineIcon}/></IconButton>
+                    </Tooltip>
+                </Grid>
+            }
+        </Grid>
+    )
+}
+
+export default MonitoringSetupCheck;

--- a/frontend/app/ScanTargets/MonitoringSetupCheck.tsx
+++ b/frontend/app/ScanTargets/MonitoringSetupCheck.tsx
@@ -12,7 +12,12 @@ interface MonitoringSetupCheckProps {
 const useStyles = makeStyles((theme)=>({
     inlineIcon: {
         height: "24px",
+        width: "24px",
+        verticalAlign: "bottom",
         marginRight: "0.4em"
+    },
+    extraMargin: {
+        marginLeft: "0.4em"
     },
     warning: {
         color: theme.palette.warning.main
@@ -37,11 +42,13 @@ const MonitoringSetupCheck:React.FC<MonitoringSetupCheckProps> = (props) => {
                 await axios.post<MonitoringConfigurationResponse>(url);
 
             setLoading(false);
+            setLastError("");
             setNeedsAttention(response.data.updatesRequired);
         } catch(err) {
             console.error(`Could not get monitoring configuration for scan target ${encodeURIComponent(props.scanTarget)}: `, err);
             setLoading(false);
             setLastError("Could not check monitoring configuration, consult the browser console logs for more information");
+            setNeedsAttention(false);
         }
     }
 
@@ -50,26 +57,23 @@ const MonitoringSetupCheck:React.FC<MonitoringSetupCheckProps> = (props) => {
     const fixConfig = async ()=>request(false);
 
     useEffect(()=>{
-        updateInfo();
+        if(props.scanTarget) updateInfo();
     }, [props.scanTarget]);
 
     return (
-        <Grid container>
+        <Grid container spacing={3} alignItems="baseline">
             {
-                loading ? <Grid item><CircularProgress className={classes.inlineIcon}/></Grid> : undefined
+                loading ? <Grid item className={classes.extraMargin}><CircularProgress className={classes.inlineIcon}/></Grid> : undefined
             }
             {
-                needsAttention ? <>
-                    <Grid item><WarningRounded className={clsx(classes.warning, classes.inlineIcon)}/></Grid>
-                    <Grid item><Typography>Configuration is not valid</Typography></Grid>
-                    <Grid item>
-                    <Tooltip title="Try to fix">
-                        <IconButton onClick={fixConfig}><Build className={classes.inlineIcon}/></IconButton>
-                    </Tooltip>
+                needsAttention && !lastError ? <>
+                    <Grid item className={classes.extraMargin}>
+                        <WarningRounded className={clsx(classes.warning, classes.inlineIcon)}/>
+                        <Typography style={{display: "inline"}}>Configuration is not valid</Typography>
                     </Grid>
                     <Grid item>
-                    <Tooltip title="Check again">
-                        <IconButton onClick={updateInfo}><Refresh className={classes.inlineIcon}/></IconButton>
+                    <Tooltip title="Try to fix">
+                        <IconButton onClick={fixConfig}><Build/></IconButton>
                     </Tooltip>
                     </Grid>
                 </> : <>
@@ -83,7 +87,7 @@ const MonitoringSetupCheck:React.FC<MonitoringSetupCheckProps> = (props) => {
             {
                 <Grid item>
                     <Tooltip title="Check again">
-                        <IconButton onClick={updateInfo}><Refresh className={classes.inlineIcon}/></IconButton>
+                        <IconButton onClick={updateInfo}><Refresh/></IconButton>
                     </Tooltip>
                 </Grid>
             }

--- a/frontend/app/ScanTargets/ScanTargetEdit.jsx
+++ b/frontend/app/ScanTargets/ScanTargetEdit.jsx
@@ -27,6 +27,7 @@ import {baseStyles} from "../BaseStyles";
 import ScanTargetActionsBox from "./ScanTargetActionsBox";
 import {Helmet} from "react-helmet";
 import {BugReport, Tune} from "@material-ui/icons";
+import MonitoringSetupCheck from "./MonitoringSetupCheck";
 
 const styles = (theme) => Object.assign(createStyles({
     formContainer: {
@@ -313,6 +314,10 @@ class ScanTargetEdit extends React.Component {
                         />
                     </Tooltip>
                         </td>
+                </tr>
+                <tr>
+                    <td>Monitoring setup</td>
+                    <td><MonitoringSetupCheck scanTarget={this.state.idToLoad}/></td>
                 </tr>
                 <tr>
                     <td style={{verticalAlign: "top"}}>Transcode Setup</td>

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -349,3 +349,9 @@ interface GenericResponse {
     status: string;
     detail: string;
 }
+
+interface MonitoringConfigurationResponse {
+    status: string;
+    updatesRequired: boolean;
+    didUpdate: boolean;
+}


### PR DESCRIPTION
## What does this change?

Adds a function to the Scan Target configuration which allows you to check and apply a fixed notification configuration to allow event-driven updates.

<img width="1190" alt="Screenshot 2022-04-05 at 13 14 38" src="https://user-images.githubusercontent.com/12482441/161751549-c8008ff1-d745-456f-a54d-8c181289e4bd.png">

<img width="1198" alt="Screenshot 2022-04-05 at 13 14 53" src="https://user-images.githubusercontent.com/12482441/161751569-9ca9d48d-7ab3-4154-90a0-6f1143020e4b.png">

## How to test

Go into the Scan Targets configuration and choose any bucket - check the form UI shows as above.  The buttons have tooltips; the spanner button will update or add a notification (lambda ARN is configured in the Cloudformation via the config file) and the refresh button will check again.

## How can we measure success?

Consistent monitoring configuration should fix the issues we have with the UI being out of sync with the state of the buckets

## Have we considered potential risks?

None

