### PR TITLE
Fixes for CloudFormation

### DIFF
--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -257,9 +257,7 @@ Resources:
           KeyType: HASH
         - AttributeName: fileId
           KeyType: RANGE
-      ProvisionedThroughput:
-        WriteCapacityUnits: 1
-        ReadCapacityUnits: 4
+      BillingMode: PAY_PER_REQUEST
       GlobalSecondaryIndexes:
         - IndexName: statusIndex
           KeySchema:
@@ -269,9 +267,6 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            WriteCapacityUnits: 1
-            ReadCapacityUnits: 4
         - IndexName: memberOfBulkIndex
           KeySchema:
             - AttributeName: memberOfBulk
@@ -280,9 +275,6 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            WriteCapacityUnits: 1
-            ReadCapacityUnits: 4
         - IndexName: fileIdIndex
           KeySchema:
             - AttributeName: fileId
@@ -291,9 +283,6 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            WriteCapacityUnits: 1
-            ReadCapacityUnits: 4
 
   LightboxBulkEntryTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
## What does this change?

Fixes the CloudFormation template so it has the same settings as the live system currently has.

## Have we considered potential risks?

This will likely break attempts to update the dev. system as it has settings the same as the file before these edits. If that happens, either change the settings of the dev. system table in the AWS Web interface or use the template as was before these edits.