### PR TITLE
Time Out and Refresh Keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions: # required by aws-actions/configure-aws-credentials
       id-token: write

--- a/app/auth/BearerTokenAuth.scala
+++ b/app/auth/BearerTokenAuth.scala
@@ -116,7 +116,8 @@ class BearerTokenAuth @Inject() (config:Configuration) {
   //see https://stackoverflow.com/questions/475074/regex-to-parse-or-validate-base64-data
   //it is not the best option but is the simplest that will work here
   private val authXtractor = "^Bearer\\s+([a-zA-Z0-9+/._-]*={0,3})$".r
-  private val maybeVerifiers = loadInKey() match {
+  var loadTime: Long = System.currentTimeMillis / 1000
+  private var maybeVerifiers = loadInKey() match {
     case Failure(err)=>
       if(!sys.env.contains("CI")) logger.warn(s"No token validation cert in config so bearer token auth will not work. Error was ${err.getMessage}")
       None
@@ -169,6 +170,7 @@ class BearerTokenAuth @Inject() (config:Configuration) {
     * @return Either an initialised JWKSet or a Failure indicating why it would not load.
     */
   def loadInKey():Try[JWKSet] = Try {
+    loadTime = System.currentTimeMillis / 1000
     val isRemoteMatcher = "^https*:".r.unanchored
 
     if(isRemoteMatcher.matches(signingCertPath)) {
@@ -267,6 +269,16 @@ class BearerTokenAuth @Inject() (config:Configuration) {
     logger.debug(s"validating token $token")
     parseTokenContent(token.content) match {
       case Success(signedJWT) =>
+        if ((System.currentTimeMillis / 1000) - loadTime > config.get[Int]("oAuth.keyTimeOut")) {
+          logger.debug(s"Keys too old. Attempting key refresh.")
+          maybeVerifiers = loadInKey() match {
+            case Failure(err)=>
+              if(!sys.env.contains("CI")) logger.warn(s"Could not load keys. Error was ${err.getMessage}")
+              None
+            case Success(jwk)=>
+              Some(jwk)
+          }
+        }
         getVerifier(Option(signedJWT.getHeader.getKeyID)) match {
           case Some(verifier) =>
             if (signedJWT.verify(verifier)) {

--- a/cloudformation/appstack.yaml
+++ b/cloudformation/appstack.yaml
@@ -1138,6 +1138,7 @@ Resources:
             oAuthTokensTable: "${OAuthTokensTable}"
             origin: "${Origin}"
             type: "Azure"
+            keyTimeOut = 86400
           }
 
           serverToken {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -37,6 +37,7 @@ oAuth {
     tokenSigningCertPath: "keycloak.pem"
     validAudiences: ["archivehunter"]
     oAuthTokensTable: "archivehunter-DEV-andy-OAuthTokensTable-1C46GVKE0M3TM"
+    keyTimeOut = 604800 # Seconds in a week
 }
 
 scanner {


### PR DESCRIPTION
## What does this change?

 Times out keys after a certain amount of seconds and attempts to download new keys before they are used.

Requires new setting of oAuth.keyTimeOut in a number of seconds be present in the application configuration file.

## How can we measure success?

Keys should be invalid less often.

This was tested on a machine running macOS 12.6.8 and on the dev. system.
