### PR TITLE
Fix/lightbox direct download

### DIFF
--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -887,6 +887,8 @@ Resources:
             Action:
               - s3:ListBucket
               - s3:GetObject
+              - s3:GetObjectVersion
+              - s3:ListBucketVersions
               - s3:RestoreObject
               - s3:GetBucketNotification
               - s3:PutBucketNotification

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/clientManagers/S3ClientManager.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/clientManagers/S3ClientManager.scala
@@ -1,5 +1,7 @@
 package com.theguardian.multimedia.archivehunter.common.clientManagers
 
+import akka.actor.ActorSystem
+import akka.stream.alpakka.s3.S3Ext
 import com.amazonaws.services.s3.AmazonS3
 import com.theguardian.multimedia.archivehunter.common.ArchiveHunterConfiguration
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
@@ -22,6 +24,17 @@ class S3ClientManager @Inject() (config:ArchiveHunterConfiguration) extends Clie
     }
   }
 
+  /**
+    * Returns S3Settings containing our preferred credentials provider, suitable for use with Alpakka.
+    * See https://doc.akka.io/docs/alpakka/current/s3.html#apply-s3-settings-to-a-part-of-the-stream for
+    * how to use this
+    * @param profileName optional AWS profile name to use (used in development)
+    * @param actorSystem implicitly provided actorsystem reference
+    * @return an S3Settings object
+    */
+  def getAlpakkaCredentials(profileName:Option[String]=None)(implicit actorSystem: ActorSystem) = {
+    S3Ext(actorSystem).settings.withCredentialsProvider(getCredentialsProvider(profileName))
+  }
   /**
     * Obtain an S3 client object for the given region, optionally using profile credentials.  This will re-use previously created
     * clients and not create a new one on every call.

--- a/frontend/__tests__/common/test_FileInfo.ts
+++ b/frontend/__tests__/common/test_FileInfo.ts
@@ -1,0 +1,22 @@
+import {baseName} from "../../app/common/Fileinfo";
+
+describe("baseName", ()=>{
+    it("should return only the filename portion of an absolute path", ()=>{
+        const result = baseName("/path/to/some/file.ext");
+        expect(result).toEqual("file.ext");
+    });
+
+    it("should return only the filename portion of a relative path", ()=>{
+        const result = baseName("to/some/file.ext");
+        expect(result).toEqual("file.ext");
+    });
+
+    it("should return a bare filename unchanged", ()=>{
+        const result = baseName("file.ext");
+        expect(result).toEqual("file.ext");
+    });
+
+    it("should return undefined if passed undefined", ()=>{
+        expect(baseName(undefined)).toBeUndefined();
+    })
+})

--- a/frontend/app/Lightbox/LightboxDetailsInsert.tsx
+++ b/frontend/app/Lightbox/LightboxDetailsInsert.tsx
@@ -5,7 +5,7 @@ import TimestampFormatter from "../common/TimestampFormatter";
 import RestoreStatusComponent from "./RestoreStatusComponent";
 import {baseStyles} from "../BaseStyles";
 import RestoreStatusIndicator from "./RestoreStatusIndicator";
-import {AirportShuttle, GetApp, YoutubeSearchedFor} from "@material-ui/icons";
+import {AirportShuttle, CheckCircle, GetApp, YoutubeSearchedFor} from "@material-ui/icons";
 import axios, {AxiosResponse} from "axios";
 import {baseName} from "../common/Fileinfo";
 
@@ -31,6 +31,14 @@ const useStyles = makeStyles((theme)=>Object.assign({
     nicelyAlignedIcon: {
         marginTop: "auto",
         marginBottom: "auto"
+    },
+    successIcon: {
+        color: theme.palette.success.main,
+        marginRight: "0.4em",
+        verticalAlign: "middle"
+    },
+    smallText: {
+        fontSize: "0.8em"
     }
 } as StylesMap, baseStyles));
 
@@ -40,6 +48,7 @@ const useStyles = makeStyles((theme)=>Object.assign({
 const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) => {
     const [downloadUrl, setDownloadUrl] = useState<string|undefined>();
     const [downloading, setDownloading] = useState(false);
+    const [downloadedTo, setDownloadedTo] = useState<string|undefined>();
 
     const classes = useStyles();
 
@@ -74,6 +83,8 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
             setDownloading(true);
             //the pipeTo method will automatically close the writable stream
             await content.body.pipeTo(writable);
+            const targetFile:File = await handle.getFile();
+            setDownloadedTo(targetFile.name);
             setDownloading(false);
         } else {
             alert("No content was available to download");
@@ -184,6 +195,9 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
                 </Typography>
                 <TimestampFormatter relative={true} value={props.lightboxEntry.availableUntil} className={classes.runOnText}/>
             </> : <Typography className={classes.runOnText}>Available indefinitely</Typography>
+        }
+        {
+            downloadedTo ? <Typography className={classes.smallText}><CheckCircle className={classes.successIcon}/>Downloaded to {downloadedTo}</Typography> : undefined
         }
     </div>;
 }

--- a/frontend/app/Lightbox/LightboxDetailsInsert.tsx
+++ b/frontend/app/Lightbox/LightboxDetailsInsert.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {createRef, useState} from "react";
 import {LightboxEntry, ObjectGetResponse, RestoreStatus, StylesMap} from "../types";
 import {CircularProgress, Divider, Grid, Icon, IconButton, makeStyles, Tooltip, Typography} from "@material-ui/core";
 import TimestampFormatter from "../common/TimestampFormatter";
@@ -8,7 +8,7 @@ import {IconProp} from "@fortawesome/fontawesome-svg-core";
 import clsx from "clsx";
 import RestoreStatusIndicator from "./RestoreStatusIndicator";
 import {AirportShuttle, GetApp, YoutubeSearchedFor} from "@material-ui/icons";
-import axios from "axios";
+import axios, {AxiosResponse} from "axios";
 import {formatError} from "../common/ErrorViewComponent";
 
 interface LightboxDetailsInsertProps {
@@ -41,16 +41,9 @@ const useStyles = makeStyles((theme)=>Object.assign({
  */
 const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) => {
     const [downloadUrl, setDownloadUrl] = useState<string|undefined>();
+    const [downloading, setDownloading] = useState(false);
 
     const classes = useStyles();
-
-    // const displayInfo = (status:string) => {
-    //     if(status=='RS_UNNEEDED') {
-    //         return "Not in deep freeze";
-    //     } else {
-    //         return undefined;
-    //     }
-    // }
 
     const displayRedo = (status:RestoreStatus) => {
         switch(status) {
@@ -69,20 +62,84 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
         return props.lightboxEntry.restoreStatus=="RS_SUCCESS" || props.lightboxEntry.restoreStatus=="RS_UNNEEDED" || props.lightboxEntry.restoreStatus=="RS_ALREADY"
     }
 
-    const doDownload  = async () => {
-        try {
-            const response = await axios.get<ObjectGetResponse<string>>("/api/download/" + props.archiveEntryId);
-            setDownloadUrl(response.data.entry);
-        } catch(err) {
-            console.error("Could not get download URL: ", err);
-            props.onError ? props.onError(formatError(err, false)) : null;
+    // const doDownload  = async () => {
+    //     try {
+    //         const response = await axios.get<ObjectGetResponse<string>>("/api/download/" + props.archiveEntryId);
+    //         setDownloadUrl(response.data.entry);
+    //     } catch(err) {
+    //         console.error("Could not get download URL: ", err);
+    //         props.onError ? props.onError(formatError(err, false)) : null;
+    //     }
+    // }
+
+    const baseNameXtractor = /\/([^\/]+)$/;
+    const baseName = (str:string|undefined) => {
+        if(str) {
+            const result = baseNameXtractor.exec(str);
+            return result ? result[0][1] : undefined
+        } else {
+            return undefined
         }
     }
 
-    return <div className={classes.centered}>
-        {
-            downloadUrl ? <iframe src={downloadUrl} style={{display:"none"}}/> : null
+    const newStyleDownload = async (response: AxiosResponse<ObjectGetResponse<string>>) => {
+        //saveShowFilePicker is available in Chrome and other Chromium based browsers but typescript has no definitions for it
+        console.log("Using new file picker")
+        // @ts-ignore
+        const handle = await window.showSaveFilePicker({
+            suggestedName: baseName(props.archiveEntryPath)
+        });
+        const writable = await handle.createWritable();
+        const content = await fetch(response.data.entry);
+
+        if(content.body) {
+            setDownloading(true);
+            //the pipeTo method will automatically close the writable stream
+            await content.body.pipeTo(writable);
+            setDownloading(false);
+        } else {
+            alert("No content was available to download");
         }
+    }
+
+    const oldStyleDownload = (response:AxiosResponse<ObjectGetResponse<string>>) => {
+        console.log("Using legacy output");
+        setDownloadUrl(response.data.entry);
+        const triggerDownload = (ctr:number)=> window.setTimeout(()=>{
+            if(oldStyleDownloadRef.current) {
+                oldStyleDownloadRef.current.click();
+            } else {
+                if(ctr>10) {
+                    console.error("Could not trigger download after 5 seconds, something has gone wrong.");
+                } else {
+                    triggerDownload(ctr+1);
+                }
+            }
+        }, 500);
+
+        triggerDownload(0);
+    }
+
+    const doDownload = async () => {
+        try {
+            const response = await axios.get<ObjectGetResponse<string>>(`/api/download/${props.archiveEntryId}`);
+            // @ts-ignore
+            if(window.showSaveFilePicker) {
+                //the new style uses the File System Access API, which also requires a secure context to work.
+                await newStyleDownload(response);
+            } else {
+                await oldStyleDownload(response);
+            }
+        } catch(err)  {
+            console.error("Could not download content: ", err);
+            alert("Could not download, see browser console for details");
+        }
+    }
+
+    const oldStyleDownloadRef = createRef<HTMLAnchorElement>();
+
+    return <div className={classes.centered}>
+        <a ref={oldStyleDownloadRef} href={downloadUrl ?? "#"} style={{display:"none"}}/>
         <span style={{display: "block"}}>
             <Typography className={classes.runOnText}>Added to lightbox&nbsp;</Typography>
             <TimestampFormatter className={classes.runOnText} relative={true} value={props.lightboxEntry.addedAt}/>
@@ -123,10 +180,13 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
                     </Grid>
                     <Grid item>
                         {
-                            isDownloadable() ? <Tooltip title="Download just this file">
-                                <IconButton onClick={doDownload}>
-                                    <GetApp/>
-                                </IconButton>
+                            isDownloadable() ? <Tooltip title={downloading ? "Download in progress..." : "Download just this file"}>
+                                {
+                                    downloading ? <CircularProgress/> :
+                                        <IconButton onClick={doDownload}>
+                                            <GetApp/>
+                                        </IconButton>
+                                }
                             </Tooltip> : null
                         }
                     </Grid>
@@ -136,33 +196,11 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
         {
             props.lightboxEntry.availableUntil ? <>
                 <Typography className={classes.runOnText}>
-                    Available for
+                    Available for{" "}
                 </Typography>
                 <TimestampFormatter relative={true} value={props.lightboxEntry.availableUntil} className={classes.runOnText}/>
             </> : <Typography className={classes.runOnText}>Available indefinitely</Typography>
         }
-
-        {/*<Typography className={clsx(classes.centered, classes.small)}>*/}
-        {/*    <a style={{cursor: "pointer"}} onClick={props.checkArchiveStatusClicked}>Re-check</a>*/}
-        {/*</Typography>*/}
-        {/*<Typography className={clsx(classes.centered, classes.small)}>*/}
-        {/*    <a style={{cursor: "pointer"}} onClick={()=>props.archiveEntryId ? props.redoRestoreClicked(props.archiveEntryId) : null}>*/}
-        {/*        {displayRedo(props.lightboxEntry.restoreStatus)}*/}
-        {/*    </a>*/}
-        {/*    {*/}
-        {/*        props.showingArchiveSpinner ? <CircularProgress className={classes.smallSpinner}/> : null*/}
-        {/*    }*/}
-        {/*</Typography>*/}
-        {/*<AvailabilityInsert status={props.lightboxEntry.restoreStatus}*/}
-        {/*                    availableUntil={props.lightboxEntry.availableUntil}*/}
-        {/*                    hidden={shouldHideAvailability()}*/}
-        {/*                    fileId={props.archiveEntryId}*/}
-        {/*                    fileNameOnly={extractPath()}*/}
-        {/*/>*/}
-        {/*<Typography className={clsx(classes.centered, classes.small, classes.information)}>*/}
-        {/*    {props.lightboxEntry.restoreStatus}*/}
-        {/*</Typography>*/}
-        {/*<Divider style={{display: shouldHideAvailability() ? "inherit" : "none" }}/>*/}
     </div>;
 }
 

--- a/frontend/app/Lightbox/LightboxDetailsInsert.tsx
+++ b/frontend/app/Lightbox/LightboxDetailsInsert.tsx
@@ -4,12 +4,10 @@ import {CircularProgress, Divider, Grid, Icon, IconButton, makeStyles, Tooltip, 
 import TimestampFormatter from "../common/TimestampFormatter";
 import RestoreStatusComponent from "./RestoreStatusComponent";
 import {baseStyles} from "../BaseStyles";
-import {IconProp} from "@fortawesome/fontawesome-svg-core";
-import clsx from "clsx";
 import RestoreStatusIndicator from "./RestoreStatusIndicator";
 import {AirportShuttle, GetApp, YoutubeSearchedFor} from "@material-ui/icons";
 import axios, {AxiosResponse} from "axios";
-import {formatError} from "../common/ErrorViewComponent";
+import {baseName} from "../common/Fileinfo";
 
 interface LightboxDetailsInsertProps {
     lightboxEntry: LightboxEntry;
@@ -62,28 +60,8 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
         return props.lightboxEntry.restoreStatus=="RS_SUCCESS" || props.lightboxEntry.restoreStatus=="RS_UNNEEDED" || props.lightboxEntry.restoreStatus=="RS_ALREADY"
     }
 
-    // const doDownload  = async () => {
-    //     try {
-    //         const response = await axios.get<ObjectGetResponse<string>>("/api/download/" + props.archiveEntryId);
-    //         setDownloadUrl(response.data.entry);
-    //     } catch(err) {
-    //         console.error("Could not get download URL: ", err);
-    //         props.onError ? props.onError(formatError(err, false)) : null;
-    //     }
-    // }
-
-    const baseNameXtractor = /\/([^\/]+)$/;
-    const baseName = (str:string|undefined) => {
-        if(str) {
-            const result = baseNameXtractor.exec(str);
-            return result ? result[0][1] : undefined
-        } else {
-            return undefined
-        }
-    }
 
     const newStyleDownload = async (response: AxiosResponse<ObjectGetResponse<string>>) => {
-        //saveShowFilePicker is available in Chrome and other Chromium based browsers but typescript has no definitions for it
         console.log("Using new file picker")
         // @ts-ignore
         const handle = await window.showSaveFilePicker({
@@ -128,11 +106,17 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
                 //the new style uses the File System Access API, which also requires a secure context to work.
                 await newStyleDownload(response);
             } else {
+                alert("Downloading like this works best in Chrome. If the download does not work, please load Chrome and try again in that.");
                 await oldStyleDownload(response);
             }
         } catch(err)  {
-            console.error("Could not download content: ", err);
-            alert("Could not download, see browser console for details");
+            if(err.name && err.name==="AbortError") {
+                //the user aborted the download, so don't alert them
+                console.log("User cancelled download");
+            } else {
+                console.error("Could not download content: ", err);
+                alert("Could not download, see browser console for details");
+            }
         }
     }
 

--- a/frontend/app/common/Fileinfo.ts
+++ b/frontend/app/common/Fileinfo.ts
@@ -20,5 +20,21 @@ function extractFileInfo (fullpath:string):FileInfo {
     }
 }
 
+const baseNameXtractor = /\/([^\/]+)$/;
+const baseName = (str:string|undefined) => {
+    if(str && str.length>0) {
+        const result = baseNameXtractor.exec(str);
+        if(result) {
+            return result[1];
+        } else if(!str.includes("/")) {
+            return str;
+        } else {
+            throw `baseName extraction failed on ${str}, please fix`;
+        }
+    } else {
+        return undefined
+    }
+}
+
 export type {FileInfo};
-export {extractFileInfo};
+export {extractFileInfo, baseName};

--- a/test/BulkDownloadsControllerSpec.scala
+++ b/test/BulkDownloadsControllerSpec.scala
@@ -88,8 +88,10 @@ class BulkDownloadsControllerSpec extends Specification with Mockito with ZonedD
       val fakeConfig = Configuration.from(Map(
         "externalData"-> Map("indexName"->"archivehunter", "awsRegion"->"ap-east-1")
       ))
+      implicit val s3ClientMgr = mock[S3ClientManager]
+
       val toTest = new BulkDownloadsController(fakeConfig, mock[SyncCacheApi], mock[ServerTokenDAO], mock[LightboxBulkEntryDAO],
-        mock[LightboxEntryDAO], mock[ESClientManager], mock[S3ClientManager], mock[ControllerComponents], mock[BearerTokenAuth], TestProbe().ref) {
+        mock[LightboxEntryDAO], mock[ESClientManager], mock[ControllerComponents], mock[BearerTokenAuth], TestProbe().ref) {
         override protected def getSearchSource(p: ScrollPublisher): Source[ArchiveEntry, NotUsed] = fakeInputData
 
         def callFunc(bulkEntry:LightboxBulkEntry) =  streamingEntriesForBulk(bulkEntry)
@@ -129,9 +131,10 @@ class BulkDownloadsControllerSpec extends Specification with Mockito with ZonedD
       val mockServerTokenDAO = mock[ServerTokenDAO]
 
       mockServerTokenDAO.put(any) returns Future(mock[ServerTokenEntry])
+      implicit val s3ClientMgr = mock[S3ClientManager]
 
       val toTest = new BulkDownloadsController(fakeConfig, mock[SyncCacheApi], mockServerTokenDAO, mock[LightboxBulkEntryDAO],
-        mock[LightboxEntryDAO], mock[ESClientManager], mock[S3ClientManager], mock[ControllerComponents], mock[BearerTokenAuth], TestProbe().ref)  {
+        mock[LightboxEntryDAO], mock[ESClientManager], mock[ControllerComponents], mock[BearerTokenAuth], TestProbe().ref)  {
         def callFunc(updatedToken:ServerTokenEntry, bulkEntry:LightboxBulkEntry) = saveTokenOnly(updatedToken, bulkEntry)
       }
 


### PR DESCRIPTION
## What does this change?

Fixes the "direct download" functionality from the lightbox, which Vega reported as broken.

**Note** that the improved code uses APIs which are currently unique to Chrome (but are part of upcoming standards).  For this reason, if the API is not found to be supported then a warning is shown requesting the user to try with Chrome.  This is acceptable for us, because Chrome is the "standard" supported browser.  Functionality has been checked against our standard version.

## How to test

- Deploy to CODE
- Using the Browse view, add some content to your Lightbox
- Go to the Lightbox, and click one of the files you just added.
- Click the "download" button that appears on the right, below the preview and "Added to lightbox..." message
- You should be prompted for a save location. While save is in progress the "download" button changes to a spinner and when it completes a success message should be shown underneath

## How can we measure success?

Syndication users can download individual files again

## Have we considered potential risks?

This uses browser APIs which are not fully standardised and falls back to the old (most likely broken, in many cases) behaviour if not.  This is considered acceptable since our standard user recommendations include a browser which does support the APIs and as a company we do not support usage on other browsers.
