### PR TITLE
Lambda Function Support for Restore Jobs Starting and Restored Items Expiring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,6 +125,11 @@ lazy val inputLambda = (project in file("lambda/input"))
     "com.amazonaws" % "aws-java-sdk-lambda" % awsSdkVersion,
     "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
     "com.amazonaws" % "aws-lambda-java-core" % "1.0.0",
+    "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
+    "com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion,
+    "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-protobuf" % akkaVersion,
+    "com.typesafe.akka" %% "akka-protobuf-v3" % akkaVersion,
   ),
   assembly / assemblyJarName:= "inputLambda.jar",
   assembly / assemblyMergeStrategy:= {

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -283,6 +283,17 @@ Resources:
           ProvisionedThroughput:
             WriteCapacityUnits: 1
             ReadCapacityUnits: 4
+        - IndexName: fileIdIndex
+          KeySchema:
+            - AttributeName: fileId
+              KeyType: HASH
+            - AttributeName: userEmail
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            WriteCapacityUnits: 1
+            ReadCapacityUnits: 4
 
   LightboxBulkEntryTable:
     Type: AWS::DynamoDB::Table

--- a/cloudformation/bucketmonitor.yaml
+++ b/cloudformation/bucketmonitor.yaml
@@ -48,6 +48,10 @@ Resources:
               - ":443"
           NOTIFICATION_QUEUE:
             Fn::ImportValue: !Sub ${ArchiveHunterAppStack}-IngestTranscodeMsg
+          JOB_TABLE:
+            Fn::ImportValue: !Sub ${ArchiveHunterAppStack}-JobHistoryTable
+          LIGHTBOX_TABLE:
+            Fn::ImportValue: !Sub ${ArchiveHunterAppStack}-LightboxTable
       Handler: InputLambdaMain
       FunctionName: !Sub archivehunter-input-${Stage}
       MemorySize: 768
@@ -121,3 +125,41 @@ Resources:
                 - logs:CreateLogStream
                 - logs:PutLogEvents
               Resource: "*"
+            - Effect: Allow
+              Action:
+                - dynamodb:BatchGetItem
+                - dynamodb:BatchWriteItem
+                - dynamodb:ConditionCheckItem
+                - dynamodb:PutItem
+                - dynamodb:DescribeTable
+                - dynamodb:DeleteItem
+                - dynamodb:GetItem
+                - dynamodb:Scan
+                - dynamodb:Query
+                - dynamodb:UpdateItem
+                - dynamodb:GetShardIterator
+                - dynamodb:DescribeStream
+                - dynamodb:GetRecords
+                - dynamodb:ListStreams
+                - dynamodb:DescribeLimits
+              Resource:
+                - Fn::ImportValue: !Sub ${ArchiveHunterAppStack}-JobHistoryTable
+            - Effect: Allow
+              Action:
+                - dynamodb:BatchGetItem
+                - dynamodb:BatchWriteItem
+                - dynamodb:ConditionCheckItem
+                - dynamodb:PutItem
+                - dynamodb:DescribeTable
+                - dynamodb:DeleteItem
+                - dynamodb:GetItem
+                - dynamodb:Scan
+                - dynamodb:Query
+                - dynamodb:UpdateItem
+                - dynamodb:GetShardIterator
+                - dynamodb:DescribeStream
+                - dynamodb:GetRecords
+                - dynamodb:ListStreams
+                - dynamodb:DescribeLimits
+              Resource:
+                - Fn::ImportValue: !Sub ${ArchiveHunterAppStack}-LightboxTable

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveHunterConfigurationExt.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/ArchiveHunterConfigurationExt.scala
@@ -10,7 +10,9 @@ class ArchiveHunterConfigurationExt extends ArchiveHunterConfiguration {
     "externalData.awsProfile"->"AWS_PROFILE",
     "elasticsearch.hostname"->"ES_HOST_NAME",
     "proxies.tableName" -> "PROXIES_TABLE_NAME",
-    "instances.tableName" -> "INSTANCES_TABLE"
+    "instances.tableName" -> "INSTANCES_TABLE",
+    "externalData.jobTable" -> "JOB_TABLE",
+    "lightbox.tableName" -> "LIGHTBOX_TABLE",
   )
 
   override def getOptional[T](key: String)(implicit converter: String=>T): Option[T] = {

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxEntryDAO.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxEntryDAO.scala
@@ -61,4 +61,9 @@ class LightboxEntryDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr
       .exec(table.put(entry))
       .runWith(Sink.head)
       .map(_=>entry)
+
+  def getForFileId(fileId:String)(implicit ec:ExecutionContext) =
+    scanamoAlpakka
+      .exec(table.query("fileId"===fileId))
+      .runWith(MakeLightboxEntrySink)
 }

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxEntryDAO.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxEntryDAO.scala
@@ -28,6 +28,7 @@ class LightboxEntryDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr
 
   protected val table = Table[LightboxEntry](lightboxTableName)
   protected val statusIndex = table.index("statusIndex")
+  protected val fileIdIndex = table.index("fileIdIndex")
 
   private val MakeLightboxEntrySink = Sink.fold[List[Either[DynamoReadError, LightboxEntry]], List[Either[DynamoReadError, LightboxEntry]]](List())(_ ++ _)
 
@@ -64,6 +65,6 @@ class LightboxEntryDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr
 
   def getFilesForId(fileId:String)(implicit ec:ExecutionContext) =
     scanamoAlpakka
-      .exec(table.query("fileId"===fileId))
+      .exec(fileIdIndex.query("fileId"===fileId))
       .runWith(MakeLightboxEntrySink)
 }

