### PR TITLE
Download with HTML

### DIFF
--- a/frontend/app/Lightbox/LightboxDetailsInsert.tsx
+++ b/frontend/app/Lightbox/LightboxDetailsInsert.tsx
@@ -1,4 +1,4 @@
-import React, {createRef, useState} from "react";
+import React, {createRef, useState, useEffect} from "react";
 import {LightboxEntry, ObjectGetResponse, RestoreStatus, StylesMap} from "../types";
 import {CircularProgress, Divider, Grid, Icon, IconButton, makeStyles, Tooltip, Typography} from "@material-ui/core";
 import TimestampFormatter from "../common/TimestampFormatter";
@@ -135,6 +135,19 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
 
     const oldStyleDownloadRef = createRef<HTMLAnchorElement>();
 
+    const getDownloadURL = async () => {
+        try {
+            const response = await axios.get<ObjectGetResponse<string>>("/api/download/" + props.archiveEntryId);
+            setDownloadUrl(response.data.entry);
+        } catch(err) {
+            console.error("Could not get download URL: ", err);
+        }
+    }
+
+    useEffect(() => {
+        getDownloadURL();
+    });
+
     return <div className={classes.centered}>
         <a ref={oldStyleDownloadRef} href={downloadUrl ?? "#"} style={{display:"none"}}/>
         <span style={{display: "block"}}>
@@ -177,12 +190,14 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
                     </Grid>
                     <Grid item>
                         {
-                            isDownloadable() ? <Tooltip title={downloading ? "Download in progress..." : "Download just this file"}>
+                            isDownloadable() ? <Tooltip title={downloading ? "Download in progress..." : "To download the file, right click on this button and select 'Save Link As...'"}>
                                 {
                                     downloading ? <CircularProgress/> :
-                                        <IconButton onClick={doDownload}>
-                                            <GetApp/>
-                                        </IconButton>
+                                        <a href={downloadUrl} download>
+                                            <IconButton>
+                                                <GetApp/>
+                                            </IconButton>
+                                        </a>
                                 }
                             </Tooltip> : null
                         }

--- a/frontend/app/Lightbox/LightboxDetailsInsert.tsx
+++ b/frontend/app/Lightbox/LightboxDetailsInsert.tsx
@@ -117,7 +117,7 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
             // @ts-ignore
             if(window.showSaveFilePicker) {
                 //the new style uses the File System Access API, which also requires a secure context to work.
-                await newStyleDownload(response);
+                await oldStyleDownload(response);
             } else {
                 alert("Downloading like this works best in Chrome. If the download does not work, please load Chrome and try again in that.");
                 await oldStyleDownload(response);

--- a/frontend/app/Lightbox/LightboxDetailsInsert.tsx
+++ b/frontend/app/Lightbox/LightboxDetailsInsert.tsx
@@ -117,7 +117,7 @@ const LightboxDetailsInsertImpl:React.FC<LightboxDetailsInsertProps> = (props) =
             // @ts-ignore
             if(window.showSaveFilePicker) {
                 //the new style uses the File System Access API, which also requires a secure context to work.
-                await oldStyleDownload(response);
+                await newStyleDownload(response);
             } else {
                 alert("Downloading like this works best in Chrome. If the download does not work, please load Chrome and try again in that.");
                 await oldStyleDownload(response);


### PR DESCRIPTION
## What does this change?

Changes the download button so it presents an HTML link that the user has to right click on and select 'Save Link As...'.

The old JavaScript code was not working well, likely because users close the browser window after starting the download before the download finishes. I have not removed all the old JavaScript code here, but this would be a good idea to do at some point to tidy up if we decide to keep HTML based downloading.