### PR TITLE
Fix / improve lambda concurrnecy

### DIFF
--- a/lambda/input/src/test/scala/InputLambdaMainSpec.scala
+++ b/lambda/input/src/test/scala/InputLambdaMainSpec.scala
@@ -180,6 +180,8 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
       mockDao.jobsForSource("test-source-id") returns Future(List(Right(job1),Right(job2),Right(job3)))
       mockDao.putJob(any[JobModel]) returns Future(None)
       val test = new InputLambdaMain {
+        override protected def getIndexName: String = "test-index"
+        override protected def getClusterEndpoint: String = "localhost:9200"
         override protected def getJobModelDAO: JobModelDAO = mockDao
 
         override def makeDocId(bucket:String,path:String) = "test-source-id"
@@ -218,6 +220,8 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
       val mockS3Client = mock[S3Client]
 
       val test = new InputLambdaMain {
+        override protected def getIndexName: String = "test-index"
+        override protected def getClusterEndpoint: String = "localhost:9200"
         override protected def getSqsClient() = mockSqsClient
         override protected def getS3Client() = mockS3Client
         override protected def getNotificationQueue() = "fake-queue"
@@ -259,6 +263,8 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
       mockDao.putJob(any[JobModel]) returns Future(None)
 
       val test = new InputLambdaMain {
+        override protected def getIndexName: String = "test-index"
+        override protected def getClusterEndpoint: String = "localhost:9200"
         override protected def getJobModelDAO: JobModelDAO = mockDao
 
         override def makeDocId(bucket: String, path: String) = "test-source-id"
@@ -294,6 +300,8 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
       mockDao.getFilesForId("test-file-id") returns Future(List(Right(entry1), Right(entry2), Right(entry3)))
 
       val test = new InputLambdaMain {
+        override protected def getIndexName: String = "test-index"
+        override protected def getClusterEndpoint: String = "localhost:9200"
         override protected def getLightboxEntryDAO: LightboxEntryDAO = mockDao
 
         override def makeDocId(bucket: String, path: String) = "test-file-id"
@@ -316,7 +324,10 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
             new S3BucketEntity("my-bucket", new UserIdentityEntity("owner"),"arn"),
             new S3ObjectEntity("path/to/object",1234L,"fakeEtag","v1"),"1"),
           new UserIdentityEntity("no-principal"))
-      val test = new InputLambdaMain
+      val test = new InputLambdaMain {
+        override protected def getIndexName: String = "test-index"
+        override protected def getClusterEndpoint: String = "localhost:9200"
+      }
       val maybeVersionId = test.getObjectVersion(fakeEvent)
       maybeVersionId must beSome("v1")
     }
@@ -329,7 +340,10 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
           new S3BucketEntity("my-bucket", new UserIdentityEntity("owner"),"arn"),
           new S3ObjectEntity("path/to/object",1234L,"fakeEtag",""),"1"),
         new UserIdentityEntity("no-principal"))
-      val test = new InputLambdaMain
+      val test = new InputLambdaMain {
+        override protected def getIndexName: String = "test-index"
+        override protected def getClusterEndpoint: String = "localhost:9200"
+      }
       val maybeVersionId = test.getObjectVersion(fakeEvent)
       maybeVersionId must beNone
     }
@@ -342,7 +356,10 @@ class InputLambdaMainSpec extends Specification with Mockito with ZonedDateTimeE
           new S3BucketEntity("my-bucket", new UserIdentityEntity("owner"),"arn"),
           new S3ObjectEntity("path/to/object",1234L,"fakeEtag",null),"1"),
         new UserIdentityEntity("no-principal"))
-      val test = new InputLambdaMain
+      val test = new InputLambdaMain {
+        override protected def getIndexName: String = "test-index"
+        override protected def getClusterEndpoint: String = "localhost:9200"
+      }
       val maybeVersionId = test.getObjectVersion(fakeEvent)
       maybeVersionId must beNone
     }


### PR DESCRIPTION


## What does this change?

improve fast-start performance of the input lambda by initialising connections at startup rather than on every run. Hopefully avoid "too many open files" issues

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