--- a/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxEntryDAO.scala
+++ b/common/src/main/scala/com/theguardian/multimedia/archivehunter/common/cmn_models/LightboxEntryDAO.scala
@@ -62,7 +62,7 @@ class LightboxEntryDAO @Inject()(config:ArchiveHunterConfiguration, ddbClientMgr
       .runWith(Sink.head)
       .map(_=>entry)
 
-  def getForFileId(fileId:String)(implicit ec:ExecutionContext) =
+  def getFilesForId(fileId:String)(implicit ec:ExecutionContext) =
     scanamoAlpakka
       .exec(table.query("fileId"===fileId))
       .runWith(MakeLightboxEntrySink)

--- a/lambda/input/src/main/scala/InputLambdaMain.scala
+++ b/lambda/input/src/main/scala/InputLambdaMain.scala
@@ -268,20 +268,60 @@ class InputLambdaMain extends RequestHandler[S3Event, Unit] with DocId with Zone
 
       val path = URLDecoder.decode(rec.getS3.getObject.getKey,"UTF-8")
 
-      println(s"Source object is s3://${rec.getS3.getBucket.getName}/$path in ${rec.getAwsRegion}")
+      println(s"Source object is s3://${rec.getS3.getBucket.getName}/$path version ${rec.getS3.getObject.getVersionId} in ${rec.getAwsRegion}")
       println(s"Event was sent by ${rec.getUserIdentity.getPrincipalId}")
 
       rec.getEventName match {
+        /*
+        All of these events indicate new content
+         */
         case "ObjectCreated:Put"=>
+          handleCreated(rec, path)
+        case "ObjectCreated:Post"=>
           handleCreated(rec, path)
         case "ObjectCreated:CompleteMultipartUpload"=>
           handleCreated(rec, path)
         case "ObjectCreated:Copy"=>
           handleCreated(rec, path)
-        case "ObjectRemoved:Delete"=>
+
+        /*
+        All of these events indicate something was deleted, or an deletion attempt
+         */
+        case "ObjectRemoved:Delete"=> //object was _actually_ deleted
           handleRemoved(rec, path)
-        case "ObjectRestore:Completed"=>
+        case "ReducedRedundancyLostObject"=>
+          handleRemoved(rec, path)
+        case "LifecycleExpiration:Delete"=>
+          handleRemoved(rec, path)
+        case "ObjectRemoved:DeleteMarkerCreated"=> //object was _apparently_ deleted, leaving versions behind
+          println("ERROR ObjectRemoved:DeleteMarkerCreated not implemented")
+          throw new RuntimeException("event was not implemented")
+        case "LifecycleExpiration:DeleteMarkerCreated"=>  //lifecycle rule 'deleted' the object, leaving versions behind
+          println("ERROR LifecycleExpiration:DeleteMarkerCreated not implemented")
+          throw new RuntimeException("event was not implemented")
+
+        /*
+        All of these events relate to Glacier restores
+         */
+        case "ObjectRestore:Post"=> //restore has been initiated
+          println("ERROR ObjectRestore:Post not implemented")
+          throw new RuntimeException("event was not implemented")
+        case "ObjectRestore:Completed"=>  //restore has been completed
           handleRestored(rec, path)
+        case "ObjectRestore:Delete"=>     //restore has expired and been dropped back
+          println("ERROR ObjectRestore:Delete not implemented")
+          throw new RuntimeException("event was not implemented")
+
+        /*
+        This relates to Standard -> IA -> Glacier -> Glacier Deep transitions
+         */
+        case "LifecycleTransition"=>      //s3 changed the storage tier
+          println("ERROR LifecycleTransition not implemented")
+          throw new RuntimeException("event was not implemented")
+
+        /*
+        Default catch-all that shows an error
+         */
         case other:String=>
           println(s"ERROR: received unknown event $other")
           throw new RuntimeException(s"unknown event $other received")

--- a/lambda/input/src/main/scala/InputLambdaMain.scala
+++ b/lambda/input/src/main/scala/InputLambdaMain.scala
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.LogManager
 import com.sksamuel.elastic4s.http.ElasticClient
 import com.sksamuel.elastic4s.http.ElasticDsl.update
 import com.theguardian.multimedia.archivehunter.common.cmn_helpers.PathCacheExtractor
-import com.theguardian.multimedia.archivehunter.common.cmn_models.{IngestMessage, ItemNotFound, JobModelDAO, JobStatus, PathCacheEntry, PathCacheIndexer, LightboxEntryDAO, RestoreStatus}
+import com.theguardian.multimedia.archivehunter.common.cmn_models.{IngestMessage, ItemNotFound, JobModelDAO, JobStatus, LightboxEntryDAO, PathCacheEntry, PathCacheIndexer, RestoreStatus}
 import org.apache.http.HttpHost
 import org.elasticsearch.client.RestClient
 import io.circe.syntax._
@@ -27,11 +27,13 @@ import com.theguardian.multimedia.archivehunter.common.cmn_helpers.S3ClientExten
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.model.{HeadObjectResponse, NoSuchKeyException}
 import software.amazon.awssdk.http.apache.ApacheHttpClient
+import akka.actor.ActorSystem
+import akka.stream.Materializer
 
-class InputLambdaMain extends RequestHandler[S3Event, Unit] with DocId with ZonedDateTimeEncoder with StorageClassEncoder {
+class InputLambdaMain (implicit actorSystem:ActorSystem, mat:Materializer) extends RequestHandler[S3Event, Unit] with DocId with ZonedDateTimeEncoder with StorageClassEncoder {
   private final val logger = LogManager.getLogger(getClass)
 
-  private val injector = Guice.createInjector(new Module)
+  private val injector = Guice.createInjector(new Module(actorSystem, mat))
   val maxRetries = 20
 
   def getRegionFromEnvironment:Option[Region] = Option(System.getenv("AWS_REGION")).map(Region.of)

--- a/lambda/input/src/main/scala/Module.scala
+++ b/lambda/input/src/main/scala/Module.scala
@@ -1,8 +1,14 @@
+import akka.actor.ActorSystem
 import com.google.inject.AbstractModule
+import com.theguardian.multimedia.archivehunter.common.clientManagers.{ESClientManager, ESClientManagerImpl}
 import com.theguardian.multimedia.archivehunter.common.{ArchiveHunterConfiguration, ArchiveHunterConfigurationExt}
+import akka.stream.Materializer
 
-class Module extends AbstractModule {
+class Module(system:ActorSystem, mat:Materializer) extends AbstractModule {
   override def configure(): Unit = {
+    bind(classOf[ActorSystem]).toInstance(system)
+    bind(classOf[ESClientManager]).to(classOf[ESClientManagerImpl])
     bind(classOf[ArchiveHunterConfiguration]).to(classOf[ArchiveHunterConfigurationExt])
+    bind(classOf[Materializer]).toInstance(mat)
   }
 }

--- a/lambda/input/src/main/scala/TestMain.scala
+++ b/lambda/input/src/main/scala/TestMain.scala
@@ -8,6 +8,8 @@ import software.amazon.awssdk.services.s3.model.{HeadObjectRequest, NoSuchKeyExc
 import java.time.{LocalDateTime, ZonedDateTime}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
+import akka.actor.ActorSystem
+import akka.stream.Materializer
 
 object TestMain {
   private val logger = LoggerFactory.getLogger(getClass)
@@ -30,6 +32,8 @@ object TestMain {
   }
 
   def main(args:Array[String]) = {
+    implicit val system:ActorSystem = ActorSystem("root")
+    implicit val mat:Materializer = Materializer.matFromSystem
     val m = new InputLambdaMain
 
     if(args.length<2) {

--- a/lambda/input/src/test/scala/InputLambdaMainSpec.scala
+++ b/lambda/input/src/test/scala/InputLambdaMainSpec.scala
@@ -286,7 +286,7 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
       val entry2 = LightboxEntry("test2@test.org", "test-file-id", date2, RestoreStatus.RS_SUCCESS, date1, date1, date1, None, None)
       val entry3 = LightboxEntry("test3@test.org", "test-file-id", date2, RestoreStatus.RS_SUCCESS, date1, date1, date1, None, None)
 
-      mockDao.getForFileId("test-file-id") returns Future(List(Right(entry1), Right(entry2), Right(entry3)))
+      mockDao.getFilesForId("test-file-id") returns Future(List(Right(entry1), Right(entry2), Right(entry3)))
 
       val test = new InputLambdaMain {
         override protected def getLightboxEntryDAO: LightboxEntryDAO = mockDao

--- a/lambda/input/src/test/scala/InputLambdaMainSpec.scala
+++ b/lambda/input/src/test/scala/InputLambdaMainSpec.scala
@@ -28,10 +28,15 @@ import scala.util.Success
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import akka.actor.ActorSystem
+import akka.stream.Materializer
 
 @RunWith(classOf[JUnitRunner])
 class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeEncoder with StorageClassEncoder {
   sequential
+
+  implicit val system:ActorSystem = ActorSystem("root")
+  implicit val mat:Materializer = Materializer.matFromSystem
 
   "InputLambdaMain" should {
     "handle paths with spaces encoded to +" in {


### PR DESCRIPTION
## What does this change?

Adds Lambda support for restore jobs starting and restored items expiring.

If the job for an item has started, an update will be attempted to the job model to change its status.

If a restored item has expired, an update will be attempted to any lightbox entries referencing the item to change their status.
