### PR TITLE
Fix/invalid lightboxinfo

### DIFF
--- a/frontend/app/Lightbox/NewLightbox.tsx
+++ b/frontend/app/Lightbox/NewLightbox.tsx
@@ -116,13 +116,14 @@ const NewLightbox:React.FC<RouteComponentProps> = (props) => {
     const refreshData = async () => {
         setLoading(true);
         try {
+            console.log("debug: loading lightbox details");
             const results = await performLoad();
 
             const detailsResult = results[0].data as LightboxDetailsResponse;
             const configResult = results[1].data as ObjectListResponse<string>;
-            setLightboxDetails(detailsResult.entries)
+            setLightboxDetails(detailsResult.entries);
+            console.log("debug: lightbox details loaded");
             setExpiryDays(configResult.entries.length>0 ? parseInt(configResult.entries[0]) : 10);
-
         } catch(err) {
             console.error("Could not load in lightbox data: ", err);
             setLastError(formatError(err, false));
@@ -130,6 +131,14 @@ const NewLightbox:React.FC<RouteComponentProps> = (props) => {
         }
     }
 
+    useEffect(()=>{
+        console.log("LightboxDetails are changing", lightboxDetails);
+        console.log("LightboxDetails are ", Object.keys(lightboxDetails).length, " records long");
+
+        return ()=>{
+            console.log("Old LightboxDetails are ", Object.keys(lightboxDetails).length, " records long")
+        }
+    }, [lightboxDetails]);
     /**
      * updates our record of the archive status for the currently selected item
      */

--- a/frontend/app/Lightbox/NewLightbox.tsx
+++ b/frontend/app/Lightbox/NewLightbox.tsx
@@ -19,6 +19,8 @@ import EntryDetails from "../Entry/EntryDetails";
 import LightboxDetailsInsert from "./LightboxDetailsInsert";
 import {UserContext} from "../Context/UserContext";
 import BrowseFilter from "../browse/BrowseFilter";
+import {Simulate} from "react-dom/test-utils";
+import select = Simulate.select;
 
 const useStyles = makeStyles({
     browserWindow: {
@@ -116,7 +118,11 @@ const NewLightbox:React.FC<RouteComponentProps> = (props) => {
     const refreshData = async () => {
         setLoading(true);
         try {
-            console.log("debug: loading lightbox details");
+            if(selectedUser=="") {
+                console.log("Not trying to load lightbox for empty selectedUser string");
+                return;
+            }
+            console.log(`debug: loading lightbox details for '${selectedUser}'`);
             const results = await performLoad();
 
             const detailsResult = results[0].data as LightboxDetailsResponse;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@material-ui/icons": "^4.9.1",
         "@material-ui/lab": "^4.0.0-alpha.57",
         "@types/react-helmet": "^6.1.0",
-        "axios": "^0.21.1",
+        "axios": "^0.27.1",
         "can-ndjson-stream": "^1.0.2",
         "chart.js": "^2.9.4",
         "date-fns": "^2.22.1",
@@ -1756,6 +1756,15 @@
         "axios": "^0.21.1"
       }
     },
+    "node_modules/@types/moxios/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "14.14.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
@@ -2249,15 +2258,28 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.1.tgz",
+      "integrity": "sha512-ePNMai55xo5GsXajb/k756AqZqpqeDaGwGcdvbZLSSELbbYwsIn2jNmGfUPEwd8j/yu4OoMstLLIVa4t0MneEA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-code-frame": {
@@ -2816,7 +2838,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3107,7 +3128,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3733,9 +3753,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "funding": [
         {
           "type": "individual",
@@ -10596,6 +10616,17 @@
       "dev": true,
       "requires": {
         "axios": "^0.21.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        }
       }
     },
     "@types/node": {
@@ -11053,15 +11084,27 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.1.tgz",
+      "integrity": "sha512-ePNMai55xo5GsXajb/k756AqZqpqeDaGwGcdvbZLSSELbbYwsIn2jNmGfUPEwd8j/yu4OoMstLLIVa4t0MneEA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "babel-code-frame": {
@@ -11528,7 +11571,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -11768,8 +11810,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -12271,9 +12312,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "form-data": {
       "version": "3.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@types/react-helmet": "^6.1.0",
-    "axios": "^0.21.1",
+    "axios": "^0.27.1",
     "can-ndjson-stream": "^1.0.2",
     "chart.js": "^2.9.4",
     "date-fns": "^2.22.1",


### PR DESCRIPTION
## What does this change?

Fix for lightbox information panel crashing

## How to test

Load a large lightbox, then switch user. The "details" call for the first should be automatically cancelled when you load the second (this data inconsistency is what was causing the crash before)

## How can we measure success?

Consistent user experience for admins

