### PR TITLE
Fix/archive status

### DIFF
--- a/app/controllers/LightboxController.scala
+++ b/app/controllers/LightboxController.scala
@@ -253,7 +253,12 @@ class LightboxController @Inject() (override val config:Configuration,
             case GlacierRestoreActor.RestoreInProgress(entry)=>
               Ok(RestoreStatusResponse("ok", entry.id, RestoreStatus.RS_UNDERWAY, None, None).asJson)
             case GlacierRestoreActor.RestoreNotRequested(entry)=>
-              Ok(RestoreStatusResponse("not_requested", entry.id, RestoreStatus.RS_UNNEEDED, None, None).asJson)
+              val restoreStatus = if(entry.storageClass==StorageClass.GLACIER) {
+                RestoreStatus.RS_EXPIRED
+              } else {
+                RestoreStatus.RS_UNNEEDED
+              }
+              Ok(RestoreStatusResponse("not_requested", entry.id, restoreStatus, None, None).asJson)
           })
       })
     }

--- a/app/services/GlacierRestoreActor.scala
+++ b/app/services/GlacierRestoreActor.scala
@@ -85,7 +85,7 @@ class GlacierRestoreActor @Inject() (config:Configuration, esClientMgr:ESClientM
         lbEntry.copy(restoreStatus = newStatus, restoreCompleted = Some(ZonedDateTime.now()), availableUntil = expiryTime)
       case RestoreStatus.RS_ERROR=>
         lbEntry.copy(restoreStatus = newStatus, restoreCompleted = Some(ZonedDateTime.now()))
-      case RestoreStatus.RS_UNDERWAY=>
+      case _=>
         lbEntry.copy(restoreStatus = newStatus)
     }
     lbEntryDAO.put(updatedEntry)

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/RestoreStatus.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/RestoreStatus.scala
@@ -11,9 +11,10 @@ import io.circe.{Decoder, Encoder}
   * underway - restore request has been sent and is being processed
   * success - item has been restored
   * error - item could not be restored for some reason
