### PR TITLE
MIME Type Filter for Search Page

### DIFF
--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -85,7 +85,7 @@ class SearchController @Inject()(override val config:Configuration,
             } from actualStart size actualLength sortBy fieldSort("path.keyword")
           } else {
             search(indexName) query {
-              boolQuery().must(searchTerms, not(regexQuery("path.keyword", ".*/+\\.[^\\.]+")), regexQuery("mimeType.major", mIMEMajor), regexQuery("mimeType.minor", mIMEMinor))
+              boolQuery().must(searchTerms, not(regexQuery("path.keyword", ".*/+\\.[^\\.]+")), termQuery("mimeType.major.keyword", mIMEMajor), termQuery("mimeType.minor.keyword", mIMEMinor))
             } from actualStart size actualLength sortBy fieldSort("path.keyword")
           }
         }

--- a/app/controllers/SearchController.scala
+++ b/app/controllers/SearchController.scala
@@ -68,16 +68,26 @@ class SearchController @Inject()(override val config:Configuration,
     })
   }
 
-  def simpleStringSearch(q:Option[String],start:Option[Int],length:Option[Int]) = IsAuthenticatedAsync { _=> _=>
+  def simpleStringSearch(q:Option[String],start:Option[Int],length:Option[Int],mimeMajor:Option[String],mimeMinor:Option[String]) = IsAuthenticatedAsync { _=> _=>
     val cli = esClientManager.getClient()
 
     val actualStart=start.getOrElse(0)
     val actualLength=length.getOrElse(50)
+    val mIMEMajor = mimeMajor.getOrElse("Any")
+    val mIMEMinor = mimeMinor.getOrElse("")
 
     q match {
       case Some(searchTerms) =>
         val responseFuture = esClient.execute {
-          search(indexName) query { boolQuery().must(searchTerms, not(regexQuery("path.keyword",".*/+\\.[^\\.]+"))) } from actualStart size actualLength sortBy fieldSort("path.keyword")
+          if (mIMEMajor == "Any") {
+            search(indexName) query {
+              boolQuery().must(searchTerms, not(regexQuery("path.keyword", ".*/+\\.[^\\.]+")))
+            } from actualStart size actualLength sortBy fieldSort("path.keyword")
+          } else {
+            search(indexName) query {
+              boolQuery().must(searchTerms, not(regexQuery("path.keyword", ".*/+\\.[^\\.]+")), regexQuery("mimeType.major", mIMEMajor), regexQuery("mimeType.minor", mIMEMinor))
+            } from actualStart size actualLength sortBy fieldSort("path.keyword")
+          }
         }
 
         responseFuture.map(response=>{

--- a/conf/routes
+++ b/conf/routes
@@ -28,7 +28,7 @@ POST    /api/scanTarget/:id/createPipelines @controllers.ScanTargetController.cr
 GET     /api/scanTarget/:id/monitoringConfiguration @controllers.ScanTargetController.checkNotificationConfiguration(id)
 POST     /api/scanTarget/:id/monitoringConfiguration @controllers.ScanTargetController.fixNotificationConfiguration(id)
 
-GET     /api/search/basic      @controllers.SearchController.simpleStringSearch(q:Option[String],start:Option[Int],length:Option[Int])
+GET     /api/search/basic      @controllers.SearchController.simpleStringSearch(q:Option[String],start:Option[Int],length:Option[Int],mimeMajor:Option[String],mimeMinor:Option[String])
 GET     /api/entry/:id                  @controllers.SearchController.getEntry(id)
 PUT     /api/search/suggestions         @controllers.SearchController.suggestions
 POST    /api/search/browser             @controllers.SearchController.browserSearch(start:Int ?= 0, size:Int ?=100)

--- a/frontend/app/common/NewSearchComponent.tsx
+++ b/frontend/app/common/NewSearchComponent.tsx
@@ -20,6 +20,7 @@ interface NewSearchComponentProps {
     extraRequiredItemId?: string;         //if the container wants to be sure certain items are loaded, given that they exist, put the id here
     filterString?: string;
     typeString?: string;
+    typeQuery?: string;
 }
 
 const useStyles = makeStyles({
@@ -78,8 +79,8 @@ const NewSearchComponent:React.FC<NewSearchComponentProps> = (props) => {
             return axios.get<SearchResponse>(props.basicQueryUrl + `${separator}start=${startAt}&length=${props.pageSize}`, {
                 cancelToken: token
             })
-        } else if(props.basicQuery) {
-            return axios.get<SearchResponse>("/api/search/basic?q=" + encodeURIComponent(props.basicQuery as string) + "&start=" + startAt + "&length=" + props.pageSize,
+        } else if(props.basicQuery && props.typeQuery) {
+            return axios.get<SearchResponse>("/api/search/basic?q=" + encodeURIComponent(props.basicQuery as string) + "&start=" + startAt + "&length=" + props.pageSize + "&mimeMajor=" + encodeURIComponent(props.typeQuery.split('/')[0] as string) + "&mimeMinor=" + encodeURIComponent(props.typeQuery.split('/')[1] as string),
                 {
                     cancelToken: token
                 });

--- a/frontend/app/search/NewBasicSearch.tsx
+++ b/frontend/app/search/NewBasicSearch.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from "react";
 import {RouteComponentProps} from "react-router";
-import {CircularProgress, Grid, Input, makeStyles, Snackbar} from "@material-ui/core";
+import {CircularProgress, Grid, Input, makeStyles, Snackbar, Select, MenuItem} from "@material-ui/core";
 import {Search} from "@material-ui/icons";
 import MuiAlert from "@material-ui/lab/Alert";
 import NewSearchComponent from "../common/NewSearchComponent";
@@ -37,6 +37,7 @@ const NewBasicSearch:React.FC<RouteComponentProps> = (props) => {
     const [isLoading, setIsLoading] = useState(false);
     const [dividerLocation, setDividerLocation] = useState(20);
     const [newlyLightboxedList, setNewlyLightboxedList] = useState<string[]>([]);
+    const [typeString, setTypeString] = useState<string>("Any");
 
     const closeAlert = ()=>setShowingAlert(false);
 
@@ -51,6 +52,11 @@ const NewBasicSearch:React.FC<RouteComponentProps> = (props) => {
             window.clearTimeout(timerId);
         }
     }, [typedSearch]);
+
+    useEffect(()=>{
+        setActiveSearch("");
+        const timerId2 = window.setTimeout(()=>setActiveSearch(typedSearch), 10);
+    }, [typeString]);
 
     /**
      * if the user has selected an entry, then open the details panel; if s/he has deselected then close it.
@@ -77,6 +83,60 @@ const NewBasicSearch:React.FC<RouteComponentProps> = (props) => {
                        value={typedSearch}
                        style={{width: "100%"}}/>
             </Grid>
+            <Grid item style={{flexGrow: 1}}>
+                Type: <Select id="filter-type" value={typeString} onChange={(evt) => setTypeString(evt.target.value as string)} >
+                <MenuItem value="Any">Any</MenuItem>
+                <MenuItem value="application/gzip">application/gzip</MenuItem>
+                <MenuItem value="application/javascript">application/javascript</MenuItem>
+                <MenuItem value="application/json">application/json</MenuItem>
+                <MenuItem value="application/msword">application/msword</MenuItem>
+                <MenuItem value="application/mxf">application/mxf</MenuItem>
+                <MenuItem value="application/octet-stream">application/octet-stream</MenuItem>
+                <MenuItem value="application/pdf">application/pdf</MenuItem>
+                <MenuItem value="application/photoshop">application/photoshop</MenuItem>
+                <MenuItem value="application/postscript">application/postscript</MenuItem>
+                <MenuItem value="application/psd">application/psd</MenuItem>
+                <MenuItem value="application/rtf">application/rtf</MenuItem>
+                <MenuItem value="application/x-7z-compressed">application/x-7z-compressed</MenuItem>
+                <MenuItem value="application/x-cdf">application/x-cdf</MenuItem>
+                <MenuItem value="application/x-gzip">application/x-gzip</MenuItem>
+                <MenuItem value="application/x-photoshop">application/x-photoshop</MenuItem>
+                <MenuItem value="application/x-tar">application/x-tar</MenuItem>
+                <MenuItem value="application/xml">application/xml</MenuItem>
+                <MenuItem value="application/zip">application/zip</MenuItem>
+                <MenuItem value="audio/aac">audio/aac</MenuItem>
+                <MenuItem value="audio/aiff">audio/aiff</MenuItem>
+                <MenuItem value="audio/midi">audio/midi</MenuItem>
+                <MenuItem value="audio/mpeg">audio/mpeg</MenuItem>
+                <MenuItem value="audio/ogg">audio/ogg</MenuItem>
+                <MenuItem value="audio/wav">audio/wav</MenuItem>
+                <MenuItem value="audio/x-aiff">audio/x-aiff</MenuItem>
+                <MenuItem value="audio/x-wav">audio/x-wav</MenuItem>
+                <MenuItem value="binary/octet-stream">binary/octet-stream</MenuItem>
+                <MenuItem value="image/bmp">image/bmp</MenuItem>
+                <MenuItem value="image/gif">image/gif</MenuItem>
+                <MenuItem value="image/jpeg">image/jpeg</MenuItem>
+                <MenuItem value="image/png">image/png</MenuItem>
+                <MenuItem value="image/psd">image/psd</MenuItem>
+                <MenuItem value="image/tiff">image/tiff</MenuItem>
+                <MenuItem value="image/vnd.adobe.photoshop">image/vnd.adobe.photoshop</MenuItem>
+                <MenuItem value="image/x-icon">image/x-icon</MenuItem>
+                <MenuItem value="text/css">text/css</MenuItem>
+                <MenuItem value="text/csv">text/csv</MenuItem>
+                <MenuItem value="text/html">text/html</MenuItem>
+                <MenuItem value="text/plain">text/plain</MenuItem>
+                <MenuItem value="text/richtext">text/richtext</MenuItem>
+                <MenuItem value="text/xml">text/xml</MenuItem>
+                <MenuItem value="video/mp4">video/mp4</MenuItem>
+                <MenuItem value="video/mpeg">video/mpeg</MenuItem>
+                <MenuItem value="video/ogg">video/ogg</MenuItem>
+                <MenuItem value="video/quicktime">video/quicktime</MenuItem>
+                <MenuItem value="video/webm">video/webm</MenuItem>
+                <MenuItem value="video/x-msvideo">video/x-msvideo</MenuItem>
+                <MenuItem value="video/x-sgi-movie">video/x-sgi-movie</MenuItem>
+                <MenuItem value="video/x-flv">video/x-flv</MenuItem>
+            </Select>
+            </Grid>
             {
                 isLoading ? <Grid item className={classes.spinner}><CircularProgress/></Grid> : null
             }
@@ -96,6 +156,7 @@ const NewBasicSearch:React.FC<RouteComponentProps> = (props) => {
                                     onLoadingStarted={()=>setIsLoading(true)}
                                     onLoadingFinished={()=>setIsLoading(false)}
                                     newlyLightboxed={newlyLightboxedList}
+                                    typeQuery={typeString}
                 />
             </div>
             <div style={{gridColumnStart: dividerLocation, gridColumnEnd: -1}}>


### PR DESCRIPTION
## What does this change?

Adds a MIME type filter to the Search page.

## How can we measure success?

A MIME type filter exists on the search page.

## Images

![AH15](https://github.com/guardian/archivehunter/assets/10620802/905a0c6c-4fa2-45fe-99ac-f45f6c857929)

Tested on the dev. system and a machine running macOS 12.6.8.