+  * expired - item was restored but is now archived again
   */
 object RestoreStatus extends Enumeration {
-  val RS_UNNEEDED,RS_ALREADY,RS_PENDING,RS_UNDERWAY,RS_SUCCESS,RS_ERROR=Value
+  val RS_UNNEEDED,RS_ALREADY,RS_PENDING,RS_UNDERWAY,RS_SUCCESS,RS_ERROR,RS_EXPIRED=Value
 }
 
 trait RestoreStatusEncoder {

--- a/frontend/app/Lightbox/LightboxAvailability.tsx
+++ b/frontend/app/Lightbox/LightboxAvailability.tsx
@@ -34,7 +34,7 @@ const LightboxAvailability:React.FC<LightboxAvailabilityProps> = (props) => {
     }, [props.maybeAvailableUntil]);
 
     if(expiryDate) {
-        if(expiryDate.isAfter(moment())) {
+        if(expiryDate.isBefore(moment())) {
             return <Typography className={classes.runOnText}>Expired {expiryDate.fromNow(false)}</Typography>
         } else {
             return <Typography className={classes.runOnText}>Available for {expiryDate.fromNow(false)}</Typography>
@@ -45,6 +45,8 @@ const LightboxAvailability:React.FC<LightboxAvailabilityProps> = (props) => {
                 return <Typography className={classes.runOnText}>Available indefinitely</Typography>
             case "RS_ERROR":
                 return <Typography className={classes.runOnText}>Not available</Typography>
+            case "RS_EXPIRED":
+                return <Typography className={classes.runOnText}>Returned to archive</Typography>
             default:
                 return <></>
         }

--- a/frontend/app/Lightbox/LightboxAvailability.tsx
+++ b/frontend/app/Lightbox/LightboxAvailability.tsx
@@ -1,0 +1,55 @@
+import React, {useEffect, useState} from "react";
+import moment, {Moment} from "moment";
+import {makeStyles, Typography} from "@material-ui/core";
+import TimestampFormatter from "../common/TimestampFormatter";
+import {RestoreStatus} from "../types";
+
+interface LightboxAvailabilityProps {
+    maybeAvailableUntil?: string;
+    restoreStatus: RestoreStatus;
+}
+
+const useStyles = makeStyles({
+    runOnText: {
+        display: "inline"
+    },
+});
+
+const LightboxAvailability:React.FC<LightboxAvailabilityProps> = (props) => {
+    const [expiryDate, setExpiryDate] = useState<Moment|undefined>();
+
+    const classes = useStyles();
+
+    useEffect(()=>{
+        if(props.maybeAvailableUntil) {
+            try {
+                const parsedDate = moment(props.maybeAvailableUntil);
+                setExpiryDate(parsedDate);
+            } catch(err) {
+                console.error("Could not parse timestring ", props.maybeAvailableUntil, ": ", err);
+            }
+        } else {
+            setExpiryDate(undefined);
+        }
+    }, [props.maybeAvailableUntil]);
+
+    if(expiryDate) {
+        if(expiryDate.isAfter(moment())) {
+            return <Typography className={classes.runOnText}>Expired {expiryDate.fromNow(false)}</Typography>
+        } else {
+            return <Typography className={classes.runOnText}>Available for {expiryDate.fromNow(false)}</Typography>
+        }
+    } else {
+        switch(props.restoreStatus) {
+            case "RS_UNNEEDED":
+                return <Typography className={classes.runOnText}>Available indefinitely</Typography>
+            case "RS_ERROR":
+                return <Typography className={classes.runOnText}>Not available</Typography>
+            default:
+                return <></>
+        }
+
+    }
+}
+
+export default LightboxAvailability;

--- a/frontend/app/Lightbox/LightboxDetailsInsert.tsx
+++ b/frontend/app/Lightbox/LightboxDetailsInsert.tsx
@@ -8,6 +8,7 @@ import RestoreStatusIndicator from "./RestoreStatusIndicator";
 import {AirportShuttle, CheckCircle, GetApp, YoutubeSearchedFor} from "@material-ui/icons";
 import axios, {AxiosResponse} from "axios";
 import {baseName} from "../common/Fileinfo";
+import LightboxAvailability from "./LightboxAvailability";
 
 interface LightboxDetailsInsertProps {
     lightboxEntry: LightboxEntry;
@@ -188,14 +189,7 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
                 </Grid>
             </Grid>
         </Grid>
-        {
-            props.lightboxEntry.availableUntil ? <>
-                <Typography className={classes.runOnText}>
-                    Available for{" "}
-                </Typography>
-                <TimestampFormatter relative={true} value={props.lightboxEntry.availableUntil} className={classes.runOnText}/>
-            </> : <Typography className={classes.runOnText}>Available indefinitely</Typography>
-        }
+        <LightboxAvailability maybeAvailableUntil={props.lightboxEntry.availableUntil} restoreStatus={props.lightboxEntry.restoreStatus}/>
         {
             downloadedTo ? <Typography className={classes.smallText}><CheckCircle className={classes.successIcon}/>Downloaded to {downloadedTo}</Typography> : undefined
         }

--- a/frontend/app/Lightbox/LightboxDetailsInsert.tsx
+++ b/frontend/app/Lightbox/LightboxDetailsInsert.tsx
@@ -60,6 +60,7 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
             case "RS_UNNEEDED":
                 return false;
             case "RS_ERROR":
+            case "RS_EXPIRED":
             case "RS_ALREADY":
             case "RS_SUCCESS":
                 return true;
@@ -145,7 +146,7 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
             startTime={props.lightboxEntry.restoreStarted}
             completed={props.lightboxEntry.restoreCompleted}
             expires={props.lightboxEntry.availableUntil}
-            hidden={props.lightboxEntry.restoreStatus==="RS_UNNEEDED"}
+            hidden={props.lightboxEntry.restoreStatus==="RS_UNNEEDED"||props.lightboxEntry.restoreStatus==="RS_EXPIRED"}
         />
         <Grid container direction="row" justify="space-between" spacing={3}>
             <Grid item className={classes.nicelyAlignedIcon} style={{marginLeft: "auto"}}>

--- a/frontend/app/Lightbox/RestoreStatusComponent.jsx
+++ b/frontend/app/Lightbox/RestoreStatusComponent.jsx
@@ -3,6 +3,15 @@ import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import TimestampFormatter from "../common/TimestampFormatter";
 import axios from 'axios';
+import {
+    AccessTime,
+    CheckCircle,
+    DirectionsRun,
+    RemoveShoppingCart,
+    RemoveShoppingCartRounded,
+    WarningRounded
+} from "@material-ui/icons";
+import {Tooltip} from "@material-ui/core";
 
 class RestoreStatusComponent extends React.Component {
     static propTypes = {
@@ -14,19 +23,21 @@ class RestoreStatusComponent extends React.Component {
     };
 
     /**
-     *   val RS_UNNEEDED,RS_ALREADY,RS_PENDING,RS_UNDERWAY,RS_SUCCESS,RS_ERROR=Value
+     *   val RS_UNNEEDED,RS_ALREADY,RS_PENDING,RS_UNDERWAY,RS_SUCCESS,RS_ERROR,RS_EXPIRED=Value
      */
     statusIcon(){
         switch(this.props.status){
             case "RS_PENDING":
-                return <span data-tip="Pending"><FontAwesomeIcon size="1.5x" icon="clock"/></span>;
+                return <Tooltip title="Pending"><AccessTime/></Tooltip>;
             case "RS_UNDERWAY":
-                return <span data-tip="Running" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="running" style={{color: "blue"}}/></span>;
+                return <Tooltip title="Running"><DirectionsRun style={{color: "blue"}}/></Tooltip>;
             case "RS_SUCCESS":
             case "RS_ALREADY":
-                return <span data-tip="Success" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="check-circle" style={{color:"green"}}/></span>;
+                return <Tooltip title="Available"><CheckCircle style={{color:"green"}}/></Tooltip>;
             case "RS_ERROR":
-                return <span data-tip="Error" data-for="jobslist-tooltip"><FontAwesomeIcon size="1.5x" icon="exclamation-triangle" style={{color:"red"}}/></span>;
+                return <Tooltip title="Error"><WarningRounded style={{color:"red"}}/></Tooltip>;
+            case "RS_EXPIRED":
+                return <Tooltip title="Expired"><RemoveShoppingCartRounded/></Tooltip>;
             default:
                 return <span data-tip={this.props.status}>{this.props.status}</span>;
         }
@@ -42,6 +53,8 @@ class RestoreStatusComponent extends React.Component {
                 return <TimestampFormatter relative={true} value={this.props.completed}/>;
             case "RS_ERROR":
                 return <TimestampFormatter relative={true} value={this.props.completed ? this.props.completed : this.props.startTime}/>;
+            default:
+                return <span/>;
         }
     }
 

--- a/frontend/app/Lightbox/RestoreStatusIndicator.tsx
+++ b/frontend/app/Lightbox/RestoreStatusIndicator.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {LightboxEntry} from "../types";
 import {Tooltip} from "@material-ui/core";
-import {AcUnit, Check} from "@material-ui/icons";
+import {AcUnit, Check, RemoveShoppingCartRounded} from "@material-ui/icons";
 
 interface RestoreStatusIndicatorProps {
     entry: LightboxEntry;
@@ -22,6 +22,8 @@ const RestoreStatusIndicator:React.FC<RestoreStatusIndicatorProps> = (props) => 
                 return "Not in deep-freeze";
             case "RS_UNDERWAY":
                 return "Restore in progress";
+            case "RS_EXPIRED":
+                return "Restore has expired";
         }
     }
 
@@ -36,6 +38,8 @@ const RestoreStatusIndicator:React.FC<RestoreStatusIndicatorProps> = (props) => 
                 return <Check className={props.className} style={{color: "green"}}/>;
             case "RS_UNDERWAY":
                 return <AcUnit className={props.className} style={{color: "orange"}}/>;
+            case "RS_EXPIRED":
+                return <RemoveShoppingCartRounded className={props.className}/>;
         }
     }
 

--- a/frontend/app/types.d.ts
+++ b/frontend/app/types.d.ts
@@ -270,7 +270,7 @@ interface LightboxBulk {
 
 type LightboxBulkResponse = ObjectListResponse<LightboxBulk>;
 
-type RestoreStatus = "RS_UNNEEDED"|"RS_ALREADY"|"RS_PENDING"|"RS_UNDERWAY"|"RS_SUCCESS"|"RS_ERROR";
+type RestoreStatus = "RS_UNNEEDED"|"RS_ALREADY"|"RS_PENDING"|"RS_UNDERWAY"|"RS_SUCCESS"|"RS_ERROR"|"RS_EXPIRED";
 
 interface LightboxEntry {
     userEmail: string;


### PR DESCRIPTION
## What does this change?

Fixes items whose restores have expired showing "available indefinitely"

## How to test

Go into a lightbox and find an item which has expired but has the wrong status showing. Click the 're-check status' button. You should now see that the item has an "expired" restore status:

<img width="336" alt="Screenshot 2022-04-26 at 17 26 32" src="https://user-images.githubusercontent.com/12482441/165347932-344f2f3d-10ab-43aa-934e-d89880aac0f8.png">


## How can we measure success?

More accurate restore status data
